### PR TITLE
「We're hiring」を4パネルから2パネルに減らす

### DIFF
--- a/scripts/hiring_panels.js
+++ b/scripts/hiring_panels.js
@@ -1,0 +1,53 @@
+'use strict';
+
+// 記事末尾の「We're hiring」に出すパネル
+// スクロール量を抑えるため2枠だけ表示する。1枠目は採用ページ固定で、
+// 2枠目はコンテンツ3種から記事ごとに1つを選ぶ。
+
+const recruitPanel = {
+  url: 'https://www.future.co.jp/recruit/recruit/rec-career/',
+  title: 'フューチャー採用情報',
+  label: 'フューチャー採用ページ',
+  image: '/career_official.jpg',
+  lede: '私たちは、多様なバックグラウンドを持つ人材が集まってこそ、より強い組織になると考えています。',
+};
+
+const contentPanels = [
+  {
+    url: 'https://future-architect.github.io/typescript-guide/',
+    title: '仕事ですぐに使えるTypeScript',
+    label: '仕事ですぐに使えるTypeScript',
+    image: '/typescript_guidelines.png',
+    lede: 'ウェブフロントエンドの開発を学ぶときに、JavaScriptを経由せずに、最初からTypeScriptで学んでいくコンテンツです。',
+  },
+  {
+    url: 'https://future-architect.github.io/arch-guidelines/',
+    title: 'Future Architecture Guidelines',
+    label: 'アーキテクチャガイドライン',
+    image: '/archtecture_guidelines.png',
+    lede: 'フューチャー株式会社の有志が作成する良いアーキテクチャを実現するための設計ガイドラインです。',
+  },
+  {
+    url: 'https://future-architect.github.io/coding-standards/',
+    title: 'Future Enterprise Coding Standard',
+    label: 'コーディング規約',
+    image: '/coding_standards.png',
+    lede: 'フューチャー株式会社が作成するエンタープライズ領域に特化したコーディング規約',
+  },
+];
+
+// 記事のパスから決まるハッシュ値（FNV-1a 32bit）
+// 乱数ライブラリを使うとバージョン差で結果が変わりうるため、自前で計算する
+function hash(str) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h;
+}
+
+hexo.extend.helper.register('hiring_panels', function(post) {
+  // 同じ記事なら常に同じパネルになるよう、パスだけを入力にする
+  return [recruitPanel, contentPanels[hash(post.path) % contentPanels.length]];
+});

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -42,83 +42,27 @@
               <p>フューチャーで一緒に働く仲間を大募集しています！ また、様々なコンテンツも公開中です。</p>
 
               <div class="row g-4">
