### PR TITLE
関連記事の同点時に、公開日が近い記事を優先する

### DIFF
--- a/scripts/related_posts.js
+++ b/scripts/related_posts.js
@@ -128,13 +128,21 @@ hexo.extend.helper.register('list_related_posts', function() {
     return acc;
   }, []);
 
-  // 3. 関連度スコアでソートし、同スコアの場合は日付でソート
+  // 3. 関連度スコアでソートし、同スコアの場合は公開日が近い記事を優先する。
+  //    技術記事は前提バージョンなど時代の文脈に依存するため、同じ関連度なら
+  //    同時期の記事の方が読み継ぎやすい。連載の古い回が埋もれる問題も解消する。
+  //    ただし過去方向は未来方向より重く扱い、わずかに新しい記事へ流れるようにする
+  const PAST_PENALTY = 2;
+  const dateDistance = p => {
+    const diff = p.date.valueOf() - post.date.valueOf();
+    return diff >= 0 ? diff : -diff * PAST_PENALTY;
+  };
+
   relatedPosts.sort((a, b) => {
     if (b.score !== a.score) {
       return b.score - a.score;
-    } else {
-      return b.date.valueOf() - a.date.valueOf();
     }
+    return dateDistance(a) - dateDistance(b);
   });
 
   // 4. 記事数がmaxCountに満たない場合はカテゴリから補填


### PR DESCRIPTION
## 概要

関連記事の同点時のタイブレークを、日付降順から**公開日の近さ**に変えます。

## 理由

技術記事の関連性は時代の文脈に依存します。2019年のTerraform記事と2026年のTerraform記事は、同じタグでも前提バージョンも周辺エコシステムも違います。同じ関連度なら同時期の記事の方が読み継ぎやすい、という判断です。

**新着記事の読者体験は変わりません。** 新しい記事にとって「近い」のは新しい記事なので、従来と同じ挙動になります。変わるのは古い記事を読んでいる読者で、文脈の合わない現代の記事ではなく同時期の記事が出るようになります。

## 実装

```js
// 過去方向は未来方向より重く扱い、わずかに新しい記事へ流れるようにする
const PAST_PENALTY = 2;
const dateDistance = p => {
  const diff = p.date.valueOf() - post.date.valueOf();
  return diff >= 0 ? diff : -diff * PAST_PENALTY;
};
```

同じ1年差でも、過去方向は2年分の距離として評価します。

## 効果（`hexo clean` からフルビルドして実測）

| | #1907 時点 | 本PR |
| --- | --- | --- |
| 露出0の記事 | 115記事 | **106記事** |
| 最大露出 | 21回 | **15回** |

関連記事4377件の年差を測ると、**中央値0年、62%（2733件）が1年以内**に収まりました。未来方向1481件・過去方向1509件で、非対称ペナルティを入れてもほぼ均衡しています。

## 効果が及ばなかったケース

`LT大会（前編）`（2016年）の関連記事は2020〜2021年のLT大会のままでした。原因は**著者ボーナス**です。

```js
if (p.author === post.author) score += authorIDF[p.author];
```

同じタグ構成でも著者が違うとスコアに差が出るため、そもそも同点になっていませんでした。著者一致は妥当な関連シグナルなので、今回は手を入れていません。タイブレークが効くのは「タグ構成も著者も同じ」ケースに限られます。

## 通算

| | 修正前 | #1907 | 本PR |
| --- | --- | --- | --- |
| 最大露出 | 61回 | 21回 | **15回** |
| 露出0の記事 | 195記事 | 115記事 | **106記事** |
