### PR TITLE
タグが1つ以下だった記事42件にタグを振り下ろす

### DIFF
--- a/source/_posts/2016/20160216_ごあいさつ.md
+++ b/source/_posts/2016/20160216_ごあいさつ.md
@@ -4,6 +4,7 @@ date: 2016-02-16 09:02:14
 postid: ""
 tag:
   - TechBlog
+  - 運営
 category:
   - Culture
 thumbnail: /images/2016/20160216/thumbnail_20160216.jpg

--- a/source/_posts/2016/20160217_LT大会前編.md
+++ b/source/_posts/2016/20160217_LT大会前編.md
@@ -4,6 +4,7 @@ date: 2016-02-17 09:09:12
 postid: ""
 tag:
   - LT
+  - 勉強会
 category:
   - Culture
 author: 真野隼記

--- a/source/_posts/2016/20160218-LT大会後編.md
+++ b/source/_posts/2016/20160218-LT大会後編.md
@@ -4,6 +4,7 @@ date: 2016-02-18 11:31:15
 postid: ""
 tag:
   - LT
+  - 勉強会
 category:
   - Culture
 author: 真野隼記

--- a/source/_posts/2016/20160413-LT大会2.md
+++ b/source/_posts/2016/20160413-LT大会2.md
@@ -4,6 +4,7 @@ date: 2016-04-13 14:37:37
 postid: ""
 tag:
   - LT
+  - 勉強会
 category:
   - Culture
 author: 齋場俊太朗

--- a/source/_posts/2016/20160718-lt4.md
+++ b/source/_posts/2016/20160718-lt4.md
@@ -4,6 +4,7 @@ date: 2016/07/18 18:14:46
 postid: ""
 tag:
   - LT
+  - 勉強会
 category:
   - Culture
 author: 真野隼記

--- a/source/_posts/2016/20161013-lt5.md
+++ b/source/_posts/2016/20161013-lt5.md
@@ -4,6 +4,7 @@ date: 2016/10/13 11:06:05
 postid: ""
 tag:
   - LT
+  - 勉強会
 category:
   - Culture
 author: 真野隼記

--- a/source/_posts/2016/20161206-iot.md
+++ b/source/_posts/2016/20161206-iot.md
@@ -4,6 +4,7 @@ date: 2016/12/9 10:56:44
 postid: ""
 tag:
   - OSS
+  - コミュニティ
 category:
   - IoT
 author: 山本力世

--- a/source/_posts/2017/20170216-lt6.md
+++ b/source/_posts/2017/20170216-lt6.md
@@ -4,6 +4,7 @@ date: 2017/02/16 10:30:00
 postid: ""
 tag:
   - LT
+  - 勉強会
 category:
   - Culture
 author: 谷村元気

--- a/source/_posts/2017/20170314-statistics.md
+++ b/source/_posts/2017/20170314-statistics.md
@@ -4,6 +4,7 @@ date: 2017-03-14 14:00:00
 postid: ""
 tag:
   - 統計
+  - データ分析
 category:
   - DataScience
 thumbnail: /images/2017/20170310/thumbnail_20170310.jpg

--- a/source/_posts/2017/20170322-silicon-valley.md
+++ b/source/_posts/2017/20170322-silicon-valley.md
@@ -4,6 +4,7 @@ date: 2017/03/22 12:00:00
 postid: ""
 tag:
   - Elastic{ON}
+  - 参加レポート
 category:
   - Culture
 author: 前原応光

--- a/source/_posts/2019/20190904-terraform-practice.md
+++ b/source/_posts/2019/20190904-terraform-practice.md
@@ -4,6 +4,7 @@ date: 2019/09/03 15:20:52
 postid: ""
 tag:
   - Terraform
+  - IaC
 category:
   - DevOps
 author: 木村拓海

--- a/source/_posts/2020/20200923_久しぶりに社内LT大会を開催しました。2020_Summer.md
+++ b/source/_posts/2020/20200923_久しぶりに社内LT大会を開催しました。2020_Summer.md
@@ -4,6 +4,7 @@ date: 2020/09/23 00:00:00
 postid: ""
 tag:
   - LT
