### PR TITLE
タグの表記ゆれ18種を統合する

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -137,3 +137,23 @@ alias:
   tags/GCP/: tags/GoogleCloud/
   tags/画像認識/: tags/画像処理/
   tags/icon: categories/アイコン/
+
+  # 表記ゆれの統合（公式表記、なければ多数派に寄せる）
+  tags/Bigquery/: tags/BigQuery/
+  tags/DaisyUI/: tags/daisyUI/
+  tags/daisyui/: tags/daisyUI/
+  tags/DataDog/: tags/Datadog/
+  tags/deno/: tags/Deno/
+  tags/Goland/: tags/GoLand/
+  tags/goland/: tags/GoLand/
+  tags/JavaSCript/: tags/JavaScript/
+  tags/M5stack/: tags/M5Stack/
+  tags/mcis/: tags/MCIS/
+  tags/microPython/: tags/MicroPython/
+  tags/RedShift/: tags/Redshift/
+  tags/cloudflare/: tags/Cloudflare/
+  tags/copilot/: tags/Copilot/
+  tags/lambda/: tags/Lambda/
+  tags/minikube/: tags/Minikube/
+  tags/pv/: tags/PV/
+  tags/rfc/: tags/RFC/

--- a/source/_posts/2019/20190625-redshift.md
+++ b/source/_posts/2019/20190625-redshift.md
@@ -4,7 +4,7 @@ date: 2019/06/25 09:00:00
 postid: ""
 tag:
   - AWS
-  - RedShift
+  - Redshift
   - DWH
 category:
   - DB

--- a/source/_posts/2020/20200519-go-tips-2-goland.md
+++ b/source/_posts/2020/20200519-go-tips-2-goland.md
@@ -4,7 +4,7 @@ date: 2020/05/19 21:52:54
 postid: ""
 tag:
   - Go
-  - Goland
+  - GoLand
   - GoTips連載
 category:
   - Programming

--- a/source/_posts/2020/20200612-春祭り10-deno.md
+++ b/source/_posts/2020/20200612-春祭り10-deno.md
@@ -3,7 +3,7 @@ title: "denoに触れてみよう"
 date: 2020/06/12 12:06:07
 postid: ""
 tag:
-  - deno
+  - Deno
   - JavaScript
   - Node.js
 category:

--- a/source/_posts/2021/20210902b_GoLand_Tips_7選.md
+++ b/source/_posts/2021/20210902b_GoLand_Tips_7選.md
@@ -4,7 +4,7 @@ date: 2021/09/02 00:00:01
 postid: b
 tag:
   - Go
-  - Goland
+  - GoLand
   - JetBrains
   - ショートカット
   - Tips

--- a/source/_posts/2021/20211105a_極小LinuxマシンでSwiftを動かそうとしてみた.md
+++ b/source/_posts/2021/20211105a_極小LinuxマシンでSwiftを動かそうとしてみた.md
@@ -4,7 +4,7 @@ date: 2021/11/05 00:00:00
 postid: a
 tag:
   - Rust
-  - M5stack
+  - M5Stack
   - Linux
 category:
   - IoT

--- a/source/_posts/2022/20220207a_オンライン勉強会の発表順を決めるサービスを作ってみた.md
+++ b/source/_posts/2022/20220207a_オンライン勉強会の発表順を決めるサービスを作ってみた.md
@@ -4,7 +4,7 @@ date: 2022/02/07 00:00:00
 postid: a
 tag:
   - Svelte
-  - DaisyUI
+  - daisyUI
   - 勉強会
   - 運営
   - OSS

--- a/source/_posts/2022/20220406a_プロトタイピングの勧め.md
+++ b/source/_posts/2022/20220406a_プロトタイピングの勧め.md
@@ -6,7 +6,7 @@ tag:
   - M5Stack
   - 電子工作
   - シリアル通信
-  - microPython
+  - MicroPython
 category:
   - IoT
 thumbnail: /images/2022/20220406a/thumbnail.png

--- a/source/_posts/2023/20230320a_数字と振り返るフューチャー技術ブログ（2022年）.md
+++ b/source/_posts/2023/20230320a_数字と振り返るフューチャー技術ブログ（2022年）.md
@@ -5,7 +5,7 @@ postid: a
 tag:
   - techblog
   - 運営
-  - pv
+  - PV
   - ベスブロ
 category:
   - Culture

--- a/source/_posts/2023/20230418a_お家で電子工作入門_～上空のフライト情報を可視化する🛫～.md
+++ b/source/_posts/2023/20230418a_お家で電子工作入門_～上空のフライト情報を可視化する🛫～.md
@@ -3,7 +3,7 @@ title: "お家で電子工作入門 ～上空のフライト情報を可視化�
 date: 2023/04/18 00:00:00
 postid: a
 tag:
