### PR TITLE
「タグから記事を探す」の表示をSNSリアクション合計の上位25件に絞る

### DIFF
--- a/scripts/list_tags.js
+++ b/scripts/list_tags.js
@@ -3,6 +3,10 @@
 // custom list_tags
 // https://github.com/noraj/hexo/blob/master/lib/plugins/helper/list_tags.js
 
+const {getSNSCnt} = require('./lib/sns');
+
+// タグに紐づく記事のSNSリアクション（Twitter/FaceBook/Hatebu/Pocket/Feedly）の合計
+const snsTotalCount = tag => tag.posts.map(post => getSNSCnt(post.permalink)).reduce((acc, cur) => acc + cur, 0);
 
 function listTopPageTags(tags, options) {
   if (!options && (!tags || !Object.prototype.hasOwnProperty.call(tags, 'length'))) {
@@ -21,23 +25,28 @@ function listTopPageTags(tags, options) {
   const minCount = options.minCount || 1; // 拡張
   let result = '';
 
-  // Sort the tags
-  tags = tags.sort(orderby, order);
-
   // Ignore tags with zero posts
-  tags = tags.filter(tag => tag.length);
+  // 表示対象の絞り込みは amount で件数を切る前に済ませる
+  tags = tags.filter(tag => tag.length && tag.length >= minCount);
+
+  // Sort the tags
+  // snsCount は Warehouse のフィールドではないため、配列に変換して独自に並べ替える
+  if (orderby === 'snsCount') {
+    tags = tags.toArray()
+      .map(tag => ({tag, snsCount: snsTotalCount(tag)})) // 比較のたびに集計し直さないよう先にキーを持たせる
+      .sort((a, b) => b.snsCount - a.snsCount)
+      .map(entry => entry.tag);
+  } else {
+    tags = tags.sort(orderby, order).toArray();
+  }
 
   // Limit the number of tags
-  if (options.amount) tags = tags.limit(options.amount);
+  if (options.amount) tags = tags.slice(0, options.amount);
 
   if (style === 'list') {
     result += `<ul class="${className}-list" itemprop="keywords">`;
 
     tags.forEach(tag => {
-      if (tag.length < minCount) {
-        return;
-      }
-
       result += `<li class="${className}-list-item">`;
 
       result += `<a class="${className}-list-link" href="${this.url_for(tag.path)}${suffix}" rel="tag">`;
@@ -62,9 +71,6 @@ function listTopPageTags(tags, options) {
     result += '</ul>';
   } else {
     tags.forEach((tag, i) => {
-      if (tag.length < minCount) {
-          return;
-      }
       if (i) result += separator;
 
       result += `<a class="${className}-link" href="${this.url_for(tag.path)}${suffix}" rel="tag">`;

--- a/themes/future/_config.yml
+++ b/themes/future/_config.yml
@@ -16,7 +16,10 @@ excerpt_link: 続きを読む
 featured_count: 10
 
 # 一覧画面のタグ表示
+# min: 表示対象とするタグの最低記事数
+# max: SNSリアクション合計の多い順に絞り込む表示上限（スクロール量を抑えるため3行程度に収める）
 tag_display_min_count: 15
+tag_display_max_count: 25
 
 # Integrations(GA4 プロパティ)
 google_analytics: G-X1C28R8H0M

--- a/themes/future/layout/_widget/tag.ejs
+++ b/themes/future/layout/_widget/tag.ejs
@@ -1,6 +1,6 @@
 <% if (site.tags.length){ %>
 <div class="widget">
-  <%- list_toppagetags({show_count: true, minCount: theme.tag_display_min_count, transform(str) {
+  <%- list_toppagetags({show_count: true, minCount: theme.tag_display_min_count, orderby: 'snsCount', amount: theme.tag_display_max_count, transform(str) {
     if (str === "Go") {
       return "Go言語";
     }


### PR DESCRIPTION
## 概要

「タグから記事を探す」の表示件数を、69件から25件に絞ります。

#1889 と同じく、記事の長文化が進むなかでトップページのスクロール量を抑えることが目的です。従来は縦に7行ほど占めていました。

絞り込みの条件は「記事数15本以上」を維持したうえで、**タグに紐づく記事のSNSリアクション合計の降順で上位25件**としています。

## 変更前後

| | 変更前 | 変更後 |
| --- | --- | --- |
| 表示タグ数 | 69件 | 25件 |
| 並び順 | タグ名のアルファベット順 | SNSリアクション合計の降順 |
| 推定行数（container 1140px） | 7行 | 3行 |
| 推定行数（container 960px） | 8行 | 3行 |

「タグ一覧へ」のリンクは従来どおり末尾に残ります。

なお変更前の並び順は、helper 側の既定値 `orderby = 'name'` がそのまま効いていたためアルファベット順でした。上位N件を選ぶにあたり、上部のランキング群と同じくリアクション量を軸にしています。

## 表示結果

```
順  タグ            SNS合計  記事数        順  タグ           SNS合計  記事数
 1  Web             18430    18         14  OpenAPI         2549    21
 2  Go言語           18114   259         15  チーム開発        2526    16
 3  設計              7886    42         16  環境構築          2508    32
 4  Docker           5160    38         17  ORM             2347    16
 5  Java             4973    40         18  TypeScript      2266    25
 6  入門              4910    60         19  React           2259    23
 7  Python           4793    57         20  テスト            2111    33
 8  ガイドライン        3914    22         21  Network         1927    30
 9  AWS              3628   125         22  OSS             1897    37
10  初心者向け         3597    71         23  GoogleCloud     1779   107
11  書評              3527    42         24  Terraform       1652    59
12  技術選定           3164    18         25  VSCode          1481    22
13  ドキュメント        2783    15
```

集計は `scripts/lib/sns.js` の `getSNSCnt`（Twitter + FaceBook + Hatebu + Pocket + Feedly）を記事ごとに合計したもので、`scripts/tags.js` の `ranking_tags` と同じ定義です。

## 変更内容

- `scripts/list_tags.js` … `orderby: 'snsCount'` に対応。Warehouse のフィールドではないため、配列に変換して独自に並べ替える。比較のたびに集計し直さないよう、ソートキーは事前に計算している
- `themes/future/layout/_widget/tag.ejs` … `orderby` と `amount` を指定
- `themes/future/_config.yml` … `tag_display_max_count: 25` を追加

### あわせて修正した既存の不具合

変更前は `amount` で件数を切ってから `minCount` で除外していたため、`amount` を指定すると足切り対象のタグが表示枠を消費し、指定件数に満たない状態になりえました。絞り込みを `amount` より前に寄せ、ループ内の重複チェックを削除しています。

## 動作確認

`hexo generate` の出力 `public/index.html` を確認しました。あわせて、Hexo のコンソールコマンドを一時的に登録して実データのタグ別SNS合計を出力し、生成されたHTMLの並びと完全に一致することを確認しています（デバッグ用スクリプトはコミットに含めていません）。

行数は実ブラウザでの計測ではなく、Bootstrap 5 のグリッド幅とチップのCSS（font-size 12px / padding 8px / margin 4px・6px）から折り返しを計算した見積もりです。±1行の誤差はありえます。

## 補足

単純合計のため、少数のバズ記事を持つタグが上位に来ます（1位の Web は18記事で、259記事の Go言語とほぼ同点）。記事数の影響を均したい場合は、`ranking_tags` と同じ「シェア数 ÷ 記事数」系の指標に寄せる案もあります。