-
+                <% hiring_panels(post).forEach(function(panel){ %>
                 <div class="col-12 col-md-6">
                   <div class="article-card h-100 p-3" style="border: 1px solid #eee; border-radius: 8px;">
                     <div class="row mb-3">
                       <div class="col-6">
-                        <a href="https://www.future.co.jp/recruit/recruit/rec-career/" title="フューチャー採用情報" class="img_wrap">
-                          <img src="/career_official.jpg" class="img-fluid" alt="フューチャー採用情報" width="200" height="135" loading="lazy">
+                        <a href="<%= panel.url %>" title="<%= panel.title %>" class="img_wrap">
+                          <img src="<%= panel.image %>" class="img-fluid" alt="<%= panel.title %>" width="200" height="135" loading="lazy">
                         </a>
                       </div>
                       <div class="col-6 d-flex align-items-center">
-                        <a href="https://www.future.co.jp/recruit/recruit/rec-career/">
-                          <div style="font-weight:bold;">フューチャー採用ページ</div>
+                        <a href="<%= panel.url %>">
+                          <div style="font-weight:bold;"><%= panel.label %></div>
                         </a>
                       </div>
                     </div>
                     <div>
-                      <div class="lede">私たちは、多様なバックグラウンドを持つ人材が集まってこそ、より強い組織になると考えています。</div>
+                      <div class="lede"><%= panel.lede %></div>
                     </div>
                   </div>
                 </div>
-                <div class="col-12 col-md-6">
-                  <div class="article-card h-100 p-3" style="border: 1px solid #eee; border-radius: 8px;">
-                    <div class="row mb-3">
-                      <div class="col-6">
-                        <a href="https://future-architect.github.io/typescript-guide/" title="仕事ですぐに使えるTypeScript" class="img_wrap">
-                          <img src="/typescript_guidelines.png" class="img-fluid" alt="仕事ですぐに使えるTypeScript" width="200" height="135" loading="lazy">
-                        </a>
-                      </div>
-                      <div class="col-6 d-flex align-items-center">
-                        <a href="https://future-architect.github.io/typescript-guide/">
-                          <div style="font-weight:bold;">仕事ですぐに使えるTypeScript</div>
-                        </a>
-                      </div>
-                    </div>
-                    <div>
-                      <div class="lede">ウェブフロントエンドの開発を学ぶときに、JavaScriptを経由せずに、最初からTypeScriptで学んでいくコンテンツです。</div>
-                    </div>
-                  </div>
-                </div>
-                <div class="col-12 col-md-6">
-                  <div class="article-card h-100 p-3" style="border: 1px solid #eee; border-radius: 8px;">
-                    <div class="row mb-3">
-                      <div class="col-6">
-                        <a href="https://future-architect.github.io/arch-guidelines/" title="Future Architecture Guidelines" class="img_wrap">
-                          <img src="/archtecture_guidelines.png" class="img-fluid" alt="アーキテクチャガイドライン" width="200" height="135" loading="lazy">
-                        </a>
-                      </div>
-                      <div class="col-6 d-flex align-items-center">
-                        <a href="https://future-architect.github.io/arch-guidelines/">
-                          <div style="font-weight:bold;">アーキテクチャガイドライン</div>
-                        </a>
-                      </div>
-                    </div>
-                    <div>
-                      <div class="lede">フューチャー株式会社の有志が作成する良いアーキテクチャを実現するための設計ガイドラインです。</div>
-                    </div>
-                  </div>
-                </div>
-                <div class="col-12 col-md-6">
-                  <div class="article-card h-100 p-3" style="border: 1px solid #eee; border-radius: 8px;">
-                    <div class="row mb-3">
-                      <div class="col-6">
-                        <a href="https://future-architect.github.io/coding-standards/" title="Future Enterprise Coding Standard" class="img_wrap">
-                          <img src="/coding_standards.png" class="img-fluid" alt="Future Enterprise Coding Standards" width="200" height="135" loading="lazy">
-                        </a>
-                      </div>
-                      <div class="col-6 d-flex align-items-center">
-                        <a href="https://future-architect.github.io/coding-standards//">
-                          <div style="font-weight:bold;">コーディング規約</div>
-                        </a>
-                      </div>
-                    </div>
-                    <div>
-                      <div class="lede">フューチャー株式会社が作成するエンタープライズ領域に特化したコーディング規約</div>
-                    </div>
-                  </div>
-                </div>
+                <% }) %>
               </div>
 
             </section>


### PR DESCRIPTION
## 概要

記事末尾の「We're hiring」を、4パネルから2パネルに減らします。#1889 / #1890 / #1891 と同じくスクロール量の削減が目的です。

- 1枠目は **フューチャー採用ページで固定**
- 2枠目は残り3種（TypeScript / アーキテクチャガイドライン / コーディング規約）から記事ごとに1つを選ぶ

## 選び方

記事パスのハッシュ（FNV-1a 32bit）で決めています。入力が記事パスだけの純粋な計算なので、

- 同じ記事は常に同じパネルになる
- `hexo generate` を何度実行しても結果が変わらない

`random-seed` が依存に入っていますがリポジトリ内で未使用で、ライブラリのバージョン差で結果が変わる可能性があるため、自前のハッシュにしています。

## 変更内容

- `scripts/hiring_panels.js`（新規）… パネル定義と選択ロジック。`hiring_panels(post)` が表示する2枠を配列で返す
- `themes/future/layout/_partial/article.ejs` … ほぼ同一のHTMLが4つ並んでいたので、データとループにまとめた

既存markupの軽微な修正も含みます。

- コーディング規約のテキストリンクが `https://future-architect.github.io/coding-standards//` と末尾スラッシュ二重だったのを、画像リンク側と同じ単一スラッシュに統一
- 同パネルの `alt` が "Future Enterprise Coding Standards"、`title` が "Future Enterprise Coding Standard" と揺れていたので `title` に統一

## 動作確認

`hexo clean` してからフルビルドし、全記事ページを走査しました。

```
We're hiring があるページ: 1460
パネル数の分布: {"2":1460}
1枠目が採用ページでないページ: 0

2枠目の分布:
  仕事ですぐに使えるTypeScript: 500ページ
  アーキテクチャガイドライン:   499ページ
  コーディング規約:            461ページ
```

全ページが2パネルで、1枠目は必ず採用ページです。2枠目もほぼ均等に散っています。

determinism は、`hexo clean` からのフルビルドを2回実行し、全記事の該当セクションのリンクを連結したダイジェストが一致することで確認しました。

```
1回目: 30d982b9c2c895e592a24aace0fcb2dc
2回目: 30d982b9c2c895e592a24aace0fcb2dc
```
