### PR TITLE
記事本文の先頭画像に fetchpriority=high を付ける

### DIFF
--- a/scripts/lcp_image_priority.js
+++ b/scripts/lcp_image_priority.js
@@ -1,0 +1,31 @@
+'use strict';
+
+/**
+ * 記事本文の最初の画像に fetchpriority="high" を付けるフィルター。
+ *
+ * 記事冒頭の画像は LCP 要素になりやすいが、既定では他のリソースと同じ
+ * 優先度で読み込まれるため、表示が遅れて LCP を悪化させる。
+ * ブラウザに最優先で取得するよう指示する。
+ *
+ * 本文の画像は Markdown 記法ではなく <img> タグを直接書く運用のため、
+ * 記事側を書き換えるには1400本以上に手を入れる必要がある。ここで
+ * 一括処理することで、記事は変更せずに済む。
+ *
+ * 置換は最初の1つだけ。String#replace に非グローバルの正規表現を渡すと
+ * 最初の一致しか置換されないため、2枚目以降は対象にならない。
+ * 先頭画像は画面内に入るので、lazy 読み込みも外す（LCP候補に lazy が
+ * 付いていると Lighthouse でも減点される）。
+ */
+hexo.extend.filter.register('after_post_render', function(data) {
+  // 属性値の中に > が入ることがある（alt にコード片が書かれている記事がある）ため、
+  // 引用符で囲まれた範囲を読み飛ばしながらタグの終端を探す
+  data.content = data.content.replace(/<img\b(?:[^>"']|"[^"]*"|'[^']*')*>/i, tag => {
+    // 同じタグに loading="lazy" が2回書かれている記事があるため、タグ内は全て除去する
+    let t = tag.replace(/\s+loading\s*=\s*(["']?)lazy\1/gi, '');
+    if (!/\bfetchpriority=/i.test(t)) {
+      t = t.replace(/<img\b/i, '<img fetchpriority="high"');
+    }
+    return t;
+  });
+  return data;
+});


### PR DESCRIPTION
## 概要

記事冒頭の画像は LCP 要素になりやすいのに、既定では他のリソースと同じ優先度で読み込まれ、表示が遅れて LCP を悪化させます。ブラウザに最優先で取得するよう指示します。

## 記事は1本も変更していません

本文の画像は Markdown 記法ではなく `<img>` タグを直接書く運用のため、記事側で対応すると**1400本以上に手を入れる**ことになります。`scripts/lcp_image_priority.js` を追加し、`after_post_render` フィルターで一括処理しました。#1923 の headerlink と同じ方式です。

## 「最初の1つだけ」に絞れます

`String#replace` に**非グローバルの正規表現**を渡すと最初の一致しか置換されません。これだけで2枚目以降は対象外になります。

```js
data.content = data.content.replace(/<img\b(?:[^>"']|"[^"]*"|'[^']*')*>/i, tag => { ... });
```

あわせて、その画像からは `loading="lazy"` を外しています。画面内に入る画像に lazy が付いていると Lighthouse でも減点対象になるためです。

## 実データで見つかった2つの厄介なケース

全記事に適用して検証したところ、素朴な正規表現では取りこぼす記事がありました。

**1. `alt` 属性の中に `>` が入っている**

```html
<img alt="test('calc', async ({ page }) => { にハイライトがあたった..." ...>
```

`<img[^>]*>` だと `=>` の `>` でタグの終端と誤認します。引用符で囲まれた範囲を読み飛ばす形に変えました。

**2. 同じタグに `loading="lazy"` が2回書かれている**（`/articles/20191008/`）

```html
<img src="..." alt="Stoplight StudioのGUI" loading="lazy" style="..." loading="lazy">
```

記事側の不備ですが、フィルターで扱えるようタグ内は全て除去するようにしています。

## 確認

`hexo clean` からフルビルドし、全記事を走査しました。

```
本文に画像がある記事      1437
  fetchpriority が1つだけ  1437   ← 全件
  複数付与                    0
  lazy が残存                 0
本文に画像がない記事        29（対象外。正常）
```

出力例です。

```html
<img fetchpriority="high" src="/images/2026/20260806a/top.jpg" alt="" width="720" height="402">
```

2枚目以降は従来どおり `loading="lazy"` のままで、影響していません。

## 補足

LCP の実測改善はデプロイ後の計測でご確認ください。

なお、直近のレポート（`/articles/20260806a/`）ではパフォーマンスが50まで落ちていましたが、**最大の要因は TBT 2,000ms**（mermaid 832ms + gtag 約1,100ms + ページ内 508ms）で、LCP ではありません。UAタグは #1936 で削除済みです。mermaid はその記事の性質によるものとの判断で、今回は対象外としています。