### PR TITLE
フッターのリンクを整理し、タップ領域を広げる

### DIFF
--- a/themes/future/layout/_partial/footer.ejs
+++ b/themes/future/layout/_partial/footer.ejs
@@ -37,7 +37,7 @@
             ><br />
           </address>
         </div>
-        <div class="col-lg-4 col-md-4 col-sm-4 col-4 pre-footer-col">
+        <div class="col-lg-4 col-md-4 col-sm-4 col-4 pre-footer-col footer-links">
           <h2>Links
           </h2>
           <a
@@ -46,27 +46,6 @@
             target="_blank"
             rel="noopener"
             >connpass</a
-          ><br />
-          <a
-            href="https://www.future.co.jp/futureinsightseminar/"
-            title="フューチャーインサイトセミナー"
-            target="_blank"
-            rel="noopener"
-            >Webセミナー</a
-          ><br />
-          <a
-            href="https://github.com/future-architect"
-            title="Future's official open source repositories"
-            target="_blank"
-            rel="noopener"
-            >GitHub</a
-          ><br />
-          <a
-            href="https://qiita.com/organizations/future"
-            title="フューチャーのQiita Organizationです"
-            target="_blank"
-            rel="noopener"
-            >Qiita</a
           ><br />
           <a
             href="https://note.future.co.jp/"

--- a/themes/future/source/css/theme-styles.styl
+++ b/themes/future/source/css/theme-styles.styl
@@ -1306,3 +1306,12 @@ pre.mermaid {
 .slideshare-responsive {
   width: min(500px, 90%);
 }
+
+/* フッターのリンクは行の高さ分しかタップ領域が無く、Lighthouse の
+   target-size（最低24px、間隔も必要）を満たしていなかった。
+   上下に余白を持たせてタップしやすくする */
+.footer-links a {
+  display: inline-block;
+  padding: 7px 0;
+  line-height: 1.4;
+}


### PR DESCRIPTION
## 概要

Lighthouse（モバイル計測）のユーザー補助で残っていた `target-size`（重み7）への対応です。

前回の #1925 でユーザー補助は **86 → 91** に改善しました。指摘された `target-size` の7件は**すべてフッターの Links 欄**で、`<br />` で区切られた行内リンクのためタップ領域が行の高さ分しかありませんでした。

## 対応

**1. リンクを3つ削除**

数が多く間隔も詰まっていたため、7つから4つに減らしました。

| 削除 | 残す |
| --- | --- |
| Webセミナー / GitHub / Qiita | connpass / 未来報 / Youtube / メディアポリシー |

**2. 残るリンクのタップ領域を拡大**

```styl
.footer-links a {
  display: inline-block;
  padding: 7px 0;
  line-height: 1.4;
}
```

行の高さ（約18px）に上下 7px を足して約32pxとし、Lighthouse が求める最低24pxと、リンク同士の間隔を確保しました。

## 確認

`hexo clean` からフルビルド、エラー0件。フッターのリンクが意図した4つになり、CSSが出力されていることを確認しました。

```
フッターLinks欄: connpass / 未来報 / Youtube / メディアポリシー
```

## 対応しない項目

**リンクは色に依存して識別可能（重み7）** … 本文中の外部リンクに下線が無い件です。`text-decoration: underline` で確実に解消しますが、**本文の見た目を変えたくない**という判断でペナルティを受け止める方針としました。

したがってユーザー補助は、この項目の分（重み7）を除いた水準が上限になります。