### PR TITLE
タグの意味の重なりを解消し、GC・技術選定を展開する

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -145,6 +145,13 @@ alias:
   tags/論文解説/: tags/論文紹介/
   tags/SQLLite/: tags/SQLite/ # 誤記の修正
 
+  tags/Pマーク/: tags/ISMS/            # 同一記事に重複していたためISMSに寄せる
+  tags/Foundationmodel/: articles/20260624a/ # 記事固有のためタグを廃し、記事へ転送
+  tags/OJT/: tags/コーチング/          # 社内育成の意味に寄せる
+  tags/教育/: tags/コーチング/          # プログラミング教育（産業）と区別する
+  tags/Bob/: tags/ORM/
+  tags/SeaORM/: tags/ORM/
+
   # 表記ゆれの統合（公式表記、なければ多数派に寄せる）
   tags/mermaid.js/: tags/Mermaid.js/
   tags/kubernetes/: tags/Kubernetes/

--- a/source/_posts/2022/20220808a_Go_1.19のメモリ周りの更新.md
+++ b/source/_posts/2022/20220808a_Go_1.19のメモリ周りの更新.md
@@ -6,6 +6,7 @@ tag:
   - Go
   - Go1.19
   - メモリ
+  - GC
 category:
   - Programming
 thumbnail: /images/2022/20220808a/thumbnail.png

--- a/source/_posts/2024/20241002a_JDK_23_リリース記念連載_|_第3回_JDK_23_新機能紹介.md
+++ b/source/_posts/2024/20241002a_JDK_23_リリース記念連載_|_第3回_JDK_23_新機能紹介.md
@@ -5,6 +5,7 @@ postid: a
 tag:
   - Java
   - JDK23
+  - GC
 category:
   - Programming
 thumbnail: /images/2024/20241002a/thumbnail.png

--- a/source/_posts/2025/20251107a_なぜアーキチームは設計や実装のパターンを絞りたいか？_背景にある思考と技術選定のジレンマ.md
+++ b/source/_posts/2025/20251107a_なぜアーキチームは設計や実装のパターンを絞りたいか？_背景にある思考と技術選定のジレンマ.md
@@ -5,6 +5,7 @@ postid: a
 tag:
   - アーキテクチャ
   - 設計
+  - 技術選定
 category:
   - Programming
 thumbnail: /images/2025/20251107a/thumbnail.jpg

--- a/source/_posts/2026/20260423a_これだけやろうOJT.md
+++ b/source/_posts/2026/20260423a_これだけやろうOJT.md
@@ -3,8 +3,7 @@ title: "これだけやろうOJT"
 date: 2026/04/23 00:00:00
 postid: a
 tag:
-  - OJT
-  - 教育
+  - コーチング
   - リーダーシップ
 category:
   - Management

--- a/source/_posts/2026/20260511a_Gopher_が_Rust_に入門して感じた_Go_との違いについて.md
+++ b/source/_posts/2026/20260511a_Gopher_が_Rust_に入門して感じた_Go_との違いについて.md
@@ -4,8 +4,7 @@ date: 2026/05/11 00:00:00
 postid: a
 tag:
   - Rust
-  - Bob
-  - SeaORM
+  - ORM
   - 入門
   - Go
 category:

--- a/source/_posts/2026/20260608a_OJTをいつ終えるか.md
+++ b/source/_posts/2026/20260608a_OJTをいつ終えるか.md
@@ -3,8 +3,7 @@ title: "OJTをいつ終えるか"
 date: 2026/06/08 00:00:00
 postid: a
 tag:
-  - OJT
-  - 教育
+  - コーチング
 category:
   - Management
 thumbnail: /images/2026/20260608a/thumbnail.png

--- a/source/_posts/2026/20260624a_macOSでプリインストールされるLLMサービスをコーディングエージェントから使う実験.md
+++ b/source/_posts/2026/20260624a_macOSでプリインストールされるLLMサービスをコーディングエージェントから使う実験.md
@@ -5,7 +5,6 @@ postid: a
 tag:
   - Mac
   - LLM