+  - 勉強会
 category:
   - Culture
 thumbnail: /images/2020/20200923/thumbnail.png

--- a/source/_posts/2020/20201105_イノベーションの捉え方.md
+++ b/source/_posts/2020/20201105_イノベーションの捉え方.md
@@ -4,6 +4,7 @@ date: 2020/11/05 00:00:00
 postid: ""
 tag:
   - 統計
+  - データ分析
 category:
   - DataScience
 thumbnail: /images/2020/20201105/thumbnail.jpg

--- a/source/_posts/2020/20201107_フューチャーOSS推進タスクフォース始めます.md
+++ b/source/_posts/2020/20201107_フューチャーOSS推進タスクフォース始めます.md
@@ -4,6 +4,7 @@ date: 2020/11/07 00:00:00
 postid: ""
 tag:
   - OSS
+  - コミュニティ
 category:
   - Culture
 thumbnail: /images/2020/20201107/thumbnail.jpg

--- a/source/_posts/2020/20201203_GoがApple_Siliconにネイティブ対応したのでベンチマークをとってみました.md
+++ b/source/_posts/2020/20201203_GoがApple_Siliconにネイティブ対応したのでベンチマークをとってみました.md
@@ -4,6 +4,7 @@ date: 2020/12/03 00:00:00
 postid: ""
 tag:
   - Go
+  - Mac
 category:
   - Programming
 thumbnail: /images/2020/20201203/thumbnail.png

--- a/source/_posts/2021/20210120_Androidのビルドバリアントをイチから理解する.md
+++ b/source/_posts/2021/20210120_Androidのビルドバリアントをイチから理解する.md
@@ -4,6 +4,7 @@ date: 2021/01/20 00:00:00
 postid: ""
 tag:
   - Android
+  - 入門
 category:
   - Mobile
 thumbnail: /images/2021/20210120/thumbnail.png

--- a/source/_posts/2021/20210228_LT大会#11_2021_Winter.md
+++ b/source/_posts/2021/20210228_LT大会#11_2021_Winter.md
@@ -4,6 +4,7 @@ date: 2021/02/28 00:00:00
 postid: ""
 tag:
   - LT
+  - 勉強会
 category:
   - Culture
 thumbnail: /images/2021/20210228/thumbnail.png

--- a/source/_posts/2021/20210401_declare使ってBashで配列と連想配列.md
+++ b/source/_posts/2021/20210401_declare使ってBashで配列と連想配列.md
@@ -4,6 +4,7 @@ date: 2021/04/01 00:00:00
 postid: ""
 tag:
   - ShellScript
+  - Linux
 category:
   - Infrastructure
 thumbnail: /images/2021/20210401/thumbnail.png

--- a/source/_posts/2021/20210405_オプション付きのオリジナルコマンドを作成しよう.md
+++ b/source/_posts/2021/20210405_オプション付きのオリジナルコマンドを作成しよう.md
@@ -4,6 +4,7 @@ date: 2021/04/05 00:00:00
 postid: ""
 tag:
   - ShellScript
+  - Linux
 category:
   - Infrastructure
 thumbnail: /images/2021/20210405/thumbnail.jpg

--- a/source/_posts/2021/20210406_Bashのシェル展開.md
+++ b/source/_posts/2021/20210406_Bashのシェル展開.md
@@ -4,6 +4,7 @@ date: 2021/04/06 00:00:00
 postid: ""
 tag:
   - ShellScript
+  - Linux
 category:
   - Infrastructure
 thumbnail: /images/2021/20210406/thumbnail.jpg

--- a/source/_posts/2021/20210407_LeetCodeへのコントリビュートのすすめ.md
+++ b/source/_posts/2021/20210407_LeetCodeへのコントリビュートのすすめ.md
@@ -4,6 +4,7 @@ date: 2021/04/07 00:00:00
 postid: ""
 tag:
   - 競技プログラミング
+  - アルゴリズム
 category:
   - Programming
 thumbnail: /images/2021/20210407/thumbnail.png

