### PR TITLE
Go1.23連載、記事のリンク修正

### DIFF
--- a/source/_posts/2024/20240718a_Go_1.23リリース連載_range_over_funcとiterパッケージ.md
+++ b/source/_posts/2024/20240718a_Go_1.23リリース連載_range_over_funcとiterパッケージ.md
@@ -520,4 +520,5 @@ func showLangs(langs map[string]string) iter.Seq2[string, string] {
 
 [user-defined iteration using range over func values #56413](https://github.com/golang/go/discussions/56413) を含めた「Goの反復処理の統合トレンド」は今後も進んでいくと思いますので、Go1.23での `slices` と `maps` を含めて、これからのGoのアップデートが楽しみになる内容でした。
 
-次は武田さんの[range over funcとiterパッケージ](/articles/20240718a/)です。
+次は武田さんの [unique, slices, maps](/articles/20240719a/) です。
+


### PR DESCRIPTION
# 編集内容

* 記事のリンクを修正しました
* ローカルで `hexo server` によりビルドし、適切なページへ遷移することを確認済みです

![image](https://github.com/user-attachments/assets/154eccf0-7a20-4bba-8d60-2becb5a5160b)
