### PR TITLE
トップページのランキング表示を15件から10件に減らす

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# CLAUDE.md
+
+フューチャー技術ブログ（https://future-architect.github.io ）のソースリポジトリ。
+Hexo 7.3 製の静的サイトで、GitHub Pages にホスティングされている。
+
+## 構成
+
+| パス | 役割 |
+| --- | --- |
+| `source/_posts/<年>/` | 記事本体（Markdown）。年ごとのディレクトリに分かれる |
+| `source/images/<年>/<記事ID>/` | 記事ごとの画像。`thumbnail.jpg` / `top.jpg` を置くのが慣例 |
+| `themes/future/` | 自作テーマ。`layout/*.ejs`（EJS）と `source/css/`（Stylus） |
+| `scripts/` | Hexo の generator / helper 拡張（著者ページ、タグ、SNSカウント、OGPプレビューなど） |
+| `scaffolds/` | `hexo new` のテンプレート |
+| `_config.yml` | Hexo 本体設定（permalink、alias によるURLリダイレクト等） |
+| `themes/future/_config.yml` | テーマ設定（メニュー、GA4 プロパティ、SNSリンク） |
+| `_profile.yml` | 著者プロフィール（about / twitter_id / github_id） |
+
+## 記事の書き方
+
+ファイル名は `source/_posts/<年>/YYYYMMDD<postid>_<タイトル>.md`。
+`postid` は同日複数投稿を区別する `a`, `b`, `c`…。公開URLは `/articles/YYYYMMDD<postid>/`。
+
+フロントマターは以下の形式（**キーは `tag` / `category` と単数形**。Hexo 標準の `tags` / `categories` ではない）:
+
+```yaml
+---
+title: "Go 1.27 リリース連載： uuid"
+date: 2026/08/04 00:00:00
+postid: a
+tag:
+  - Go
+  - Go1.27
+  - UUID
+category:
+  - Programming
+thumbnail: /images/2026/20260804a/thumbnail.jpg
+author: 武田大輝
+lede: "Go 1.27 で標準ライブラリに追加されたuuidパッケージを扱います。"
+---
+```
+
+- `category` は既存の語彙から選ぶ。使用実績: Programming / Infrastructure / DataScience / Culture / DataEngineering / Security / Management / DB / Business / AI / IoT / DevOps / AU
+- `author` は `_profile.yml` に未登録なら追記する。複数著者は配列可
+- `lede` は一覧・OGP に出る概要文
+- 画像は `<img src="/images/2026/20260804a/xxx.jpg" alt="" width="1024" height="559" loading="lazy">` のように実寸の width/height を明記する
+- 連載記事は冒頭で `[連載名](/articles/20260728a/) の N 本目です。` と相対リンクで親記事を参照する
+
+新規記事を追加したら、画像ディレクトリ `source/images/<年>/<記事ID>/` も併せて作る。
+
+## コマンド
+
+```sh
+make s      # ローカルサーバ（http://localhost:4000）
+make g      # 静的ファイル生成（public/）
+make clean  # キャッシュ・生成物の削除
+make fix    # textlint --fix（source/_posts 配下）
+make fmt    # markdownlint-cli2 --fix
+make lint   # npx lint-staged（git add 済みの記事のみ textlint）
+```
+
+記事を書き換えたら `make fix` か、対象ファイルだけの
+`node_modules/.bin/textlint --fix <path>` を通してから push する。
+
+## Lint ルール
+
+- `.textlintrc`: `preset-ja-technical-writing` + `spellcheck-tech-word`。一文200文字まで、漢字連続10文字まで。感嘆符・疑問符と弱い表現は許容
+  - 誤検知は `.textlintrc` の `filters.allowlist.allow` に単語を追加して黙らせる
+  - `spellcheck-tech-word` は「インターフェース→インタフェース」「% → ％」など表記統一を強制する
+- `.markdownlint-cli2.jsonc`: 行長・生URL・インラインHTMLなどは無効化済み
+- PR には reviewdog が textlint を回し、変更行にレビューコメントを付ける（`.github/workflows/reviewdog.yml`）
+
+## ブランチ / デプロイ
+
+- 作業は `feature` ブランチで行い、`main` へ PR を出してマージする
+- `main` への push で `.github/workflows/deploy.yml` が hexo generate → GitHub Pages へデプロイ
+
+## 手で編集しないファイル
+
+以下は GitHub Actions（`update-cache.yml`、毎日 9:00 JST）が生成・コミットする:
+
+- `sns_count_cache.json` / `ga_cache.json` / `ga4_pv.json` — SNSシェア数・GA の PV キャッシュ
+- `temp.json` — `snssharecount` の出力用一時ファイル
+- `db.json`（112MB、gitignore 済み）— Hexo のビルドキャッシュ
+
+`normalize.mjs` は日本語ファイル名・本文の Unicode NFC 正規化を行うスクリプトで、
+週次ワークフロー（`normalize.yml`）から実行され PR を作る。手動実行は `node normalize.mjs`。
+
+## その他
+
+- URL の付け替え（タグ→カテゴリの統合、タグの名寄せ）は `_config.yml` の `alias` に記述する
+- 画像圧縮は pngquant / jpegoptim（`jpegoptimall.bat`）を月次で回す運用。詳細は README.md

