### PR TITLE
本文中の関連記事の最大表示件数を6件から3件に減らす

### DIFF
--- a/scripts/related_posts.js
+++ b/scripts/related_posts.js
@@ -1,6 +1,8 @@
 'use strict';
 
-const maxCount = 6;
+// 関連記事の最大表示件数
+// 記事が長文化する傾向にあるため、記事末尾のスクロール量を抑える目的で絞っている
+const maxCount = 3;
 const {getSNSCnt} = require('./lib/sns');
 
 // HTMLを生成するロジックを共通関数として外に切り出す


### PR DESCRIPTION
## 概要

記事本文の下に表示している「関連記事」の最大表示件数を、6件から3件に減らします。

#1889 / #1890 と同じく、記事の長文化が進むなかでスクロール量を抑え、読者の負担を下げることが目的です。

## 変更内容

`scripts/related_posts.js` の `maxCount` 一箇所の変更です。

```diff
-const maxCount = 6;
+// 関連記事の最大表示件数
+// 記事が長文化する傾向にあるため、記事末尾のスクロール量を抑える目的で絞っている
+const maxCount = 3;
```

## 動作確認

`hexo generate` して、生成された全記事ページの `.related-posts-item` を数えました。

```
関連記事セクションを持つ記事ページ: 1464
表示件数の分布:  3件: 1464ページ
最大表示件数: 3
```

全1464記事が3件ちょうどで表示され、「No related post.」に落ちるページはありません。

## 補足

`maxCount` は表示上限に加えて、「タグ由来の関連記事がこの件数に満たなければカテゴリから補填する」しきい値も兼ねています。3件に下げたことで補填が走る機会は減りますが、上記のとおり全ページで3件を満たせているため実害はありません。
