### PR TITLE
2記事しかないタグを点検し、表記ゆれ3組の統合と5件の展開を行う

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -146,6 +146,9 @@ alias:
   tags/SQLLite/: tags/SQLite/ # 誤記の修正
 
   # 表記ゆれの統合（公式表記、なければ多数派に寄せる）
+  tags/mermaid.js/: tags/Mermaid.js/
+  tags/kubernetes/: tags/Kubernetes/
+  tags/Pandas/: tags/pandas/
   tags/Bigquery/: tags/BigQuery/
   tags/DaisyUI/: tags/daisyUI/
   tags/daisyui/: tags/daisyUI/

--- a/source/_posts/2021/20210107_Electronの使い方_Web開発の技術でデスクトップアプリを作ろう.md
+++ b/source/_posts/2021/20210107_Electronの使い方_Web開発の技術でデスクトップアプリを作ろう.md
@@ -5,6 +5,7 @@ postid: ""
 tag:
   - Vue.js
   - Electron
+  - デスクトップアプリ
 category:
   - Frontend
 thumbnail: /images/2021/20210107/thumbnail.png

--- a/source/_posts/2022/20220204a_Step_Functionsの動的並列処理をローカルで実行する.md
+++ b/source/_posts/2022/20220204a_Step_Functionsの動的並列処理をローカルで実行する.md
@@ -8,6 +8,7 @@ tag:
   - Lambda
   - Python
   - Pipenv
+  - 並列処理
 category:
   - Infrastructure
 thumbnail: /images/2022/20220204a/thumbnail.png

--- a/source/_posts/2022/20220406a_プロトタイピングの勧め.md
+++ b/source/_posts/2022/20220406a_プロトタイピングの勧め.md
@@ -7,6 +7,7 @@ tag:
   - 電子工作
   - シリアル通信
   - MicroPython
+  - マイコン
 category:
   - IoT
 thumbnail: /images/2022/20220406a/thumbnail.png

--- a/source/_posts/2023/20230623a_TetragonでeBPFとセキュリティオブサーバビリティ入門.md
+++ b/source/_posts/2023/20230623a_TetragonでeBPFとセキュリティオブサーバビリティ入門.md
@@ -3,7 +3,7 @@ title: "TetragonでeBPFとセキュリティオブサーバビリティ入門"
 date: 2023/06/23 00:00:00
 postid: a
 tag:
-  - kubernetes
+  - Kubernetes
   - CNCF
   - オブサーバビリティ
   - Linux

--- a/source/_posts/2023/20230914a_【LLMOps】LLMの実験管理にTruLens-Evalを使ってみた.md
+++ b/source/_posts/2023/20230914a_【LLMOps】LLMの実験管理にTruLens-Evalを使ってみた.md
@@ -6,6 +6,7 @@ tag:
   - LLM
   - MLOps
   - LLMOps
+  - 実験管理
 category:
   - DataScience
 thumbnail: /images/2023/20230914a/thumbnail.png

--- a/source/_posts/2023/20231107a_エッセイ：_小学2X年生、計算ドリルをしている.md
+++ b/source/_posts/2023/20231107a_エッセイ：_小学2X年生、計算ドリルをしている.md
@@ -5,7 +5,7 @@ postid: a
 tag:
   - 書評
   - テスト
-  - Pandas
+  - pandas
 category:
   - Culture
 thumbnail: /images/2023/20231107a/thumbnail.png

--- a/source/_posts/2023/20231115a_アプリエンジニアがコンテナ開発の基本を読んで学ぶ.md
+++ b/source/_posts/2023/20231115a_アプリエンジニアがコンテナ開発の基本を読んで学ぶ.md
@@ -4,7 +4,7 @@ date: 2023/11/15 00:00:00
 postid: a
 tag:
   - Docker
-  - kubernetes
+  - Kubernetes
   - 書評
   - コンテナ
 category:

--- a/source/_posts/2025/20251105a_AI-ReadyのためのAI駆動のデータモデリング.md
+++ b/source/_posts/2025/20251105a_AI-ReadyのためのAI駆動のデータモデリング.md
@@ -5,7 +5,7 @@ postid: a
 tag:
   - Gemini
   - GoogleCloud
-  - Pandas
+  - pandas
   - dbt
   - データモデル
 category:

--- a/source/_posts/2026/20260323a_【内定者インタビュー】最先端AI技術の社会実装に挑む！フューチャー「Engineer_Camp」のリアル.md
+++ b/source/_posts/2026/20260323a_【内定者インタビュー】最先端AI技術の社会実装に挑む！フューチャー「Engineer_Camp」のリアル.md
@@ -5,6 +5,7 @@ postid: a
 tag:
   - インターン
   - インターン2026
+  - インタビュー
 category:
   - Culture
 thumbnail: /images/2026/20260323a/thumbnail.jpg