--- a/scripts/popular_posts.js
+++ b/scripts/popular_posts.js
@@ -5,6 +5,10 @@ const {getSNSCnt} = require('./lib/sns');
 const fs = require("fs");
 const gaCache = JSON.parse(fs.readFileSync("ga_cache.json", 'utf-8'));
 
+// ランキング（トレンド・年間人気・SNS人気）の表示件数
+// 記事が長文化する傾向にあるため、トップページのスクロール量を抑える目的で絞っている
+const RANKING_DISPLAY_COUNT = 10;
+
 hexo.extend.helper.register('popular_posts', function(term='weekly') {
   const yearAgo = new Date();
   yearAgo.setDate(yearAgo.getDate() - 365); // 1year
@@ -66,7 +70,7 @@ hexo.extend.helper.register('popular_posts', function(term='weekly') {
     })
     .filter(post => post.pv >= 0)
     .sort(compareFunc)
-    .slice(0, 15);
+    .slice(0, RANKING_DISPLAY_COUNT);
 
   const label = post => {
     if (monthAgo.toISOString() <= post.date.toISOString()) {
@@ -90,7 +94,7 @@ hexo.extend.helper.register('sns_popular_posts', function() {
 
   const allPosts = this.site.posts.data;
   allPosts.sort((a, b) => getSNSCnt(b.permalink) - getSNSCnt(a.permalink))
-  const popularPost = allPosts.slice(0, 15)
+  const popularPost = allPosts.slice(0, RANKING_DISPLAY_COUNT)
 
   const label = post => {
     const currentTime = new Date();


### PR DESCRIPTION
## 概要

トップページのランキング（トレンド・年間人気・SNS人気）の表示件数を、15件から10件に減らします。

AI活用の広がりで記事が長文化する傾向にあり、トップページのスクロール量を抑えて読者の心理的な負荷を下げることが狙いです。

あわせて、コーディングエージェント向けの `CLAUDE.md` を別コミットで追加しています。不要であればそのコミットだけ落としてください。

## 変更内容

`scripts/popular_posts.js` の2つのヘルパーが該当箇所でした。

- `popular_posts()` … トレンド（monthly）と年間人気（yearly）の両方で使われる
- `sns_popular_posts()` … SNS人気

3箇所で同じ件数を使うため `RANKING_DISPLAY_COUNT` として定数に切り出し、絞った理由をコメントに残しています。

## 動作確認

`hexo generate` を実行し、生成された `public/index.html` の各タブの `li` 要素数を確認しました。

| タブ | 変更前 | 変更後 |
| --- | --- | --- |
| トレンド | 15 | 10 |
| 年間人気 | 15 | 10 |
| SNS人気 | 15 | 10 |

## 補足

このランキングは `themes/future/layout/_partial/archive.ejs` に置かれた共通パーツのため、トップページだけでなく `/articles/` の一覧ページ（2ページ目以降を含む）にも同じものが表示されます。今回の変更はそれらにも効きます。トップページ限定にしたい場合は別途分岐が必要です。
