### PR TITLE
Set disable in rules

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -1,7 +1,13 @@
 {
   "filters": {},
   "rules": {
-    "preset-ja-technical-writing": true,
+    "preset-ja-technical-writing": {
+      "sentence-length": {
+              "max": 200
+      },
+      "no-exclamation-question-mark": false,
+      "ja-no-weak-phrase": false
+    },
     "spellcheck-tech-word": true
   }
 }


### PR DESCRIPTION
次の textlint のルールを緩和および無効化します。

- [ja-technical-writing/sentence-length](https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing?tab=readme-ov-file#1%E6%96%87%E3%81%AE%E9%95%B7%E3%81%95%E3%81%AF100%E6%96%87%E5%AD%97%E4%BB%A5%E4%B8%8B%E3%81%A8%E3%81%99%E3%82%8B)  
  200文字制限に緩和
- [ja-technical-writing/no-exclamation-question-mark](https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing?tab=readme-ov-file#%E6%84%9F%E5%98%86%E7%AC%A6%E7%96%91%E5%95%8F%E7%AC%A6%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%AA%E3%81%84)  
  ルールを無効化
- [ja-technical-writing/ja-no-weak-phrase](https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing?tab=readme-ov-file#%E5%BC%B1%E3%81%84%E6%97%A5%E6%9C%AC%E8%AA%9E%E8%A1%A8%E7%8F%BE%E3%81%AE%E5%88%A9%E7%94%A8%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%AA%E3%81%84)  
  ルールを無効化