### PR TITLE
孤立タグを他記事へ展開し、同義タグ3種を統合する

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -138,6 +138,11 @@ alias:
   tags/画像認識/: tags/画像処理/
   tags/icon: categories/アイコン/
 
+  # 同義タグの統合
+  tags/自然言語処理/: tags/NLP/
+  tags/WSL2/: tags/WSL/
+  tags/性能テスト/: tags/性能検証/
+
   # 表記ゆれの統合（公式表記、なければ多数派に寄せる）
   tags/Bigquery/: tags/BigQuery/
   tags/DaisyUI/: tags/daisyUI/

--- a/source/_posts/2017/20170804-alphago.md
+++ b/source/_posts/2017/20170804-alphago.md
@@ -6,6 +6,7 @@ tag:
   - 機械学習
   - AI
   - AlphaGo
+  - ゲーム
 category:
   - DataScience
 thumbnail: /images/2017/20170804/thumbnail_20170804.jpg

--- a/source/_posts/2017/20171113-sport-ideathon.md
+++ b/source/_posts/2017/20171113-sport-ideathon.md
@@ -7,6 +7,7 @@ tag:
   - プログラミング教育
   - アイデアソン
   - 子ども
+  - スポーツ
 category:
   - VR
 thumbnail: /images/2017/20171113/thumbnail_20171113.png

--- a/source/_posts/2019/20190925-vr.md
+++ b/source/_posts/2019/20190925-vr.md
@@ -6,6 +6,7 @@ tag:
   - Unity
   - 子ども
   - ブラインドサッカー
+  - スポーツ
 category:
   - VR
 author: 西村祐美

--- a/source/_posts/2019/20191129-gdg-devfest.md
+++ b/source/_posts/2019/20191129-gdg-devfest.md
@@ -6,6 +6,7 @@ tag:
   - GoogleCloud
   - GCPUG
   - 登壇レポート
+  - GDG
 category:
   - Infrastructure
 author: 伊藤太斉

--- a/source/_posts/2020/20200323-aws-sam.md
+++ b/source/_posts/2020/20200323-aws-sam.md
@@ -8,6 +8,7 @@ tag:
   - サーバーレス
   - DynamoDB
   - Lambda
+  - SAM
 category:
   - Programming
 thumbnail: /images/2020/20200323/thumbnail.png

--- a/source/_posts/2020/20200929_k3sを知る、動かす、感じる.md
+++ b/source/_posts/2020/20200929_k3sを知る、動かす、感じる.md
@@ -5,6 +5,7 @@ postid: ""
 tag:
   - CNCF
   - Kubernetes
+  - k3s
 category:
   - DevOps
 thumbnail: /images/2020/20200929/thumbnail.png

--- a/source/_posts/2020/20201027_Vulsの歴史.md
+++ b/source/_posts/2020/20201027_Vulsの歴史.md
@@ -4,6 +4,7 @@ date: 2020/10/27 00:00:00
 postid: ""
 tag:
   - Vuls
+  - FutureVuls
 category:
   - Security
 thumbnail: /images/2020/20201027/thumbnail.png

--- a/source/_posts/2021/20210302_Auth0でADをユーザDBにし、SalesforceとのSSOを確認する.md
+++ b/source/_posts/2021/20210302_Auth0でADをユーザDBにし、SalesforceとのSSOを確認する.md
@@ -7,6 +7,7 @@ tag:
   - SSO
   - AD
   - Auth0Rules
+  - Salesforce
 category:
   - 認証認可
 thumbnail: /images/2021/20210302/thumbnail.png

--- a/source/_posts/2021/20210810a_Go_1.17連載が始まります。コンパイラとgo_mod.md
+++ b/source/_posts/2021/20210810a_Go_1.17連載が始まります。コンパイラとgo_mod.md
@@ -7,6 +7,7 @@ tag:
   - Go1.17
   - GoModules
   - インデックス
+  - コンパイラ
 category:
   - Programming
 thumbnail: /images/2021/20210810a/thumbnail.jpg