--- a/source/_posts/2026/20260417a_Mermaid.jsで簡易的な数値報告のためのグラフを作るTips.md
+++ b/source/_posts/2026/20260417a_Mermaid.jsで簡易的な数値報告のためのグラフを作るTips.md
@@ -3,7 +3,7 @@ title: "Mermaid.jsで数値報告のための簡易的なグラフを作るTips"
 date: 2026/04/17 00:00:00
 postid: a
 tag:
-  - mermaid.js
+  - Mermaid.js
   - Markdown
 category:
   - Management

--- a/source/_posts/2026/20260612a_Mermaid_Live_Editor_のTips_9選.md
+++ b/source/_posts/2026/20260612a_Mermaid_Live_Editor_のTips_9選.md
@@ -3,7 +3,7 @@ title: "Mermaid Live Editor のTips 9選"
 date: 2026/06/12 00:00:00
 postid: a
 tag:
-  - mermaid.js
+  - Mermaid.js
   - Tips
 category:
   - Programming


### PR DESCRIPTION
## 概要

案D（2記事しかないタグの点検）です。孤立タグ（1記事）と同じ手法を、次の階層である2記事タグ212件に適用しました。

## 1. 表記ゆれの統合（3組）

#1900 で18組を統合しましたが、2記事タグの層にまだ残っていました。

| 統合前 | 統合後 | 件数 |
| --- | --- | --- |
| `mermaid.js` (2) | `Mermaid.js` | 2+2 → **4** |
| `kubernetes` (2) | `Kubernetes` | 2+23 → **25** |
| `Pandas` (2) | `pandas` | 2+3 → **5** |

`Mermaid.js` は2記事ずつに割れていたので、統合で倍になりました。Mermaid関連の4記事（React上でのレンダリング / 調整ツール / 数値報告グラフ / Live Editor Tips）が、これでひとつのタグに揃います。

`pandas` は公式表記が小文字のため小文字に、`Kubernetes` は多数派かつ公式表記に寄せています。

## 2. タグの展開（5件）

タイトル一致を根拠にしたものだけ採用しました。

| タグ | 展開先 |
| --- | --- |
| `インタビュー` | 【内定者インタビュー】最先端AI技術の社会実装に挑む！フューチャー「Engineer Camp」のリアル |
| `実験管理` | 【LLMOps】LLMの実験管理にTruLens-Evalを使ってみた |
| `デスクトップアプリ` | Electronの使い方 Web開発の技術でデスクトップアプリを作ろう |
| `並列処理` | Step Functionsの動的並列処理をローカルで実行する |
| `マイコン` | プロトタイピングの勧め（M5Stack はマイコンボード） |

## 見送ったもの

展開候補は52タグ・124件ありましたが、大半は本文・lede中の偶発的な一致でした。

- **`WAF`** … 既存2記事は Web Application **Firewall**（CORS/API Key、Cloudflare/CDN）。候補の `WAFとして go-swagger を選択してみた` は Web Application **Framework** で、同じ綴りの別物でした
- **`HTTPS`（候補16件）** … 本文中のURLに当たるだけ
- **`ブラウザ`（13件）/ `Microsoft`（5件）/ `メモリ` / `言語化` / `生産性`** … 言及はあるが主題ではない
- **`kubernetes`（候補16件）** … 統合先の `Kubernetes` タグ側の話であり、展開ではなく統合で解決

## 近い綴りのタグは、いずれも別物でした

編集距離で洗い出した13組を確認しましたが、統合すべきものはありませんでした。

`Auth0` / `AuthN` / `AuthZ`、`OpenAI` / `OpenAPI`、`HTTP` / `HTTPS`、`ローコード` / `ノーコード`、`GitLab` / `GitLab CI`、`GoogleCloudNext2019` / `2024` / `2025`（年次シリーズ）、`NLP2024` / `NLP2025`（同）。

## 効果

```
2記事タグ    212 -> 203
タグ種類数    739 -> 736
```

統合した3タグは `_config.yml` にエイリアスを追加し、リダイレクトを確認しました。

```
/tags/mermaid.js/ -> /tags/Mermaid.js/  OK
/tags/kubernetes/ -> /tags/Kubernetes/  OK
/tags/Pandas/     -> /tags/pandas/      OK
```

## タグ整理シリーズの通算

| | 開始 | 現在 |
| --- | --- | --- |
| タグ種類数 | 761 | 736 |
| 孤立タグ（1記事） | 112 | 72 |
| 2記事タグ | 213 | 203 |
| タグ1つ以下の記事 | 54 | 12 |

#1900 #1901 #1902 #1903 と本PRで、統合25件・展開18件・振り下ろし42記事を行いました。**記事のタグを削除したのは1件もありません。**
