### PR TITLE
記事タイトル・コードブロック・summary の文字サイズを調整する

### DIFF
--- a/themes/future/source/css/highlight.styl
+++ b/themes/future/source/css/highlight.styl
@@ -12,7 +12,7 @@ highlight-aqua = #66cccc
 highlight-blue = #6699cc
 highlight-purple = #cc99cc
 article-padding = 20px
-font-size = 15px
+font-size = 14px
 line-height = 1.6em
 
 $code-block
@@ -25,7 +25,9 @@ $code-block
   overflow: auto
   color: highlight-foreground
   // font-size を指定しないと body の 13px を継承してしまい、
-  // 本文（.article-entry p の 1.2em = 15.6px）より小さくなって読みにくい
+  // 本文（.article-entry p の 1.2em = 15.6px）より小さくなって読みにくい。
+  // 等幅フォントは同じ値でも字面が大きく見え、暗い背景では膨張して見えるため、
+  // 本文よりわずかに小さい 14px にしている（このファイルが元々持っていた値）
   font-size: font-size
   line-height: font-size * line-height
 

--- a/themes/future/source/css/theme-styles.styl
+++ b/themes/future/source/css/theme-styles.styl
@@ -80,6 +80,11 @@ h4 {
   font-size: 1.2em;
   color: #424242;
 }
+/* details の summary は p / li と違って本文サイズの指定対象から漏れており、
+   body の 13px を継承して周囲（1.2em = 15.6px）より小さく表示されていた */
+.article-entry summary {
+  font-size: 1.2em;
+}
 .article-entry li p {
   font-size: 1em;
 }

--- a/themes/future/source/css/theme-styles.styl
+++ b/themes/future/source/css/theme-styles.styl
@@ -569,14 +569,19 @@ code {
 .article-title {
   color: #424242;
   font-weight: 700;
-  /* h2 から h1 に変えても見た目が変わらないよう、従来の h2 相当のサイズを明示する。
-     1024px以下では従来 `.h2, h2 { font-size: 24px }` が効いていたので、
-     同じ値をこのルールより後ろで指定する（同一詳細度では後勝ちのため） */
-  font-size: 1.5em;
+  /* 以前は Bootstrap のリセットCSSが h2 にサイズを与えていた（>=1200px で 2rem）。
+     CDN 読み込みをやめた際にサブセットへ取り込めておらず、タイトルだけが
+     ブラウザ既定の 1.5em まで縮んでいたため、当時の値を明示して復元する */
+  font-size: calc(1.325rem + 0.9vw);
 }
 @media (max-width: 1024px) {
   .article-title {
     font-size: 24px;
+  }
+}
+@media (min-width: 1200px) {
+  .article-title {
+    font-size: 2rem;
   }
 }
 /* トップページのソーシャルボタン */

--- a/themes/future/source/css/theme-styles.styl
+++ b/themes/future/source/css/theme-styles.styl
@@ -270,9 +270,6 @@ body.page-header-fixed .header {
   .h2, h2 {
     font-size: 24px;
   }
-  .article-title {
-    font-size: 24px;
-  }
 }
 
 /******************************
@@ -567,8 +564,15 @@ code {
 .article-title {
   color: #424242;
   font-weight: 700;
-  /* h2 から h1 に変えても見た目が変わらないよう、従来の h2 相当のサイズを明示する */
+  /* h2 から h1 に変えても見た目が変わらないよう、従来の h2 相当のサイズを明示する。
+     1024px以下では従来 `.h2, h2 { font-size: 24px }` が効いていたので、
+     同じ値をこのルールより後ろで指定する（同一詳細度では後勝ちのため） */
   font-size: 1.5em;
+}
+@media (max-width: 1024px) {
+  .article-title {
+    font-size: 24px;
+  }
 }
 /* トップページのソーシャルボタン */
 .archive-social-button {


### PR DESCRIPTION
## 概要

見た目のフィードバック対応3件です。いずれも文字サイズに関するもので、根っこは共通しています。

**本文のサイズは `.article-entry p, .article-entry li { font-size: 1.2em }` で作られている**ため、`p` / `li` 以外の要素は `body` の 13px を継承してしまう、という構造です。

## 1. 記事タイトルが1024px以下で小さくなっていた（#1924 のリグレッション）

#1924 でタイトルを `h2` から `h1` にした際、見た目を保つため `.article-title` に `font-size: 1.5em` を明示しましたが、**CSSの記述順を見落としていました**。

```
267行付近  @media (max-width: 1024px) { .article-title { font-size: 24px } }
567行      .article-title { font-size: 1.5em }   ← こちらが後で勝つ
```

同一詳細度では後勝ちのため、1024px以下でも 1.5em（19.5px）が適用され、従来の24pxより小さくなっていました。メディアクエリを後ろへ移して修正します。

## 2. コードブロックを 15px → 14px（#1896 の微調整）

本文15.6pxに対して15pxだと大きく見える、という指摘への対応です。錯覚ではなく理由があります。

- 等幅フォントは同じpx値でも字面が大きく見える
- 暗い背景（`#2d2d2d`）の明るい文字は膨張して見える（放射効果）

**14px は `highlight.styl` が元々持っていた `font-size` 変数の値**です。CSSプロパティとして出力されていなかっただけで、テーマ本来の意図がこの値でした。

| | #1896以前 | #1896 | 本PR |
| --- | --- | --- | --- |
| コードブロック | 13px（指定なし） | 15px | **14px** |
| 本文 | 15.6px | 15.6px | 15.6px |

## 3. `details` の `summary` が小さかった

`summary` は `p` / `li` のどちらでもないため本文サイズの指定対象から漏れ、`body` の 13px を継承していました。**コードブロックに `font-size` 指定が無かったのとまったく同じ構造の見落とし**です。

```styl
.article-entry summary {
  font-size: 1.2em;
}
```

`details` を使っている記事は60件あります。

## 確認

`hexo clean` からフルビルド、エラー0件。生成CSSで以下を確認しました。

- `.article-title` の1024px以下指定が基本ルールより後ろに出力されている
- コードブロックが `font-size: 14px` / `line-height: 22.4px`
- `.article-entry summary` のルールが出力されている