### PR TITLE
記事タイトルを h1 にする

### DIFF
--- a/themes/future/layout/_partial/post/title.ejs
+++ b/themes/future/layout/_partial/post/title.ejs
@@ -1,5 +1,7 @@
-<h2 itemprop="name" class="<%= class_name %>"><%= post.title %>
+<%# 記事ページではタイトルがページの主見出しなので h1、一覧ページでは記事が並ぶので h2 にする %>
+<% const titleTag = is_post() ? "h1" : "h2" %>
+<<%= titleTag %> itemprop="name" class="<%= class_name %>"><%= post.title %>
   <% if (is_post()) {%>
     <a href="https://github.com/future-architect/future-architect.github.io/edit/main/source/<%= encodeURIComponent(page.source) %>" title="Suggest Edits" aria-label="この記事をGitHubで編集する" class="github-edit"><i class="github-edit-icon"></i></a>
   <% } %>
-</h2>
+</<%= titleTag %>>

--- a/themes/future/source/css/theme-styles.styl
+++ b/themes/future/source/css/theme-styles.styl
@@ -270,6 +270,9 @@ body.page-header-fixed .header {
   .h2, h2 {
     font-size: 24px;
   }
+  .article-title {
+    font-size: 24px;
+  }
 }
 
 /******************************
@@ -562,6 +565,8 @@ code {
 .article-title {
   color: #424242;
   font-weight: 700;
+  /* h2 から h1 に変えても見た目が変わらないよう、従来の h2 相当のサイズを明示する */
+  font-size: 1.5em;
 }
 /* トップページのソーシャルボタン */
 .archive-social-button {


### PR DESCRIPTION
## 概要

記事ページに `h1` が存在せず、タイトルが `h2` で描画されていました。Lighthouse の `heading-order` と SEO の両方で不利になるため、タイトルを `h1` にします。

## 影響範囲の調査

`_partial/post/title.ejs` は2箇所から呼ばれています。

| 呼び出し元 | 用途 | 対応 |
| --- | --- | --- |
| `post.ejs:9` | 記事ページのタイトル | **h1 に変更** |
| `_partial/archive-post.ejs:14` | 一覧ページの記事タイトル | h2 のまま（記事が並ぶため） |

`is_post()` で出し分けています。この判定は同ファイル内の「Suggest Edits」リンクの表示条件として既に使われていたものです。

## 本文中の h1 との関係

全1464記事の最初の見出しレベルを調べました。

```
h1 で始まる: 953記事   h2 で始まる: 486記事   h3: 4記事   見出し無し: 21記事
```

**953記事は本文が `#`（h1）で始まります。** タイトルを h1 にすると、これらのページは h1 が複数になります。HTML5 では妥当で、Lighthouse の `heading-order` も「複数の h1」ではなく「レベルの飛び越し」を見るため、減点にはなりません。むしろ現状の「h2（タイトル）→ h1（本文）」という逆転が解消されます。

残り486記事は h1 が皆無だったので、今回の変更で初めて h1 を持ちます。

## 見た目は変えていません

`.article-title` にはサイズ指定が無く、`h1` と `h2` の既定値の差がそのまま出ます。

```
デスクトップ  h2: 1.5em = 19.5px  ->  h1: 2em = 26px
1024px以下   h2: 24px           ->  h1: 28px
```

意味づけだけを直す変更にしたいので、`.article-title` に従来の `h2` 相当のサイズを明示し、**視覚的な変化を伴わないように**しました。タイトルを大きくしたい場合は、この2行を消せば `h1` の既定サイズになります。

## 動作確認

`hexo clean` からフルビルド、エラー0件。

```
記事ページ    h1: 1件（class="article-title"、タイトル文字列）
一覧ページ    h1: 0件 / h2.archive-post-title: 25件（従来どおり）
本文にh1がある記事  h1総数 1件（想定どおりタイトルのみカウント）
```

Lighthouse の実測はこの環境ではできないため、スコア確認はデプロイ後にお願いします。