### PR TITLE
残っていた同義タグと誤記タグを統合する

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -142,6 +142,8 @@ alias:
   tags/自然言語処理/: tags/NLP/
   tags/WSL2/: tags/WSL/
   tags/性能テスト/: tags/性能検証/
+  tags/論文解説/: tags/論文紹介/
+  tags/SQLLite/: tags/SQLite/ # 誤記の修正
 
   # 表記ゆれの統合（公式表記、なければ多数派に寄せる）
   tags/Bigquery/: tags/BigQuery/

--- a/source/_posts/2024/20240528a_Cloudflare_D1を触ってみる.md
+++ b/source/_posts/2024/20240528a_Cloudflare_D1を触ってみる.md
@@ -3,8 +3,8 @@ title: "Cloudflare D1を触ってみる"
 date: 2024/05/28 00:00:00
 postid: a
 tag:
-  - Cloudflare 
-  - SQLLite
+  - Cloudflare
+  - SQLite
 category:
   - DB
 thumbnail: /images/2024/20240528a/thumbnail.png

--- a/source/_posts/2026/20260316a_【著者解説】NLP2026_若手奨励賞受賞論文_"TimeMachine-bench"_を著者が解説する.md
+++ b/source/_posts/2026/20260316a_【著者解説】NLP2026_若手奨励賞受賞論文_"TimeMachine-bench"_を著者が解説する.md
@@ -4,7 +4,7 @@ date: 2026/03/16 00:00:00
 postid: a
 tag:
   - NLP
-  - 論文解説
+  - 論文紹介
 category:
   - DataScience
 thumbnail: /images/2026/20260316a/thumbnail.png


### PR DESCRIPTION
## 概要

タグ棚卸しの第3弾（最終）です。#1900 #1901 で残った孤立タグ73件を、いただいた方針で仕分けました。

**結論として、削除に該当するタグはありませんでした。** 代わりに、まだ取りこぼしていた同義タグと誤記を2件見つけたので修正します。

## 修正内容

| 修正前 | 修正後 | 理由 |
| --- | --- | --- |
| `論文解説` (1) | `論文紹介` (9→10) | 同義。`論文紹介` には NeurIPS / ICLR の論文紹介記事など9件が既にあった |
| `SQLLite` (1) | `SQLite` | 誤記（L が1つ多い）。記事は Cloudflare D1 で、D1 は SQLite 互換 |

`SQLite` は1記事のままですが、誤った綴りのタグは将来の記事から再利用できないため、正しい綴りに直しました。

## 削除に該当するものがなかった理由

いただいた方針は次の3点でした。

1. 系列タグは残す（URLを直接書き換えて探す人がいるので動線確保が重要）
2. 合格記の資格タグも残す
3. 今後再利用が考えられるタグは予約として残す

これを73件に当てはめると、次のように大半が「残す」に該当します。

| 分類 | 件数 | 例 |
| --- | --- | --- |
| 系列 | 2 | `インターン2026`（2020〜2024が3〜8件ずつ存在）、`NLP2025` |
| 資格 | 13 | `PCDB` `PCDE` `PCSE` `PDE` `PGWA` `PMLE` `CDL` `CCNA` `E資格` `ISMS` `Pマーク` `SOA` `無人航空機操縦士` |
| 技術名（予約） | 約40 | `Elixir` `Prometheus` `Selenium` `Okta` `Vault` `Iceberg` `Obsidian` `RAG` `Skills` `Testcontainers` `wasmCloud` など |
| 概念・業務語（予約） | 約17 | `アンチパターン` `リバースプロキシ` `バイトコード` `新規事業` `海外展開` `銀行` `区分値` `データ移行` など |

## 誤タグの疑いを潰しました

内容と合っていない可能性があった2件について、本文を確認しました。いずれも妥当なタグでした。

- `.NET` … 記事「ユニバーサルリンクをAzure BlobStorageでやってみる」の本文に **13回** 登場（`.NET` `dotnet` 含む）
- `fluentd` … 記事「Go Cloud#7 PubSubドライバー(pubだけ)を実装してみる」の本文に **35回** 登場

## 効果（3PR通算）

```
             #1900前   #1900   #1901   本PR
タグ種類数      761  ->  743  ->  740  -> 739
孤立タグ       112  ->   88  ->   73  ->  72
無タグ記事       0  ->    0  ->    0  ->   0
```

**孤立タグは112件から72件へ、40件減りました。** その内訳は表記ゆれの統合18件、同義タグの統合5件、他記事への展開13件です。1記事も削除せず、すべて統合または展開で解消しています。

統合・改名した全25タグには `_config.yml` にエイリアスを追加しており、旧URLはすべてリダイレクトされます。

## 積み残し

- **本文からのタグ振り下ろし** … 今回はタイトル・lede・既存タグのみを根拠にしました。本文まで見ると展開できるものがあります（例: `fluentd` は「AWS ハンズオン」記事の本文にも3回登場）。ご指摘のとおりコストが高いので別ワークとします
- **残り72件の孤立タグ** … 上記の方針により、当面は予約として維持します
