### PR TITLE
復元が容易な孤立タグ20件を廃止し、タグURLを記事へ転送する

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -145,6 +145,30 @@ alias:
   tags/論文解説/: tags/論文紹介/
   tags/SQLLite/: tags/SQLite/ # 誤記の修正
 
+  # 1記事しかなく、タグ名がタイトルに含まれるため復元が容易なタグ。
+  # 一覧のノイズを減らすため廃止し、タグURLは元記事へ転送する。
+  # 将来そのタグを復活させる場合は、この行を必ず削除すること（タグページと衝突する）
+  tags/Elixir/: articles/20170414/
+  tags/TFLint/: articles/20211223a/
+  tags/wasmCloud/: articles/20230619b/
+  tags/Tinkerbell/: articles/20230622a/
+  tags/Testcontainers/: articles/20240409a/
+  tags/Prometheus/: articles/20240417b/
+  tags/Okta/: articles/20241106b/
+  tags/Obsidian/: articles/20260317a/
+  tags/rustfs/: articles/20260403a/
+  tags/Flyway/: articles/20260410a/
+  tags/moto/: articles/20260528a/
+  tags/ArtifactRegistry/: articles/20260519a/
+  tags/S3Tables/: articles/20260702a/
+  tags/Iceberg/: articles/20260702a/
+  tags/ZDR/: articles/20260703a/
+  tags/TechnologyRadar/: articles/20230523a/
+  tags/DeployGate/: articles/20210720b/
+  tags/Groovy/: articles/20220221a/
+  tags/ClaudeDesign/: articles/20260501a/
+  tags/SQLServer/: articles/20260512a/
+
   tags/Pマーク/: tags/ISMS/            # 同一記事に重複していたためISMSに寄せる
   tags/Foundationmodel/: articles/20260624a/ # 記事固有のためタグを廃し、記事へ転送
   tags/OJT/: tags/コーチング/          # 社内育成の意味に寄せる

--- a/source/_posts/2017/20170414-elixir-conf-jp.md
+++ b/source/_posts/2017/20170414-elixir-conf-jp.md
@@ -3,7 +3,6 @@ title: "Elixir Conf Japan 2017 参加レポート"
 date: 2017/04/14 12:00:00
 postid: ""
 tag:
-  - Elixir
   - 参加レポート
 category:
   - Programming

--- a/source/_posts/2021/20210720b_FlutterアプリをDeployGateで公開するためのいろいろ.md
+++ b/source/_posts/2021/20210720b_FlutterアプリをDeployGateで公開するためのいろいろ.md
@@ -4,7 +4,6 @@ date: 2021/07/20 00:00:02
 postid: b
 tag:
   - Flutter
-  - DeployGate
 category:
   - Mobile
 thumbnail: /images/2021/20210721b/thumbnail.png

--- a/source/_posts/2021/20211223a_TFLintを使ってみる（GCP×Terraform）.md
+++ b/source/_posts/2021/20211223a_TFLintを使ってみる（GCP×Terraform）.md
@@ -5,7 +5,6 @@ postid: a
 tag:
   - Terraform
   - GoogleCloud
-  - TFLint
 category:
   - DevOps
 thumbnail: /images/2021/20211223a/thumbnail.png

--- a/source/_posts/2022/20220221a_Groovyスクリプトで、ファイルの最終更新日時をgit_clone／pullの日時ではなく、commit日時にしてみた.md
+++ b/source/_posts/2022/20220221a_Groovyスクリプトで、ファイルの最終更新日時をgit_clone／pullの日時ではなく、commit日時にしてみた.md
@@ -3,7 +3,6 @@ title: "Groovyスクリプトで、ファイルの最終更新日時を`git clon
 date: 2022/02/21 00:00:00
 postid: a
 tag:
-  - Groovy
   - Perl
   - Git
 category:

--- a/source/_posts/2023/20230523a_Technology_Radar_の機械学習関連技術を見てみる.md
+++ b/source/_posts/2023/20230523a_Technology_Radar_の機械学習関連技術を見てみる.md
@@ -6,7 +6,6 @@ tag:
   - 機械学習
   - AI
   - MLOps
-  - TechnologyRadar
 category:
   - DataScience
 thumbnail: /images/2023/20230523a/thumbnail.png

--- a/source/_posts/2023/20230619b_wasmCloudが夢見る世界.md
+++ b/source/_posts/2023/20230619b_wasmCloudが夢見る世界.md
@@ -3,7 +3,6 @@ title: "wasmCloudが夢見る世界"
 date: 2023/06/19 00:00:01
 postid: b
 tag:
-  - wasmCloud
   - WebAssembly
   - CNCF
 category:

--- a/source/_posts/2023/20230622a_Tinkerbellについて.md
+++ b/source/_posts/2023/20230622a_Tinkerbellについて.md
@@ -4,7 +4,6 @@ date: 2023/06/22 00:00:00
 postid: a
 tag:
   - CNCF