--- a/source/_posts/2022/20220829a_S3_on_LocalStackをGoとFUSEを使ってMountする（WSL2）.md
+++ b/source/_posts/2022/20220829a_S3_on_LocalStackをGoとFUSEを使ってMountする（WSL2）.md
@@ -6,6 +6,7 @@ tag:
   - S3
   - LocalStack
   - Go
+  - WSL
 category:
   - Programming
 thumbnail: /images/2022/20220829a/thumbnail.png

--- a/source/_posts/2022/20221014a_GoLand(JetBrains_IDE)のDatabase_Tools_and_SQLプラグインをメインのSQLクライアントにする.md
+++ b/source/_posts/2022/20221014a_GoLand(JetBrains_IDE)のDatabase_Tools_and_SQLプラグインをメインのSQLクライアントにする.md
@@ -7,6 +7,7 @@ tag:
   - JetBrains
   - 便利ツール
   - SQL
+  - IDE
 category:
   - DB
 thumbnail: /images/2022/20221014a/thumbnail.png

--- a/source/_posts/2023/20230327b_terraform_1.4_Update：Private_Service_Connectを利用したbackend／gcsへのアクセス.md
+++ b/source/_posts/2023/20230327b_terraform_1.4_Update：Private_Service_Connectを利用したbackend／gcsへのアクセス.md
@@ -6,6 +6,7 @@ tag:
   - GoogleCloud
   - Terraform
   - Terraform1.4
+  - GCS
 category:
   - DevOps
 thumbnail: /images/2023/20230327b/thumbnail.png

--- a/source/_posts/2025/20250428a_CursorによるAI駆動開発入門.md
+++ b/source/_posts/2025/20250428a_CursorによるAI駆動開発入門.md
@@ -7,6 +7,7 @@ tag:
   - 生成AI
   - LLM
   - cursor
+  - AI駆動開発
 category:
   - AIDD
 thumbnail: /images/2025/20250428a/thumbnail.gif

--- a/source/_posts/2025/20251027a_Vue.jsで脆弱なアプリを作って学ぶ、セキュリティ面で気をつけたいポイント.md
+++ b/source/_posts/2025/20251027a_Vue.jsで脆弱なアプリを作って学ぶ、セキュリティ面で気をつけたいポイント.md
@@ -5,6 +5,7 @@ postid: a
 tag:
   - Vue.js
   - 脆弱性
+  - CSRF
 category:
   - Frontend
 thumbnail: /images/2025/20251027a/thumbnail.png

--- a/source/_posts/2026/20260316a_【著者解説】NLP2026_若手奨励賞受賞論文_"TimeMachine-bench"_を著者が解説する.md
+++ b/source/_posts/2026/20260316a_【著者解説】NLP2026_若手奨励賞受賞論文_"TimeMachine-bench"_を著者が解説する.md
@@ -3,7 +3,6 @@ title: "【著者解説】NLP2026 若手奨励賞受賞論文 \"TimeMachine-benc
 date: 2026/03/16 00:00:00
 postid: a
 tag:
-  - 自然言語処理
   - NLP
   - 論文解説
 category:

--- a/source/_posts/2026/20260421b_自宅だと_apt_update_ができなかった話（WSL2_+_社内VPN環境での名前解決の遅延）.md
+++ b/source/_posts/2026/20260421b_自宅だと_apt_update_ができなかった話（WSL2_+_社内VPN環境での名前解決の遅延）.md
@@ -3,7 +3,7 @@ title: "自宅だと apt update ができなかった話（WSL2 + 社内VPN環�
 date: 2026/04/21 00:00:01
 postid: b
 tag:
-  - WSL2
+  - WSL
   - VPN
   - Ubuntu
   - 環境構築

--- a/source/_posts/2026/20260610a_はじめての性能テストを公開しました.md
+++ b/source/_posts/2026/20260610a_はじめての性能テストを公開しました.md
@@ -4,7 +4,7 @@ date: 2026/06/10 00:00:00
 postid: a
 tag:
   - 非機能
-  - 性能テスト
+  - 性能検証
   - ガイドライン
 category:
   - Infrastructure


### PR DESCRIPTION
## 概要

タグ棚卸しの第2弾です。#1900（表記ゆれの統合）に続き、**孤立タグを他記事へ展開**します。

