### PR TITLE
Update 20240930b_JDK_23_リリース記念連載スタートします_＆_JDK_21_新機能紹介.md

### DIFF
--- a/source/_posts/20240930b_JDK_23_リリース記念連載スタートします_＆_JDK_21_新機能紹介.md
+++ b/source/_posts/20240930b_JDK_23_リリース記念連載スタートします_＆_JDK_21_新機能紹介.md
@@ -153,6 +153,8 @@ $ java -XX:+UseZGC -XX:+ZGenerational
 リリース時には将来のリリースでこの世代別GCをデフォルトにする予定としており、
 JDK 23にて世代別GCがZGCのデフォルトになりました。
 
+こちらは[武田さんのJDK 23の紹介記事](https://future-architect.github.io/articles/20241002a/#JEP-474-ZGC-Generational-Mode-by-Default)にて記載されておりますので併せてご参照ください。
+
 ## JEP440：Record Patterns (レコードパターン)
 
 JDK 16からは[JEP394](https://openjdk.org/jeps/394)で `instanceof` 演算子を使用して型を判別した後にキャストが不要になり、パターン変数として統合して宣言できるようになりました。


### PR DESCRIPTION
ZGCの世代別GCの項目にJDK23記事への参照を追加しました。