-  - Tinkerbell
   - オンプレミス
   - Linux
 category:

--- a/source/_posts/2024/20240409a_Testcontainersを用いてテスト実行前の_docker_compose_up_を無くし、Goで並列テストする.md
+++ b/source/_posts/2024/20240409a_Testcontainersを用いてテスト実行前の_docker_compose_up_を無くし、Goで並列テストする.md
@@ -3,7 +3,6 @@ title: "Testcontainersを用いてテスト実行前の docker compose up を無
 date: 2024/04/09 00:00:00
 postid: a
 tag:
-  - Testcontainers
   - テスト
   - Go
 category:

--- a/source/_posts/2024/20240417b_Prometheus／Grafanaを使ってみる.md
+++ b/source/_posts/2024/20240417b_Prometheus／Grafanaを使ってみる.md
@@ -3,7 +3,6 @@ title: "Prometheus/Grafanaを使ってみる"
 date: 2024/04/17 00:00:01
 postid: b
 tag:
-  - Prometheus
   - Grafana
 category:
   - DevOps

--- a/source/_posts/2024/20241106b_Oktaのセキュリティの問題をGoで再現する.md
+++ b/source/_posts/2024/20241106b_Oktaのセキュリティの問題をGoで再現する.md
@@ -4,7 +4,6 @@ date: 2024/11/06 00:00:01
 postid: b
 tag:
   - Go
-  - Okta
   - ハッシュ関数
 category:
   - Security

--- a/source/_posts/2026/20260317a_記録のための日記から、対話で育てる日記へ_ーClaude_×_Obsidian_×_MCPで作る思考のジャーナリングー.md
+++ b/source/_posts/2026/20260317a_記録のための日記から、対話で育てる日記へ_ーClaude_×_Obsidian_×_MCPで作る思考のジャーナリングー.md
@@ -3,7 +3,6 @@ title: "記録のための日記から、対話で育てる日記へ ーClaude �
 date: 2026/03/17 00:00:00
 postid: a
 tag:
-  - Obsidian
   - Claude
   - MCP
 category:

--- a/source/_posts/2026/20260403a_S3エミュレーションでrustfsを使ってみたメモとPresigned_URLの仕組み.md
+++ b/source/_posts/2026/20260403a_S3エミュレーションでrustfsを使ってみたメモとPresigned_URLの仕組み.md
@@ -4,7 +4,6 @@ date: 2026/04/03 00:00:00
 postid: a
 tag:
   - S3
-  - rustfs
   - Docker
   - Go
 category:

--- a/source/_posts/2026/20260410a_Spring_Boot_マルチDataSource構成で_secondary_DB_だけに_Flyway_を適用する.md
+++ b/source/_posts/2026/20260410a_Spring_Boot_マルチDataSource構成で_secondary_DB_だけに_Flyway_を適用する.md
@@ -4,7 +4,6 @@ date: 2026/04/10 00:00:00
 postid: a
 tag:
   - SpringBoot
-  - Flyway
 category:
   - DB
 thumbnail: /images/2026/20260410a/thumbnail.png

--- a/source/_posts/2026/20260501a_【Claude_Design】インフラ構成のお絵描きからリソース実装までをClaudeで一本化してみた.md
+++ b/source/_posts/2026/20260501a_【Claude_Design】インフラ構成のお絵描きからリソース実装までをClaudeで一本化してみた.md
@@ -3,7 +3,6 @@ title: "【Claude Design】インフラ構成のお絵描きからリソース�
 date: 2026/05/01 00:00:00
 postid: a
 tag:
-  - ClaudeDesign
   - ClaudeCode
   - Terraform
   - AWS

--- a/source/_posts/2026/20260512a_PostgreSQLユーザーがSQL_Server開発で知っておきたかった実践Tips10選.md
+++ b/source/_posts/2026/20260512a_PostgreSQLユーザーがSQL_Server開発で知っておきたかった実践Tips10選.md
@@ -4,7 +4,6 @@ date: 2026/05/12 00:00:00
 postid: a
 tag:
   - PostgreSQL
-  - SQLServer
 category:
   - DB
 thumbnail: /images/2026/20260512a/thumbnail.jpg

--- a/source/_posts/2026/20260519a_Artifact_Registry利用料金の最適化方針と対応手順.md
+++ b/source/_posts/2026/20260519a_Artifact_Registry利用料金の最適化方針と対応手順.md
@@ -5,7 +5,6 @@ postid: a
 tag:
   - Terraform
   - GoogleCloud
-  - ArtifactRegistry
 category:
   - Infrastructure
 thumbnail: /images/2026/20260519a/thumbnail.png