1記事にしか付いていないタグについて、記事本文ではなくタイトル・lede・既存タグを手がかりに、他記事にも付けられないかを調べました。

## 1. 同義タグの統合（3件）

調べる過程で、同じ概念が別タグに分かれているものが見つかりました。

| 統合前 | 統合後 | 理由 |
| --- | --- | --- |
| `自然言語処理` (1) | `NLP` (19) | 日本語表記と英略称の重複。元記事は既に `NLP` も持っていた |
| `WSL2` (1) | `WSL` (3→5) | バージョン違いのタグ |
| `性能テスト` (1) | `性能検証` (5→6) | 同義 |

## 2. タグの展開（13件）

タイトルに同じ語が現れる記事へ振り下ろしました。

| タグ | 展開先 |
| --- | --- |
| `ゲーム` | 古典的ゲームAIを用いたAlphaGo解説 |
| `スポーツ` | 最新テクノロジーでスポーツアイデアソンをやって… / Oculus Questで作る入院中の子どもたちに向けたパラスポーツ体験 |
| `GDG` | GDG DevFest in 信州2019に登壇しました |
| `SAM` | Serverless連載1: SAMを使ったローカルテスト（Go編） |
| `k3s` | k3sを知る、動かす、感じる |
| `FutureVuls` | Vulsの歴史 |
| `Salesforce` | Auth0でADをユーザDBにし、SalesforceとのSSOを確認する |
| `コンパイラ` | Go 1.17連載が始まります: コンパイラとgo mod |
| `IDE` | GoLand(JetBrains IDE)のDatabase Tools and SQLプラグイン… |
| `GCS` | Terraform 1.4 Update: Private Service Connectを利用したbackend/gcs |
| `AI駆動開発` | CursorによるAI駆動開発入門 |
| `CSRF` | Vue.jsで脆弱なアプリを作って学ぶ、セキュリティ面で気をつけたいポイント |
| `WSL` | S3 on LocalStackをGoとFUSEを使ってMountする（WSL2） |

**これで12タグが「1記事だけ」の状態を脱しました。**

## 見送ったもの（誤検出）

語としては一致するが意味が異なるため、展開しませんでした。

- `ACL` … 元記事は自然言語処理の国際会議 ACL。マッチしたのは `Casbinで始めるアクセス制御`（Access Control List）で別物
- `C言語` … マッチしたのは `新入社員が「リーダブルコード」を読んでみた`。lede に「C言語」が例として出るだけ
- `PCDE` … Google Cloud 認定資格。マッチしたのは別資格（PGWA）の合格記
- `CPU` `データ移行` … lede での言及が軽く、タグを付けるほどの主題ではない

なお当初は部分一致で調べていましたが、`GC` が `GCP` に、`.NET` が `Kubernetes`（"kuber**net**es"）に当たるなど誤検出が多かったため、英数字タグは単語境界を要求する判定に変えています。

## 効果

```
タグ種類数      743 -> 740
孤立タグ         88 ->  73
無タグ記事         0 ->   0
```

#1900 と合わせると、孤立タグは **112 → 73件** になりました。

## URLの維持

統合した3タグは `_config.yml` にエイリアスを追加し、リダイレクトを確認しています。

```
/tags/自然言語処理/ -> /tags/NLP/      OK
/tags/WSL2/       -> /tags/WSL/      OK
/tags/性能テスト/    -> /tags/性能検証/   OK
```

## 残り73件の扱い

いただいた方針（系列タグ・資格タグ・将来再利用されうるタグは動線確保のため残す）を踏まえると、73件の大半は**残す**ことになります。

- 系列: `インターン2026` `NLP2025`
- 資格: `CCNA` `CDL` `PCDB` `PCSE` `PDE` `PGWA` `PMLE` `E資格` `ISMS` `Pマーク` `無人航空機操縦士` `SOA`
- 予約（将来再利用）: `Elixir` `Prometheus` `Selenium` `Okta` `Vault` `Iceberg` `Obsidian` `RAG` `Skills` など技術名の大半

削除候補として残るのは、記事固有の説明的なタグや誤タグに絞られます。次のPRで、この観点から候補を絞り込んで提示します。