--- a/source/_posts/2021/20210416a_リモートワーク連載：社用機と私用機に同じモニタ3台を使う話.md
+++ b/source/_posts/2021/20210416a_リモートワーク連載：社用機と私用機に同じモニタ3台を使う話.md
@@ -4,6 +4,7 @@ date: 2021/04/16 00:00:00
 postid: a
 tag:
   - リモートワーク
+  - 環境構築
 category:
   - Programming
 thumbnail: /images/2021/20210416a/thumbnail.JPG

--- a/source/_posts/2021/20210513b_Flutterレイアウト入門.md
+++ b/source/_posts/2021/20210513b_Flutterレイアウト入門.md
@@ -4,6 +4,7 @@ date: 2021/05/13 00:00:01
 postid: b
 tag:
   - Flutter
+  - Dart
 category:
   - Mobile
 thumbnail: /images/2021/20210513b/thumbnail.png

--- a/source/_posts/2021/20210514a_Flutterで技術ブログRSSリーダー.md
+++ b/source/_posts/2021/20210514a_Flutterで技術ブログRSSリーダー.md
@@ -4,6 +4,7 @@ date: 2021/05/14 00:00:01
 postid: a
 tag:
   - Flutter
+  - Dart
 category:
   - Mobile
 thumbnail: /images/2021/20210514a/thumbnail.png

--- a/source/_posts/2021/20210628b_近傍探索で用いられるtopKのソートアルゴリズム.md
+++ b/source/_posts/2021/20210628b_近傍探索で用いられるtopKのソートアルゴリズム.md
@@ -4,6 +4,7 @@ date: 2021/06/28 00:00:01
 postid: b
 tag:
   - アルゴリズム
+  - データ構造
 category:
   - Programming
 thumbnail: /images/2021/20210628b/thumbnail.png

--- a/source/_posts/2021/20211109a_仮想通貨の個人ウォレットの守り方.md
+++ b/source/_posts/2021/20211109a_仮想通貨の個人ウォレットの守り方.md
@@ -4,6 +4,7 @@ date: 2021/11/09 00:00:00
 postid: a
 tag:
   - FinTech
+  - 暗号
 category:
   - Security
 thumbnail: /images/2021/20211109a/thumbnail.png

--- a/source/_posts/2021/20211202a_AB_Open社と提携してRISC-V_PCを開発しました.md
+++ b/source/_posts/2021/20211202a_AB_Open社と提携してRISC-V_PCを開発しました.md
@@ -4,6 +4,7 @@ date: 2021/12/02 00:00:00
 postid: a
 tag:
   - RISC-V
+  - 電子工作
 category:
   - IoT
 thumbnail: /images/2021/20211202a/thumbnail.jpg

--- a/source/_posts/2021/20211227a_科目等履修生はいいぞ.md
+++ b/source/_posts/2021/20211227a_科目等履修生はいいぞ.md
@@ -4,6 +4,7 @@ date: 2021/12/27 00:00:00
 postid: a
 tag:
   - キャリア
+  - スキルアップ
 category:
   - Culture
 thumbnail: /images/2021/20211227a/thumbnail.jpg

--- a/source/_posts/2022/20220127a_CHAdeMO_vs_コンボ　EV充電規格を比較する.md
+++ b/source/_posts/2022/20220127a_CHAdeMO_vs_コンボ　EV充電規格を比較する.md
@@ -4,6 +4,7 @@ date: 2022/01/27 00:00:00
 postid: a
 tag:
   - 業界ドメイン
+  - エネルギー業界
 category:
   - IoT
 thumbnail: /images/2022/20220127a/thumbnail.png

--- a/source/_posts/2022/20220822b_夏の自由研究_英単語学習アプリを作ってみた.md
+++ b/source/_posts/2022/20220822b_夏の自由研究_英単語学習アプリを作ってみた.md
@@ -4,6 +4,7 @@ date: 2022/08/22 00:00:00
 postid: b
 tag:
   - Flutter
+  - Dart
 category:
   - Mobile
 thumbnail: /images/2022/20220822b/thumbnail.png