--- a/source/_posts/2026/20260528a_moto_に_Terraform_を打ち込み、基本的なイベント駆動の構成を動かしてみた.md
+++ b/source/_posts/2026/20260528a_moto_に_Terraform_を打ち込み、基本的なイベント駆動の構成を動かしてみた.md
@@ -4,7 +4,6 @@ date: 2026/05/28 00:00:00
 postid: a
 tag:
   - Terraform
-  - moto
   - モック
 category:
   - Infrastructure

--- a/source/_posts/2026/20260702a_S3_TablesのIceberg形式で、timestamptz型の登録に苦戦した話.md
+++ b/source/_posts/2026/20260702a_S3_TablesのIceberg形式で、timestamptz型の登録に苦戦した話.md
@@ -4,8 +4,6 @@ date: 2026/07/02 00:00:00
 postid: a
 tag:
   - S3
-  - S3Tables
-  - Iceberg
 category:
   - Programming
 thumbnail: /images/2026/20260702a/thumbnail.png

--- a/source/_posts/2026/20260703a_主要AIモデルのデータ保持期間とZDRを、一次情報で確認する.md
+++ b/source/_posts/2026/20260703a_主要AIモデルのデータ保持期間とZDRを、一次情報で確認する.md
@@ -4,7 +4,6 @@ date: 2026/07/03 00:00:00
 postid: a
 tag:
   - LLM
-  - ZDR
 category:
   - DataScience
 thumbnail: /images/2026/20260703a/thumbnail.png


### PR DESCRIPTION
## 概要

いただいた「タイトルにキーワードが含まれる孤立タグは復元が容易なので削除できるのでは」という仮説の実装です。孤立タグ20件を廃止します。

## 仮説の検証

孤立タグ67件（#1905 時点）を、タグ名が元記事のどこに現れるかで分類しました。

| 分類 | 件数 | 意味 |
| --- | --- | --- |
| タイトルに含まれる | 35 | タグを消しても、後からタイトル検索で記事を拾える |
| lede のみ | 11 | |
| どちらにも無い | 26 | **タグが唯一の手がかり** |

「どちらにも無い」26件は、`RAG`（タイトルは「【MLOps】Azure Data Factory と Azure Purview を使って〜」）、`Vault`（「AWSアクセスキー管理について考えてみる」）、`Bedrock`、`NotebookLM`、`Gems`、`リバースプロキシ`、`テープ装置` などでした。これらは消すと二度と辿れません。**仮説の線引き（タイトル含有なら削除可）は妥当**です。

## 削除対象（20件）

タイトル含有35件から、次の15件をさらに除外しました。

- **系列・資格 8件** … `ACL` `デブサミ` `CCNA` `E資格` `NLP2025` `無人航空機操縦士` `ISMS` ほか。「動線確保のため残す」とご判断済みのもの
- **一般語 7件** … `銀行` `新規事業` `区分値` `CPU` `GC` `ジオメトリ` `アンチパターン`。タイトル検索したときに誤ヒットが多く、復元の確実性が落ちる

残った20件はすべて**固有名詞かつタイトル含有**で、復元が確実です。

```
Elixir  TFLint  wasmCloud  Tinkerbell  Testcontainers  Prometheus  Okta
Obsidian  rustfs  Flyway  moto  ArtifactRegistry  S3Tables  Iceberg  ZDR
TechnologyRadar  DeployGate  Groovy  ClaudeDesign  SQLServer
```

対象は19記事（`S3Tables` と `Iceberg` は同一記事）です。**無タグになる記事はありません。**

## 動線は維持しています

タグを消すと `/tags/Elixir/` などが404になりますが、#1905 の `Foundationmodel` と同じ方式で、**タグURLを元記事へ転送**しています。URLを直接書き換えて探す人も記事に着地します。

```yaml
  # 1記事しかなく、タグ名がタイトルに含まれるため復元が容易なタグ。
  # 一覧のノイズを減らすため廃止し、タグURLは元記事へ転送する。
  # 将来そのタグを復活させる場合は、この行を必ず削除すること（タグページと衝突する）
  tags/Elixir/: articles/20170414/
  tags/TFLint/: articles/20211223a/
  ...
```

`hexo generate` して、20件すべてが記事URLへ転送されることを確認しました。

```
記事への転送: 20/20 件OK
```

## 注意点

`_config.yml` のコメントにも書きましたが、**将来これらのタグを復活させる場合はエイリアス行を削除する必要があります**。alias が生成するリダイレクトページと、タグジェネレータが生成するタグページが同じパスを取り合うためです。

## 効果

```
タグ種類数   731 -> 711
孤立タグ      67 ->  47
無タグ記事      0 ->   0
```

## タグ整理シリーズ通算

| | 開始 | 現在 |
| --- | --- | --- |
| タグ種類数 | 761 | 711 |
| 孤立タグ（1記事） | 112 | 47 |
| 2記事タグ | 213 | 約200 |
| タグ1つ以下の記事 | 54 | 12 |
