### PR TITLE
関連記事から「この記事を参照している記事」を除外する

### DIFF
--- a/scripts/related_posts.js
+++ b/scripts/related_posts.js
@@ -33,15 +33,23 @@ function generateRelatedPostsHtml(posts) {
     </div>`;
 }
 
+// 「この記事を参照している記事」（reference_posts.js）に出る記事のID
+// 同じ記事が関連記事にも並ばないよう、除外するために使う
+function getReferencePostIds(ctx, post) {
+  return new Set(ctx.site.posts.data
+    .filter(p => p.path !== post.path && p.content.includes(post.path))
+    .map(p => p._id));
+}
+
 // カテゴリから関連記事を取得する関数（変更なし）
-function getCategoryRelatedPosts(ctx, post) {
+function getCategoryRelatedPosts(ctx, post, excludeIds) {
   const currentCategory = post.categories.data[0];
   if (!currentCategory) {
     return [];
   }
 
   const categoryPosts = currentCategory.posts.data
-    .filter(p => p._id !== post._id);
+    .filter(p => p._id !== post._id && !excludeIds.has(p._id));
 
   categoryPosts.sort((a, b) => {
     const snsA = getSNSCnt(a.permalink);
@@ -63,6 +71,9 @@ hexo.extend.helper.register('list_related_posts', function() {
     return `<p class="related-posts-none">No related post.</p>`;
   }
 
+  // 0. 「この記事を参照している記事」と重複しないよう、除外対象を先に求める
+  const referenceIds = getReferencePostIds(this, post);
+
   // 1. 全著者数を取得し、著者のIDFを計算
   const allPostsCount = this.site.posts.length;
   const authors = [...new Set(this.site.posts.data.map(p => p.author))];
@@ -75,12 +86,12 @@ hexo.extend.helper.register('list_related_posts', function() {
   // 2. 関連度スコアリング (タグと著者のIDFを考慮)
   const tagRelatedPosts = post.tags.data
     .flatMap(tag => tag.posts.data)
-    .filter(p => p._id !== post._id);
+    .filter(p => p._id !== post._id && !referenceIds.has(p._id));
 
   if (tagRelatedPosts.length === 0) {
     // タグ関連記事がなければカテゴリの記事を取得し、HTMLを生成して返す
     console.log(`[INFO] Related Posts: No tag-related posts found for "${post.title}". Falling back to category.`);
-    const categoryPosts = getCategoryRelatedPosts(this, post);
+    const categoryPosts = getCategoryRelatedPosts(this, post, referenceIds);
     return generateRelatedPostsHtml(categoryPosts);
   }
 
@@ -122,7 +133,7 @@ hexo.extend.helper.register('list_related_posts', function() {
 
   // 4. 記事数がmaxCountに満たない場合はカテゴリから補填
   if (relatedPosts.length < maxCount) {
-    const postsToFill = getCategoryRelatedPosts(this, post);
+    const postsToFill = getCategoryRelatedPosts(this, post, referenceIds);
     postsToFill.forEach(p => {
       if(relatedPosts.findIndex(rp => rp._id === p._id) === -1) {
         relatedPosts.push(p);


### PR DESCRIPTION
## 概要

記事末尾では「関連記事」と「この記事を参照している記事」が並んで表示されますが、同じ記事が両方に出ることがありました。関連記事の側から、その記事を参照している記事を除外します。

## 変更前の重複状況

変更前の生成結果を集計したところ、**388ページ・507リンク**が重複していました。

```
articles/20160406/  重複: /articles/20160420/
articles/20160511/  重複: /articles/20160530/
articles/20160721/  重複: /articles/20200204/ /articles/20200309/
articles/20160902/  重複: /articles/20250912a/ /articles/20211007a/
articles/20160920/  重複: /articles/20170510/ /articles/20170119/ /articles/20190703/
```

## 変更内容

`scripts/related_posts.js` に `getReferencePostIds()` を追加しました。判定条件は `scripts/reference_posts.js` と同一（`p.content.includes(post.path)` かつ自分自身を除く）で、両セクションの対象が食い違わないようにしています。

除外は候補を集める2箇所の両方に適用しています。

- タグ由来の候補（`tagRelatedPosts`）
- 件数が足りないときのカテゴリ補填（`getCategoryRelatedPosts`）

**除外は候補集めの段階で行っているため、除外後も最大3件を表示します。** 除外によって表示件数が減ることはありません。

## 動作確認

`hexo generate` して全記事ページを走査しました。

| | 変更前 | 変更後 |
| --- | --- | --- |
| 関連記事と参照記事が重複するページ | 388ページ（507リンク） | **0ページ** |
| 関連記事の表示件数 | 全1464ページで3件 | **全1464ページで3件** |

「この記事を参照している記事」があるページは1051ページ（1件:501 / 2件:258 / 3件:107 / 4件:51 / 5件:134）で、そのすべてで重複が解消し、かつ関連記事は3件を維持できています。

ビルド時間は 1.8分 で、変更前（2.0分）から悪化していません。

## 補足

除外対象は「参照している記事すべて」で、参照セクションに実際に表示される上位5件に限定していません。6件以上から参照されている記事では、6件目以降も関連記事から外れます。これらはいずれも当該記事へリンクしている記事であり、参照セクション側で扱うのが自然と判断しました。表示済みの5件のみを除外対象にする方針にも変更できます。