--- a/source/_posts/2023/20230829a_クライアント／サーバ構成でみるPlaywright.md
+++ b/source/_posts/2023/20230829a_クライアント／サーバ構成でみるPlaywright.md
@@ -4,6 +4,7 @@ date: 2023/08/29 00:00:00
 postid: a
 tag:
   - Playwright
+  - テスト
 category:
   - Frontend
 thumbnail: /images/2023/20230829a/thumbnail.png

--- a/source/_posts/2024/20240313a_terraformにおける変数の制御について.md
+++ b/source/_posts/2024/20240313a_terraformにおける変数の制御について.md
@@ -4,6 +4,7 @@ date: 2024/03/13 00:00:00
 postid: a
 tag:
   - Terraform
+  - IaC
 category:
   - DevOps
 thumbnail: /images/2024/20240313a/thumbnail.png

--- a/source/_posts/2024/20240412a_systemdにおけるservice_unitの起動フロー入門.md
+++ b/source/_posts/2024/20240412a_systemdにおけるservice_unitの起動フロー入門.md
@@ -4,6 +4,7 @@ date: 2024/04/12 00:00:00
 postid: a
 tag:
   - Linux
+  - 入門
 category:
   - Infrastructure
 thumbnail: /images/2024/20240412a/thumbnail.jpg

--- a/source/_posts/2025/20250415a_Factorioに入門して「ボトルネック解消」を体感する.md
+++ b/source/_posts/2025/20250415a_Factorioに入門して「ボトルネック解消」を体感する.md
@@ -4,6 +4,7 @@ date: 2025/04/15 00:00:00
 postid: a
 tag:
   - 生成AI
+  - ゲーム
 category:
   - Management
 thumbnail: /images/2025/20250415a/thumbnail.png

--- a/source/_posts/2025/20250603b_Dokployで自宅PaaSを構築する.md
+++ b/source/_posts/2025/20250603b_Dokployで自宅PaaSを構築する.md
@@ -4,6 +4,7 @@ date: 2025/06/03 00:00:01
 postid: b
 tag:
   - Docker
+  - コンテナ
 category:
   - DevOps
 thumbnail: /images/2025/20250603b/thumbnail.png

--- a/source/_posts/2025/20250828a_Rustベースのdbt_fusion_engineを使ってみた！.md
+++ b/source/_posts/2025/20250828a_Rustベースのdbt_fusion_engineを使ってみた！.md
@@ -4,6 +4,7 @@ date: 2025/08/28 00:00:00
 postid: a
 tag:
   - dbt
+  - Rust
 category:
   - DataEngineering
 thumbnail: /images/2025/20250828a/thumbnail.png

--- a/source/_posts/2025/20251015a_「これ何のためにやってるんだっけ？」と言われないために。とりあえず手を動かす誘惑からの脱却.md
+++ b/source/_posts/2025/20251015a_「これ何のためにやってるんだっけ？」と言われないために。とりあえず手を動かす誘惑からの脱却.md
@@ -4,6 +4,7 @@ date: 2025/10/15 00:00:00
 postid: a
 tag:
   - コミュニケーション
+  - コンサルティング
 category:
   - Business
 thumbnail: /images/2025/20251015a/thumbnail.jpg

--- a/source/_posts/2025/20251022a_Vue.jsでモバイルアプリ開発をするフレームワークたち(2025秋).md
+++ b/source/_posts/2025/20251022a_Vue.jsでモバイルアプリ開発をするフレームワークたち(2025秋).md
@@ -4,6 +4,7 @@ date: 2025/10/22 00:00:00
 postid: a
 tag:
   - Vue.js
+  - クロスプラットフォーム
 category:
   - Mobile
 thumbnail: /images/2025/20251022a/thumbnail.png

--- a/source/_posts/2025/20251031a_秋のブログ週間2025_.md
+++ b/source/_posts/2025/20251031a_秋のブログ週間2025_.md
@@ -4,6 +4,7 @@ date: 2025/10/31 00:00:00
 postid: a
 tag:
   - インデックス
+  - 運営
 category:
   - Culture
 thumbnail: /images/2025/20251031a/thumbnail.jpg