-  - M5stack
+  - M5Stack
   - 電子工作
 category:
   - IoT

--- a/source/_posts/2023/20230628a__RFC閲覧補助ツールを作りました_+_リアクティブプログラミング.md
+++ b/source/_posts/2023/20230628a__RFC閲覧補助ツールを作りました_+_リアクティブプログラミング.md
@@ -5,7 +5,7 @@ postid: a
 tag:
   - React
   - Recoil
-  - daisyui
+  - daisyUI
   - RFC
   - Web
 category:

--- a/source/_posts/2024/20240226a_AWS_Lambdaのランタイムを_provided.al2023_に更新する際、2バイナリをzipして対応してみた.md
+++ b/source/_posts/2024/20240226a_AWS_Lambdaのランタイムを_provided.al2023_に更新する際、2バイナリをzipして対応してみた.md
@@ -3,7 +3,7 @@ title: "AWS Lambdaのランタイムを provided.al2023 に更新する際、2�
 date: 2024/02/26 00:00:00
 postid: a
 tag:
-  - lambda
+  - Lambda
   - AWS
   - Makefile
   - バージョンアップ

--- a/source/_posts/2024/20240531a_CloudflareでWebサイトのメンテナンスイン／アウトを実装.md
+++ b/source/_posts/2024/20240531a_CloudflareでWebサイトのメンテナンスイン／アウトを実装.md
@@ -3,7 +3,7 @@ title: "CloudflareでWebサイトのメンテナンスイン/アウトを実装"
 date: 2024/05/31 00:00:00
 postid: a
 tag:
-  - cloudflare
+  - Cloudflare
   - CDN
 category:
   - Infrastructure

--- a/source/_posts/2024/20240712a_GoLand_の_WSL2_対応状況を見てみる.md
+++ b/source/_posts/2024/20240712a_GoLand_の_WSL2_対応状況を見てみる.md
@@ -4,7 +4,7 @@ date: 2024/07/12 00:00:00
 postid: a
 tag:
   - Go
-  - goland
+  - GoLand
   - WSL
   - IDE
 category:

--- a/source/_posts/2024/20241203a_見積りソンで最優秀賞を受賞しました.md
+++ b/source/_posts/2024/20241203a_見積りソンで最優秀賞を受賞しました.md
@@ -4,7 +4,7 @@ date: 2024/12/03 00:00:00
 postid: a
 tag:
   - 見積り
-  - mcis
+  - MCIS
   - 参加レポート
 category:
   - Management

--- a/source/_posts/2024/20241205a_TypeScript／JavaScript_Array完全攻略2024.md
+++ b/source/_posts/2024/20241205a_TypeScript／JavaScript_Array完全攻略2024.md
@@ -4,7 +4,7 @@ date: 2024/12/05 00:00:00
 postid: a
 tag:
   - TypeScript
-  - JavaSCript
+  - JavaScript
   - ECMAScript
 category:
   - Frontend

--- a/source/_posts/2025/20250307a_Japan_Datadog_User_Group_Meetup#8@札幌に登壇しました.md
+++ b/source/_posts/2025/20250307a_Japan_Datadog_User_Group_Meetup#8@札幌に登壇しました.md
@@ -5,7 +5,7 @@ postid: a
 tag:
   - 登壇レポート
   - オブサーバビリティ
-  - DataDog
+  - Datadog
 category:
   - DevOps
 thumbnail: /images/2025/20250307a/thumbnail.png

--- a/source/_posts/2025/20251208a_プログラミング未経験の学生が選択すると良さそうな生成AIツールと考え方.md
+++ b/source/_posts/2025/20251208a_プログラミング未経験の学生が選択すると良さそうな生成AIツールと考え方.md
@@ -4,7 +4,7 @@ date: 2025/12/08 00:00:00
 postid: a
 tag:
   - Kiro
-  - copilot
+  - Copilot
   - 技育祭
 category:
   - AIDD

--- a/source/_posts/2026/20260325a_実験して入門するKubernetes：Pod起動の裏側を追っていたら、どうしてもSchedulerを止めてみたくなった件.md
+++ b/source/_posts/2026/20260325a_実験して入門するKubernetes：Pod起動の裏側を追っていたら、どうしてもSchedulerを止めてみたくなった件.md
@@ -4,7 +4,7 @@ date: 2026/03/25 00:00:00
 postid: a
 tag:
   - Kubernetes
