### PR TITLE
コントラスト比が不足していた2箇所の文字色を暗くする

### DIFF
--- a/themes/future/source/css/highlight.styl
+++ b/themes/future/source/css/highlight.styl
@@ -40,6 +40,10 @@ $line-numbers
     background: color-background
     text-shadow: 0 1px #fff
     padding: 0 0.3em
+  // リンク内のインラインコードは、リンク色(#0d6efd)がコード背景(#eee)に乗って
+  // コントラスト比3.87となりAA基準(4.5)に届かない。同系色のまま暗くして5.52に上げる
+  a code
+    color: #0a58ca
   pre
     @extend $code-block
     code

--- a/themes/future/source/css/theme-styles.styl
+++ b/themes/future/source/css/theme-styles.styl
@@ -428,7 +428,9 @@ ul.social-button li a {
 /* Custom Hatebu Button */
 .hatebu-btn,
 .hatebu-btn:visited {
-  color: #1b95e0;
+  /* #1b95e0 は白背景に対してコントラスト比3.27で、11pxの文字ではAA基準(4.5)に満たない。
+     同系色のまま暗くして5.65まで上げる。枠線と hover 時の背景は視認性に影響しないため元の色のまま */
+  color: #0b6ba8;
   border: 1px solid #1b95e0;
   padding-left: 10px;
 }


### PR DESCRIPTION
## 概要

Lighthouse（モバイル計測、ユーザー補助86）で失点していた `color-contrast`（重み7）への対応です。

## 指摘された2箇所

レポートが報告した実測値です。どちらも WCAG AA の基準 4.5 に届いていませんでした。

| 箇所 | 前景 / 背景 | 比 |
| --- | --- | --- |
| `div.article-entry > p > a > code`（リンク内のインラインコード） | `#0d6efd` / `#eeeeee` | 3.87 |
| `.social-btn-label`（はてなブックマークボタンのラベル、11px） | `#1b95e0` / `#ffffff` | 3.27 |

インラインコードは背景 `#eee` に対して本文色なら 8.2 で問題ないのですが、**リンクの中に置かれるとリンク色が乗って基準を割っていました**。

## 対応

どちらも**同系色のまま暗く**し、色味は保っています。

```styl
// highlight.styl
a code
  color: #0a58ca

// theme-styles.styl（はてなボタン）
color: #0b6ba8
```

| 箇所 | 変更前 | 変更後 |
| --- | --- | --- |
| リンク内のインラインコード | 3.88 | **5.55** |
| はてなボタンのラベル | 3.27 | **5.70** |

はてなボタンの枠線と hover 時の背景色は文字の視認性に影響しないため、元の `#1b95e0` のままにしています。

## 確認

`hexo clean` からフルビルド、エラー0件。生成CSSに両ルールが含まれることと、コントラスト比を WCAG の相対輝度式で検算し、いずれも AA 基準を満たすことを確認しました。

## 残るユーザー補助の指摘（今回は対象外）

同レポートの残り2項目は、いずれもデザイン判断を伴うため分けています。

- **リンクが色だけで識別可能** … 本文中の外部リンクに下線が無い。`text-decoration: underline` で解消しますが、全記事のリンクの見た目が変わります
- **タップターゲットが小さい** … フッターの connpass / future.co.jp / GitHub / Qiita などのリンク群。間隔か領域の調整が要ります