### PR TITLE
SNSボタンの位置ずれを直す

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -175,6 +175,12 @@ a:focus .img_wrap img {
 .social-area {
 	padding: 1.5em 0;
 }
+/* ul.social-button の padding-left: 16px のぶん、記事ページでは本文の左端から
+   ずれて見える。記事内では本文と左端を揃える（一覧ページは親カラムの
+   余白があるため従来のまま） */
+.social-area ul.social-button {
+  padding-left: 0;
+}
 
 .img-frame-line {
   border: 1px solid #ddd;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -175,10 +175,12 @@ a:focus .img_wrap img {
 .social-area {
 	padding: 1.5em 0;
 }
-/* ul.social-button の padding-left: 16px のぶん、記事ページでは本文の左端から
-   ずれて見える。記事内では本文と左端を揃える（一覧ページは親カラムの
-   余白があるため従来のまま） */
-.social-area ul.social-button {
+/* ul.social-button の padding-left: 16px のぶん、親が左余白を持たない場所では
+   本文やコンテナの左端からずれて見える。該当する2箇所で打ち消す。
+   記事一覧の各記事に付くボタン（.archive-social-button）は親カラムの
+   余白があるため対象外 */
+.social-area ul.social-button,
+.home-social-button ul.social-button {
   padding-left: 0;
 }
 

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -330,19 +330,16 @@ ul.social-button li a {
   white-space: nowrap;
 }
 
-/* Custom Twitter Button */
-/* Custom X Button */
-/* Custom X Button */
 /* Custom X Button */
 .x-btn, .x-btn:visited {
   color: #000000;
   border: 1px solid #000000;
 }
 .x-btn i {
-  /* アイコンのサイズを調整 */
-  width: 11px;
-  height: 11px;
-  background-size: contain; /* アイコンを要素にフィットさせる */
+  /* 箱の大きさは他のボタン（14px）と揃える。ここだけ11pxにすると
+     アイコンとラベルの位置が他とずれ、ボタン内の余白配分も崩れる。
+     Xのアイコンは他より字面が大きいため、グリフだけ11px相当に縮めて調整する */
+  background-size: 11px 11px;
   background-repeat: no-repeat; /* アイコンの繰り返しを防止 */
   background-position: center; /* アイコンを中央に配置 */
   /* 通常時の黒いXアイコン */


### PR DESCRIPTION
## 概要

SNSボタンまわりの位置ずれ2件の修正です。

## 1. X のボタンだけ中身がずれていた

X のボタンだけ、アイコンの箱のサイズが他と違っていました。

```styl
.social-btn i { width: 14px; height: 14px; }   /* Facebook・はてな */

.x-btn i {
  width: 11px;   /* ← ここだけ小さい */
  height: 11px;
  background-size: contain;
}
```

`.social-btn` は `min-width: 7em` の固定幅なので、中身（アイコン＋ラベル）の幅が3px違うと、ボタン内での配置と余白の配分が他と揃いません。マークアップは3ボタンとも `<i></i><span class="social-btn-label">` で同一なので、差はこのCSSだけでした。

箱のサイズ指定を外して14px角を継承させ、**グリフの大きさは `background-size: 11px 11px` で保ちます**。X のアイコンは他サービスより字面が大きいため小さく見せる調整自体は必要で、それを「箱を縮める」から「中身を縮める」に変えた形です。

あわせて `.x-btn` の直前に重複していた `/* Custom X Button */` コメント3行を1行に整理しました。

## 2. 記事ページのSNSボタン全体が右にずれていた

`ul.social-button` に `padding-left: 16px` が入っていました。

```styl
ul.social-button {
  padding: 8px 0px 4px 16px;   /* ← 左に16px */
}
```

一覧ページでは親が Bootstrap のカラム `.archive-social-button` で、その余白と併せて自然に見えます。一方、記事ページの親は `.social-area { padding: 1.5em 0 }` で左に余白を持たないため、**本文の左端に対して16pxそのままずれて**いました。

`.archive-social-button { margin-left: 0px }` という指定が別途あることからも、一覧側は過去に調整済みで記事側が取り残されていたようです。

記事ページ側だけ打ち消します。**一覧ページの見た目は変わりません。**

```styl
.social-area ul.social-button {
  padding-left: 0;
}
```

## 確認

`hexo clean` からフルビルド、エラー0件。統合後の `site.css` に両方のルールが出力されていることを確認しました。

デプロイ後の確認ポイントです。

- 3つのボタンでアイコンの箱とラベルの開始位置が揃っているか
- 記事ページで本文の左端とSNSボタンの左端が揃っているか
- 一覧ページ側が従来どおりか

X のグリフの大きさが気になる場合は `background-size` の値1箇所で調整できます。