### PR TITLE
Revert "fix: upgrade ejs to 3.1.7 (CVE-2022-29078)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2406,16 +2406,10 @@
       "license": "MIT"
     },
     "node_modules/ejs": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.7.tgz",
-      "integrity": "sha512-BIar7R6abbUxDA3bfXrO4DSgwo8I+fB5/1zgujl3HLLjwd6+9iOnrT+t3grn2qbk9vOgBubXOFwX2m9axoFaGw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
+      "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -51,8 +51,5 @@
   },
   "lint": {
     "terraform_guidelines.md": "textlint"
-  },
-  "overrides": {
-    "ejs": "3.1.7"
   }
 }


### PR DESCRIPTION
Reverts future-architect/future-architect.github.io#1920