### PR TITLE
サポート終了した Universal Analytics のタグを削除する

### DIFF
--- a/themes/future/layout/_partial/scripts.ejs
+++ b/themes/future/layout/_partial/scripts.ejs
@@ -5,5 +5,4 @@
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
   gtag('config', '<%= theme.google_analytics %>');
-  gtag('config', 'UA-74047147-1'); // 過渡期対応
 </script>


### PR DESCRIPTION
## 概要

`_partial/scripts.ejs` に残っていた Universal Analytics の設定を削除します。

```diff
   gtag('config', '<%= theme.google_analytics %>');
-  gtag('config', 'UA-74047147-1'); // 過渡期対応
```

## 理由

Universal Analytics は **2023年7月に計測を終了**しており、このIDにデータは入りません。それでも `gtag` はこのID向けのリクエストとスクリプト評価を行うため、実行時間だけが発生していました。

最新の Lighthouse（`/articles/20260806a/`、モバイル）では、この分がはっきり数字に出ています。

```
https://www.googletagmanager.com/gtag/js?id=UA-74047147-1&cx=c&gtm=...
  評価 303ms ／ 解析 71ms
長いタスク 369ms
```

**約370msの純粋な無駄**です。計測されないスクリプトのコストなので、削除による機能低下はありません。GA4（`G-X1C28R8H0M`）側の設定はそのまま残しています。

## 背景

同レポートでパフォーマンスが 88 → 50 に低下していました。最大の要因は TBT（Total Blocking Time）が 30ms → 2,000ms になったことで、内訳はこうです。

```
mermaid (CDN)      評価 832ms   ← この記事が mermaid を含むため
gtag (GA4)         評価 673ms ＋ 解析 129ms
ページ内スクリプト   評価 508ms
gtag (UA)          評価 303ms ＋ 解析  71ms   ← 本PRで削除
```

mermaid は記事の性質によるものなので今回は対象外としています。UAは無条件に不要なため、まずここを落とします。

## 確認

`hexo clean` からフルビルド、エラー0件。生成HTMLから `UA-74047147` が消え、GA4の設定のみが残ることを確認しました。

```
UA-74047147 の出現: 0件
gtag('config', 'G-X1C28R8H0M')
```