### PR TITLE
mermaid.jsのCSS調整

### DIFF
--- a/themes/future/source/css/theme-styles.styl
+++ b/themes/future/source/css/theme-styles.styl
@@ -1108,6 +1108,16 @@ pre.mermaid {
   padding: 0 !important;
   line-height: 1; /* SVGの上下にできる余分な空白を消す */
 }
+/* .article-entry p 等のスタイルがMermaid SVG内の foreignObject に波及するのを防ぐ */
+.article-entry pre.mermaid p,
+.article-entry pre.mermaid span,
+.article-entry pre.mermaid li {
+  color: inherit !important;
+  font-size: inherit !important;
+  line-height: inherit !important;
+  text-align: inherit !important;
+  margin: 0;
+}
 
 
 /* ::: note tip 対応 */


### PR DESCRIPTION
原因と修正の説明

  原因: theme-styles.styl:76-81 の .article-entry p ルールです。

  .article-entry p {
    color: #424242;
    font-size: 1.2em;
    line-height: 1.75em !important;
  }

  Mermaid v10以降は、ノードラベルをSVG内の <foreignObject> 要素にHTML（<p> タグ等）として描画します。この <p> タグに対して .article-entry p
  のセレクタがマッチし、color: #424242（ほぼ黒色）が直接適用されます。

  CSSの仕様では、直接マッチするルールは親要素から継承された値よりも常に優先されるため、mermaidの style TenantDB fill:#2e7d32,color:#fff
  で白文字を指定しても、.article-entry p { color: #424242 } に上書きされていました。font-size: 1.2em
  もダイアグラム内のテキストサイズに影響していたはずです。

  修正: pre.mermaid 内の p, span, li 要素に対して、color や font-size を inherit !important
  に設定し、mermaidが設定する値がそのまま使われるようにしました。