### PR TITLE
コードブロックの文字サイズを本文に合わせて15pxにする

### DIFF
--- a/themes/future/source/css/highlight.styl
+++ b/themes/future/source/css/highlight.styl
@@ -12,7 +12,7 @@ highlight-aqua = #66cccc
 highlight-blue = #6699cc
 highlight-purple = #cc99cc
 article-padding = 20px
-font-size = 14px
+font-size = 15px
 line-height = 1.6em
 
 $code-block
@@ -24,6 +24,9 @@ $code-block
   border-width: 1px 0
   overflow: auto
   color: highlight-foreground
+  // font-size を指定しないと body の 13px を継承してしまい、
+  // 本文（.article-entry p の 1.2em = 15.6px）より小さくなって読みにくい
+  font-size: font-size
   line-height: font-size * line-height
 
 $line-numbers

--- a/themes/future/source/css/theme-styles.styl
+++ b/themes/future/source/css/theme-styles.styl
@@ -1107,6 +1107,7 @@ pre.mermaid {
   border: none !important;
   padding: 0 !important;
   line-height: 1; /* SVGの上下にできる余分な空白を消す */
+  font-size: inherit; /* コードブロック用の文字サイズを図に持ち込まない */
 }
 /* .article-entry p 等のスタイルがMermaid SVG内の foreignObject に波及するのを防ぐ */
 .article-entry pre.mermaid p,


### PR DESCRIPTION
## 概要

コードブロックの文字が本文より小さく読みにくい問題を修正します。技術ブログとしてコードの視認性を優先します。

## 原因

コードブロックには **`font-size` の指定がありませんでした**。`highlight.styl` に `font-size = 14px` という変数はありますが、`line-height` の計算にしか使われておらず、CSSプロパティとしては出力されていません。

```styl
$code-block
  ...
  line-height: font-size * line-height   // 22.4px は出力されるが font-size 自体は出力されない
```

その結果、コードブロックは `body { font: 400 13px ... }` の **13px** を継承していました。

一方で本文は `.article-entry p, .article-entry li { font-size: 1.2em }` により **15.6px** で表示されます。つまり本文15.6pxに対してコードが13pxで、地の文より2.6px小さいという逆転が起きていました。

なおインラインコードは `<p>` の中にあるため15.6pxを継承しており、小さく見えていたのはコードブロックだけです。

## 修正

`$code-block` に `font-size` を明示し、変数を15pxに変更しました。

| | 変更前 | 変更後 |
| --- | --- | --- |
| コードブロック | 13px（指定なし・body継承） | **15px** |
| コードブロックの line-height | 22.4px | 24px |
| 本文 | 15.6px | 15.6px（変更なし） |
| インラインコード | 15.6px | 15.6px（変更なし） |

本文15.6pxに対して15pxとしたのは、等幅フォントは同じ字高でも大きく見えるためです。本文とほぼ同じ大きさに揃えつつ、地の文より大きくならない値にしています。

## mermaid への配慮

mermaid の図は `<pre class="mermaid">` として出力されるため、`.article-entry pre` のセレクタに該当します。そのままだと図中の文字サイズまで13px→15pxに変わってしまうため、`pre.mermaid` に `font-size: inherit` を追加して従来どおり13pxを維持しました。既存の「Mermaid SVG にスタイルを波及させない」という同ファイルの意図に沿った対応です。mermaid を使っている記事は23件あります。

セレクタの詳細度は `.article-entry pre` と `pre.mermaid` が同値ですが、`pre.mermaid` の方が後に出力されるため `!important` なしで上書きされます。

## 確認方法

CSSの変更のため、ヘッドレスブラウザでのレンダリング確認は行えていません。`hexo generate` で `public/css/theme-styles.css` に以下が出力されることを確認しています。

```css
.article-entry pre,
.article-entry .highlight {
  ...
  font-size: 15px;
  line-height: 24px;
}

pre.mermaid {
  ...
  font-size: inherit;
}
```

実際の見え方と、15pxが好みに合うかの確認をお願いします。数値だけの調整なので、大きすぎ・小さすぎがあれば `themes/future/source/css/highlight.styl` の `font-size` 変数の1箇所で変えられます。
