### PR TITLE
GitHubの編集リンクがタイトルに「#」が入っている場合に壊れないように修正

### DIFF
--- a/themes/future/layout/_partial/post/title.ejs
+++ b/themes/future/layout/_partial/post/title.ejs
@@ -1,5 +1,5 @@
 <h2 itemprop="name" class="<%= class_name %>"><%= post.title %>
   <% if (is_post()) {%>
-  <a href="https://github.com/future-architect/future-architect.github.io/edit/main/source/<%= page.source %>" title="Suggest Edits" class="github-edit"><i class="github-edit-icon"></i></a>
+    <a href="https://github.com/future-architect/future-architect.github.io/edit/main/source/<%= encodeURIComponent(page.source) %>" title="Suggest Edits" class="github-edit"><i class="github-edit-icon"></i></a>
   <% } %>
 </h2>


### PR DESCRIPTION
fix https://github.com/future-architect/future-architect.github.io/issues/1650