### PR TITLE
GitLab タグの重複を除去する

### DIFF
--- a/source/_posts/2025/20250417a_GitLabのレビューにPR-Agentを組み込んでみた.md
+++ b/source/_posts/2025/20250417a_GitLabのレビューにPR-Agentを組み込んでみた.md
@@ -5,7 +5,6 @@ postid: a
 tag:
   - GitLab
   - 生成AI
-  - GitLab
   - コードレビュー
 category:
   - AIDD


### PR DESCRIPTION
記事 20250417a「GitLabのレビューにPR-Agentを組み込んでみた」のフロントマターで `GitLab` タグが2回書かれていました。

関連記事の類似度を調べる過程で、同一記事が自分自身とのペアとして現れたことから発見しました。全1465記事を走査して、重複はこの1件のみです。

Hexo は重複タグを内部でまとめるため表示上の実害はありませんが、フロントマターとしては誤りなので直します。