-  - Foundationmodel
 category:
   - AIDD
 thumbnail: /images/2026/20260624a/thumbnail.png

--- a/source/_posts/2026/20260715a_個人情報保護士認定試験_合格体験記_-_法改正が続く個人情報保護を、ISMSとPマークから学び直す.md
+++ b/source/_posts/2026/20260715a_個人情報保護士認定試験_合格体験記_-_法改正が続く個人情報保護を、ISMSとPマークから学び直す.md
@@ -5,7 +5,6 @@ postid: a
 tag:
   - 合格記
   - ISMS
-  - Pマーク
 category:
   - Security
 thumbnail: /images/2026/20260715a/thumbnail.png


### PR DESCRIPTION
## 概要

#1904 のレビューでいただいた指摘の反映です。

## 統合

| 統合前 | 統合後 | 理由 |
| --- | --- | --- |
| `OJT` (2) / `教育` (2) | `コーチング` (2) | 「教育」は `プログラミング教育`（産業寄りの話題、4記事）と紛らわしい。社内育成・コーチングの意味に寄せる |
| `Bob` (1) / `SeaORM` (1) | `ORM` (16→17) | どちらもORMライブラリの固有名。同一記事（Gopher が Rust に入門して〜）に付いていた |

`OJT` と `教育` は #1903 で「粒度の違う2軸だから統合すべきでない」と申し上げましたが、`プログラミング教育` との対比という観点が抜けていました。ご指摘のとおりです。

## 削除

| タグ | 対応 |
| --- | --- |
| `Pマーク` | 同一記事の `ISMS` と重複していたため `ISMS` に寄せる |
| `Foundationmodel` | 記事固有のため廃止。タグURLは記事本体へ転送する |

`Foundationmodel` は転送先となる同義タグがないので、`_config.yml` で**記事URLへ直接転送**しています。タグを消しても `/tags/Foundationmodel/` を直接叩いた人は記事に辿り着けます。

```yaml
tags/Foundationmodel/: articles/20260624a/ # 記事固有のためタグを廃し、記事へ転送
```

## 展開

| タグ | 展開先 |
| --- | --- |
| `GC` (1→3) | Go 1.19のメモリ周りの更新 / Java 23 リリース記念連載 第3回 JDK 23 新機能紹介 |
| `技術選定` (18→19) | なぜアーキチームは設計や実装のパターンを絞りたいか？ 背景にある思考と技術選定のジレンマ |

## `アンチパターン` の展開は見送りを提案します

「なぜアーキチームは設計や実装のパターンを絞りたいか？」への `アンチパターン` 付与を検討しましたが、**見送りを提案**します。

本文を確認したところ、`アンチパターン` の登場は1回だけで、しかも「統制が常に正解と思い込み〜といった『象牙の塔』的なアンチパターンも世の中にはある」という**留保としての言及**でした。記事の主題は統制と技術選定のトレードオフで、アンチパターン集ではありません。`/tags/アンチパターン/` を見た読者の期待（SQLアンチパターン書評のような内容）とずれます。

代わりに、この記事には**タイトルに「技術選定のジレンマ」とあるのに `技術選定` タグが付いていませんでした**。そちらを追加しています。

## 効果

```
タグ種類数   736 -> 731
孤立タグ      72 ->  67
```

リダイレクトは6件すべて確認済みです。

```
/tags/OJT/            -> /tags/コーチング/     OK
/tags/教育/            -> /tags/コーチング/     OK
/tags/Bob/            -> /tags/ORM/          OK
/tags/SeaORM/         -> /tags/ORM/          OK
/tags/Pマーク/          -> /tags/ISMS/         OK
/tags/Foundationmodel/ -> /articles/20260624a/ OK
/tags/GC/             -> 3件                  OK
```