-  - minikube
+  - Minikube
   - 初心者向け
 category:
   - Infrastructure

--- a/source/_posts/2026/20260430a_BigQueryから直接Geminiを叩こう。BigQueryMLによるログ解析ハンズオン.md
+++ b/source/_posts/2026/20260430a_BigQueryから直接Geminiを叩こう。BigQueryMLによるログ解析ハンズオン.md
@@ -3,7 +3,7 @@ title: "BigQueryから直接Geminiを叩こう。BigQueryMLによるログ解析
 date: 2026/04/30 00:00:00
 postid: a
 tag:
-  - Bigquery
+  - BigQuery
   - GoogleCloud
   - Gemini
 category:

--- a/source/_posts/2026/20260611a_RFC_7807_から_RFC_9457_で_Web_API_のエラー表現で変わったこと.md
+++ b/source/_posts/2026/20260611a_RFC_7807_から_RFC_9457_で_Web_API_のエラー表現で変わったこと.md
@@ -4,7 +4,7 @@ date: 2026/06/11 00:00:00
 postid: a
 tag:
   - Web
-  - rfc
+  - RFC
   - WebAPI
   - エラーハンドリング
 category:


### PR DESCRIPTION
## 概要

タグ棚卸しの第1弾です。**大文字小文字だけが違うタグ18種**を統合します。

`/tags/` の調査中に見つけたもので、同じ技術が別タグとして分かれ、記事が分断されていました。孤立タグ（1記事にしか付いていないタグ）の削除を検討する前に、まずこれを潰します。

## 統合内容

統合先は公式表記、それがなければ多数派の表記に寄せています。

| 統合前 | 統合後 | 件数 |
| --- | --- | --- |
| `Bigquery` | `BigQuery` | 15 → 16 |
| `DaisyUI` / `daisyui` | `daisyUI` | 1+1+1 → **3** |
| `DataDog` | `Datadog` | 1+1 → **2** |
| `deno` | `Deno` | 1+1 → **2** |
| `Goland` / `goland` | `GoLand` | 2+1+1 → 4 |
| `JavaSCript` | `JavaScript` | 27 → 28 |
| `M5stack` | `M5Stack` | 2+1 → 3 |
| `mcis` | `MCIS` | 1+1 → **2** |
| `microPython` | `MicroPython` | 1+1 → **2** |
| `RedShift` | `Redshift` | 1+1 → **2** |
| `cloudflare` | `Cloudflare` | 10 → 11 |
| `copilot` | `Copilot` | 2 → 3 |
| `lambda` | `Lambda` | 25 → 26 |
| `minikube` | `Minikube` | 3 → 4 |
| `pv` | `PV` | 2 → 3 |
| `rfc` | `RFC` | 6 → 7 |

**太字の6タグは、統合によって「1記事しか付いていない」状態を脱しました。** 分断されていただけで、実際には複数記事に付いていたタグです。

## 効果

```
タグ種類数            761 -> 743
1記事のみのタグ        112 ->  88
```

## URLの維持

旧タグのページが404にならないよう、`_config.yml` の `alias` にリダイレクトを追加しました。CLAUDE.md に書かれている「タグの名寄せは alias に記述する」という慣例に沿っています。

```yaml
  # 表記ゆれの統合（公式表記、なければ多数派に寄せる）
  tags/Bigquery/: tags/BigQuery/
  tags/DaisyUI/: tags/daisyUI/
  ...
```

## 動作確認

`hexo clean` してフルビルドし、18件すべてのリダイレクトが正しい転送先を指していることを確認しました。

```
リダイレクト検証: 18/18 件OK
```

記事側の差分は20ファイル・20行で、すべてフロントマターの `tag` 行のみです。統合で同一記事内にタグが重複するケースはありませんでした。

## 次にやること

タグ棚卸しの本題である孤立タグ88件の処理は、別PRに分けます。調査済みの内訳は以下です。

- **他記事にも展開できそう: 約20件** — タイトル・lede に同じ語が出てくる記事があり、タグを追加できる（例: `WSL2`、`Salesforce`、`コンパイラ`、`性能テスト`）
- **展開先なし: 約68件** — ただしこの中には `インターン2026` `NLP2025` のような連載・年次シリーズのタグや、`Elixir` `Prometheus` のような将来再利用されうる技術名が含まれるため、一律削除はしない方がよいと考えています

なお、`AI-DLC, SDD、2026年4月時点のAI駆動の開発スタイルの考察` は #1898 で `AI` タグを外した結果 `スペック駆動開発` の1つだけになっており、これを消すと無タグになります。削除対象からは除外します。