--- a/source/_posts/2026/20260114a_EDIFACTメッセージ処理をJavaでスクラッチ実装した試行錯誤.md
+++ b/source/_posts/2026/20260114a_EDIFACTメッセージ処理をJavaでスクラッチ実装した試行錯誤.md
@@ -4,6 +4,7 @@ date: 2026/01/14 00:00:00
 postid: a
 tag:
   - Java
+  - 業界ドメイン
 category:
   - IoT
 thumbnail: /images/2026/20260114a/thumbnail.jpg

--- a/source/_posts/2026/20260612a_Mermaid_Live_Editor_のTips_9選.md
+++ b/source/_posts/2026/20260612a_Mermaid_Live_Editor_のTips_9選.md
@@ -4,6 +4,7 @@ date: 2026/06/12 00:00:00
 postid: a
 tag:
   - mermaid.js
+  - Tips
 category:
   - Programming
 thumbnail: /images/2026/20260612a/thumbnail.png

--- a/source/_posts/2026/20260616a_生成AIに任せたら何でテストを書く？AIに聞いてみた.md
+++ b/source/_posts/2026/20260616a_生成AIに任せたら何でテストを書く？AIに聞いてみた.md
@@ -4,6 +4,7 @@ date: 2026/06/16 00:00:00
 postid: a
 tag:
   - テスト
+  - 生成AI
 category:
   - AIDD
 thumbnail: /images/2026/20260616a/thumbnail.jpg


### PR DESCRIPTION
## 概要

案A（タグが1つ以下の記事への振り下ろし）です。孤立タグ整理の**逆方向**にあたる作業で、54件のうち42件にタグを追加しました。

タグが1つしかない記事は `related_posts.js` のスコアリング上ほぼ関連記事を導出できず、読者が辿り着く経路もありません。

## 方針

- 根拠は**タイトル・lede・カテゴリ**と、既存タグの共起関係
- **新しいタグは作らない**。既存の語彙から選び、孤立タグを増やさない
- 確信が持てないものは手を付けない

## 追加したタグ

まとまりのあるもの:

| 追加タグ | 件数 | 対象 |
| --- | --- | --- |
| `勉強会` | 8 | LT大会シリーズ（第二回〜#11、前編/後編、2020 Summer など） |
| `Linux` | 3 | Bashのシェル展開 / declareで配列と連想配列 / オリジナルコマンドの作成 |
| `Dart` | 3 | Flutterレイアウト入門 / Flutterで技術ブログRSSリーダー / 英単語学習アプリ |
| `IaC` | 2 | Terraformのベストなプラクティス / Terraform連載2024 変数の制御 |
| `データ分析` | 2 | イノベーションの捉え方 / 世論調査の内閣支持率を統計学的に解釈すると |
| `運営` | 2 | 秋のブログ週間2025 / ごあいさつ |
| `コミュニティ` | 2 | OSS推進タスクフォース / IoT関連の団体とOSSまとめ |
| `入門` | 2 | Systemdのservice unit起動フロー / Androidのビルドバリアント |

単発（22件）: `ゲーム`←Factorio、`参加レポート`←ぶらりシリコンバレー巡礼、`電子工作`←RISC-V PC開発、`エネルギー業界`←CHAdeMO vs コンボ、`暗号`←仮想通貨ウォレット、`Rust`←dbt fusion engine、`Tips`←Mermaid Live Editor、`Mac`←Go Apple Silicon、`テスト`←Playwright、`アルゴリズム`←LeetCode、`データ構造`←topKソート、`環境構築`←モニタ3台、`スキルアップ`←科目等履修生、`クロスプラットフォーム`←Vue.jsモバイル、`コンサルティング`←「これ何のためにやってるんだっけ？」、`業界ドメイン`←EDIFACT、`生成AI`←生成AIに任せたら何でテストを書く、`コンテナ`←Dokploy

## 効果

```
タグが1つ以下の記事   54 -> 12
平均タグ数         3.35 -> 3.38
タグ種類数          739（変化なし。既存語彙のみ使用）
孤立タグ            72（変化なし）
```

生成結果でも確認しました。

```
/tags/勉強会/  15 -> 23件
/tags/Dart/    9 -> 12件
/tags/ゲーム/   2 ->  3件
```

