### PR TITLE
Articles/20240718a fix code block contents

### DIFF
--- a/source/_posts/2024/20240129a_Go_1.22リリース連載始まります_&_ループの変化とTinyGo_0.31.md
+++ b/source/_posts/2024/20240129a_Go_1.22リリース連載始まります_&_ループの変化とTinyGo_0.31.md
@@ -158,7 +158,7 @@ for rows.Next() {
 
 使い方とかはすでに詳しくわかりやすく解説してくれているブログ記事があったりするのでそちらを見てもらえればよいかな、と思います。
 
-* [every Tech Blog: Go 1.22で追加予定のrange over intと、GOEXPERIMENT入り予定のrange over funcを触ってみる](https://qiita.com/kidach1/items/afa4c6c29a6eb6be487a)
+* [every Tech Blog: Go 1.22で追加予定のrange over intと、GOEXPERIMENT入り予定のrange over funcを触ってみる](https://tech.every.tv/entry/2023/12/09/1)
 
 これらがリリースされると、そのうち、次のように書けるようになるかと思います。まだExperimentalで変更もありえるので詳しくは説明しません。
 

--- a/source/_posts/20240718a_Go_1.23リリース連載_range_over_funcとiterパッケージ.md
+++ b/source/_posts/20240718a_Go_1.23リリース連載_range_over_funcとiterパッケージ.md
@@ -213,19 +213,19 @@ func f(yield func() bool) {
 
 Go1.22 で追加された `range over integer` を利用して書き換えてみます。
 
-```diff_go
+```diff
 func f(yield func() bool) {
--        if !yield() {
--                return
--        }
--        if !yield() {
--                return
--        }
-+        for range 5 {
-+                if !yield() {
-+                        return
-+                }
-+        }
+-         if !yield() {
+-                 return
+-         }
+-         if !yield() {
+-                 return
+-         }
++         for range 5 {
++                 if !yield() {
++                         return
++                 }
++         }
 }
 
 // Output:
@@ -286,13 +286,13 @@ func main() {
 }
 
 func f(yield func(k, v string) bool) {
-        maps := map[string]string{
+        langs := map[string]string{
                 "go": "golang",
                 "py": "python",
                 "rb": "ruby",
                 "js": "javascript",
         }
-        for k, v := range maps {
+        for k, v := range langs {
                 if !yield(k, v) {
                         return
                 }
@@ -371,20 +371,20 @@ import (
 )
 
 func main() {
-        maps := map[string]string{
+        langs := map[string]string{
                 "go": "golang",
                 "py": "python",
                 "rb": "ruby",
                 "js": "javascript",
         }
-        for k, v := range showMaps(maps) {
+        for k, v := range showLangs(langs) {
                 fmt.Printf("k is: %s, v is: %s\n", k, v)
         }
 }
 
-func showMaps(maps map[string]string) iter.Seq2[string, string] {
+func showLangs(langs map[string]string) iter.Seq2[string, string] {
         return func(yield func(string, string) bool) {
-                for k, v := range maps {
+                for k, v := range langs {
                         if k == "go" || k == "py" {
                                 if !yield(k, v) {
                                         return
@@ -421,7 +421,7 @@ func showMaps(maps map[string]string) iter.Seq2[string, string] {
 * 複数のゴルーチンから同時に next(), stop() を呼び出すとエラーになる
 * next()（または、stop()）の呼び出し中にイテレータでパニックが発生した場合、next()（または、stop()）自体も同じ値でパニックが発生する
 
-`Pull2` と `next()` を利用して、`showMaps` を書き換えてみます。
+`Pull2` と `next()` を利用して、`showLangs` を書き換えてみます。
 
 ```go
 package main
@@ -432,14 +432,14 @@ import (
 )
 
 func main() {
-        maps := map[string]string{
+        langs := map[string]string{
                 "go": "golang",
                 "py": "python",
                 "rb": "ruby",
                 "js": "javascript",
         }
 
-        next, _ := iter.Pull2(showMaps(maps))
+        next, _ := iter.Pull2(showLangs(langs))
         for {
                 k, v, ok := next()
                 if !ok {
@@ -449,9 +449,9 @@ func main() {
         }
 }
 
-func showMaps(maps map[string]string) iter.Seq2[string, string] {
+func showLangs(langs map[string]string) iter.Seq2[string, string] {
         return func(yield func(string, string) bool) {
-                for k, v := range maps {
+                for k, v := range langs {
                         if !yield(k, v) {
                                 return
                         }
@@ -477,15 +477,15 @@ import (
 )
 
 func main() {
-        maps := map[string]string{
+        langs := map[string]string{
                 "go": "golang",
                 "py": "python",
                 "rb": "ruby",
                 "js": "javascript",
         }
 
--        next, _ := iter.Pull2(showMaps(maps))
-+        next, stop := iter.Pull2(showMaps(maps))
+-        next, _ := iter.Pull2(showLangs(langs))
++        next, stop := iter.Pull2(showLangs(langs))
         for {
                 k, v, ok := next()
                 if !ok {
@@ -498,9 +498,9 @@ func main() {
         }
 }
 
-func showMaps(maps map[string]string) iter.Seq2[string, string] {
+func showLangs(langs map[string]string) iter.Seq2[string, string] {
         return func(yield func(string, string) bool) {
-                for k, v := range maps {
+                for k, v := range langs {
                         if !yield(k, v) {
                                 return
                         }


### PR DESCRIPTION
# 編集内容

## source/_posts/20240718a_Go_1.23リリース連載_range_over_funcとiterパッケージ.md

* コードブロックに記載の変数名を、`maps` から `langs` に変更しました
* コードブロックの「+/-」表示を修正しました
  * `hexo server` によりローカルでビルドし、view が想定通りになることを確認済みです

![image](https://github.com/user-attachments/assets/30acf478-3d37-4628-8a52-bed3290a7720)

## source/_posts/2024/20240129a_Go_1.22リリース連載始まります_&_ループの変化とTinyGo_0.31.md

* リンク先を修正しました
