### PR TITLE
noteブロック内のコードブロックで狭い画面のレイアウトが崩れるのを修正

### DIFF
--- a/themes/future/source/css/theme-styles.styl
+++ b/themes/future/source/css/theme-styles.styl
@@ -1164,6 +1164,16 @@ pre.mermaid {
   border-radius: 5px;
 }
 
+/* 本文側のフレックスアイテム。
+   min-width の初期値 auto のままだと、内部のコードブロックの最小内容幅より狭くなれず、
+   狭い画面でコンテナごと画面外にはみ出してしまう。
+   0 を明示すると幅を画面に合わせられ、コードブロックは .highlight の
+   overflow: auto でコンテナ内を横スクロールする */
+.note-container > div {
+  flex: 1;
+  min-width: 0;
+}
+
 .info > .fa-check-circle {
   display: inline-block;
   width: 18px;


### PR DESCRIPTION
## 概要

`::: note` ブロックの中にコードブロックがあると、スマートフォンなど狭い画面でレイアウトが崩れる問題を修正します。

報告いただいた箇所: https://future-architect.github.io/articles/20260730a/ の「補足: なぜ Go がインターフェースのメソッドに型パラメータを許していないのか」

## 原因

`.note-container` は `display: flex` で、アイコンの `span` と本文の `div` が横に並ぶ構造です。この本文側 `div` はフレックスアイテムであり、**フレックスアイテムの `min-width` の初期値は `auto`** です。

`auto` は「最小内容幅（min-content）より狭くならない」という意味なので、中にコードブロックがあると、そのコードの最長行の幅が `div` の下限になります。当該記事のコードは最長59文字で、14px の等幅フォントだと約500px。iPhone の 375px 幅では本文領域が約345pxしかないため、`div` が縮めず、コンテナごと画面外にはみ出します。

`body` に `overflow-x: hidden` が指定されているため、横スクロールバーは出ずに**右側が切れる**形になります。本文テキストの折り返しが効かないように見えるのも同じ理由で、コンテナ自体が画面より広いためです。

なお、noteブロックの外では `.article-entry` が通常のブロック要素なので、同じコードブロックでも `.highlight` の `overflow: auto` が効いて正しく横スクロールします。この不具合はフレックスコンテナである note ブロックの中でのみ起きます。

## 修正

```styl
.note-container > div {
  flex: 1;
  min-width: 0;
}
```

`min-width: 0` を明示して、フレックスアイテムが画面幅まで縮めるようにします。コードブロック側は既存の `.article-entry .highlight { overflow: auto }` により、コンテナ内で横スクロールします。`flex: 1` は、縮めるようにした結果として幅が内容依存にならないよう、コンテナ幅いっぱいに広げるためのものです。

CSS 1ファイル・3行の追加のみで、HTML構造や記事本文には手を入れていません。

## 影響範囲

生成物を走査したところ、noteブロックは **111ページに224個**あり、そのうち **16個がコードブロックを含みます**。これらが修正対象です。

もっとも極端な例は https://future-architect.github.io/articles/20240722a/ で、note内のコードに **4810文字の行**があります。

note内のマークダウン表は現時点で0件でした。表も同じ理屈で崩れうるので、今後追加された場合は `display: block; overflow-x: auto;` を当てる必要があります。実例がないため今回のコミットには含めていません。

## 確認方法

CSSの挙動修正のため、ヘッドレスブラウザでのレンダリング確認は行えていません。`hexo generate` で `public/css/theme-styles.css` に意図したルールが出力されることと、上記の影響範囲の集計までを確認しています。実機・DevToolsのデバイスモードでの確認をお願いします。
