### PR TITLE
関連記事のスコアを候補記事のタグ数で正規化する

### DIFF
--- a/scripts/related_posts.js
+++ b/scripts/related_posts.js
@@ -101,6 +101,13 @@ hexo.extend.helper.register('list_related_posts', function() {
   });
 
   const relatedPosts = tagRelatedPosts.reduce((acc, p) => {
+    // 既に評価済みの記事はスキップする。
+    // tagRelatedPosts には共有タグの数だけ同じ記事が並ぶため、
+    // ここで加算するとタグを多く共有する記事のスコアが二重三重に積み上がる
+    if (acc.some(item => item._id === p._id)) {
+      return acc;
+    }
+
     let score = 0;
 
     p.tags.data.forEach(tag => {
@@ -109,16 +116,15 @@ hexo.extend.helper.register('list_related_posts', function() {
       }
     });
 
+    // タグを多く持つ記事ほど1タグあたりの意味が薄いため、タグ数で正規化する。
+    // これがないと、大きなタグを複数持つ記事が全記事の関連記事を占めてしまう
+    score /= Math.sqrt(p.tags.length || 1);
+
     if (p.author === post.author) {
       score += authorIDF[p.author];
     }
 
-    const existingPostIndex = acc.findIndex(item => item._id === p._id);
-    if (existingPostIndex !== -1) {
-      acc[existingPostIndex].score += score;
-    } else {
-      acc.push({ ...p, score: score });
-    }
+    acc.push({ ...p, score: score });
     return acc;
   }, []);
 


### PR DESCRIPTION
## 概要

関連記事のスコアリングを、候補記事のタグ数で正規化します。特定の記事が関連記事として過剰に露出していた問題への対応です。

## 実測した問題

`public/articles/` 全1464ページの関連記事リンクを数えたところ、露出が大きく偏っていました。

```
最大露出   61回  JavaプログラマーのためのGo言語入門（平均の約13倍）
露出0     195記事（関連記事として一度も出てこない）

タグ数ごとの平均露出回数
  2個: 2.4回   4個: 3.6回   6個: 6.5回   9個: 13.0回
  3個: 2.9回   5個: 4.7回   7個: 7.1回
```

## 原因は2つ

**1. スコアの二重加算**

`tagRelatedPosts` は `post.tags.data.flatMap(tag => tag.posts.data)` で作られるため、**共有タグの数だけ同じ記事が並びます**。それを `reduce` の中で `acc[i].score += score` としていたので、タグを多く共有する記事ほどスコアが積み上がっていました。実質 `共有タグ数 × Σ IDF` になっていました。

**2. タグ数による正規化がない**

大きなタグを複数持つ記事が有利でした。露出61回の記事のタグは `Go(259), Java(40), 翻訳(5), 入門(62), 他言語からGoへ(3)` で、`Go` と `入門` という巨大タグを併せ持っています。タグ数自体は5個と多くありません。

## 修正

```js
// 既に評価済みの記事はスキップする（二重加算の防止）
if (acc.some(item => item._id === p._id)) {
  return acc;
}
...
// タグを多く持つ記事ほど1タグあたりの意味が薄いため、タグ数で正規化する
score /= Math.sqrt(p.tags.length || 1);
```

平方根で割るのはコサイン類似度に準じた正規化です。タグ数で単純に割ると多タグ記事を過剰に不利にするため、緩やかな形にしています。

## 効果

`hexo clean` してフルビルドし、同じ方法で再測定しました。

| | 変更前 | 変更後 |
| --- | --- | --- |
| 最大露出 | 61回 | **21回** |
| 露出0の記事 | 195記事 | **112記事** |
| 露出総数 | 4392回 | 4392回（1464記事 × 3枠） |

```
タグ数ごとの平均露出回数
            変更前          変更後
  1個        1.5回          5.9回
  2個        2.4回          4.2回
  3個        2.9回          3.1回
  4個        3.6回          2.8回
  5個        4.7回          2.7回
  6個        6.5回          2.9回
  7個        7.1回          2.7回
  9個       13.0回          2.0回
```

**タグ数と露出の単調増加が解消し、ほぼ横ばいになりました。**

## 補足

正規化の結果、今度は少タグの記事がやや有利になっています（1個: 5.9回、2個: 4.2回）。これはコサイン正規化の性質どおりで、「タグが1つしかない＝その話題に集中した記事」が、そのタグを共有する記事に対して強く出るためです。過剰な偏りではないと判断しましたが、もう少し平坦にしたい場合は `Math.sqrt` を `Math.log(1 + n)` などに変えれば調整できます。1箇所の変更で済みます。

なお、この変更は関連記事の並びを全記事で入れ替えます。露出0の112記事の調査は、この変更後の状態を前提に別途行う想定です。
