### PR TITLE
AI-DLC/SDDの記事に AI駆動開発 タグを追加する

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -128,6 +128,7 @@ alias:
   tags/VR: categories/VR/ # VRカテゴリと重複排除
   tags/データエンジニアリング: categories/DataEngineering/ # DataEngineeringカテゴリの新設対応
   tags/マネジメント: categories/Management/
+  tags/AI駆動開発/: categories/AIDD/ # AIDDカテゴリと同義
 
     # カテゴリの変更
   categories/Design: tags/UI-UX/

--- a/source/_posts/2025/20250428a_CursorによるAI駆動開発入門.md
+++ b/source/_posts/2025/20250428a_CursorによるAI駆動開発入門.md
@@ -7,7 +7,6 @@ tag:
   - 生成AI
   - LLM
   - cursor
-  - AI駆動開発
 category:
   - AIDD
 thumbnail: /images/2025/20250428a/thumbnail.gif

--- a/source/_posts/2025/20251203a_AWSのKiroを使うハッカソン「Kiroween」に参加してみた.md
+++ b/source/_posts/2025/20251203a_AWSのKiroを使うハッカソン「Kiroween」に参加してみた.md
@@ -3,6 +3,7 @@ title: "AWSのKiroを使うハッカソン「Kiroween」に参加してみた"
 date: 2025/12/03 00:00:00
 postid: a
 tag:
+  - スペック駆動開発
   - Kiro
   - ハッカソン
 category:

--- a/source/_posts/2026/20260428a_AI-DLC,_SDD、2026年4月時点のAI駆動の開発スタイルの考察.md
+++ b/source/_posts/2026/20260428a_AI-DLC,_SDD、2026年4月時点のAI駆動の開発スタイルの考察.md
@@ -3,7 +3,6 @@ title: "AI-DLC, SDD、2026年4月時点のAI駆動の開発スタイルの考察
 date: 2026/04/28 00:00:00
 postid: a
 tag:
-  - AI駆動開発
   - スペック駆動開発
 category:
   - AIDD

--- a/source/_posts/2026/20260428a_AI-DLC,_SDD、2026年4月時点のAI駆動の開発スタイルの考察.md
+++ b/source/_posts/2026/20260428a_AI-DLC,_SDD、2026年4月時点のAI駆動の開発スタイルの考察.md
@@ -3,6 +3,7 @@ title: "AI-DLC, SDD、2026年4月時点のAI駆動の開発スタイルの考察
 date: 2026/04/28 00:00:00
 postid: a
 tag:
+  - AI駆動開発
   - スペック駆動開発
 category:
   - AIDD

--- a/source/_posts/2026/20260602a_AI駆動開発は「ツール導入」ではなく「協働チーム設計」である_——_現場で運用して見えてきたこと.md
+++ b/source/_posts/2026/20260602a_AI駆動開発は「ツール導入」ではなく「協働チーム設計」である_——_現場で運用して見えてきたこと.md
@@ -3,7 +3,6 @@ title: "AI駆動開発は「ツール導入」ではなく「協働チーム設�
 date: 2026/06/02 00:00:00
 postid: a
 tag:
-  - AI駆動開発
   - ソフトウェア
   - ClaudeCode
 category:


### PR DESCRIPTION
## 概要

ビルド時に1件だけ出ていた INFO ログを解消します。

```
[INFO] Related Posts: No tag-related posts found for
"AI-DLC, SDD、2026年4月時点のAI駆動の開発スタイルの考察". Falling back to category.
```

## 原因

この記事のタグは `スペック駆動開発` の1つだけで、そのタグを持つ記事が他にありませんでした。#1898 で AIDD カテゴリへ移した際に、カテゴリと重複する `AI` タグを外した結果です。タグ由来の関連記事が0件になり、カテゴリ経路にフォールバックしていました。

## 対応

タイトルに「AI駆動の開発スタイル」とあり、既存の `AI駆動開発` タグがそのまま当てはまるため追加しました。新規タグは作っていません。

## 確認

`hexo clean` してフルビルドし、INFO ログが **0件** になることを確認しました。関連記事もタグ由来で導出されています。

```
関連記事:
  AI駆動開発は「ツール導入」ではなく「協働チーム設計」である
  CursorによるAI駆動開発入門
  AIネイティブ時代の設計書を考える

/tags/AI駆動開発/  2件 -> 3件
```