### PR TITLE
temp.json を .gitignore に追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ public*
 .idea/
 credential.json
 .envrc
+
+# snssharecount の出力用一時ファイル（update-cache.yml が生成する）
+temp.json


### PR DESCRIPTION
## 概要

#1938 の追補です。

`temp.json` はファイル自体を削除しましたが、**`.gitignore` への追記がステージ漏れでコミットに含まれていませんでした**。このままだと `update-cache.yml` の実行後に再び未追跡ファイルとして現れます。

```diff
 credential.json
 .envrc
+
+# snssharecount の出力用一時ファイル（update-cache.yml が生成する）
+temp.json
```

`temp.json` は `snssharecount` の出力先として毎回生成され、`sns_count_cache.json` へリネームされる中間ファイルです。README の手順にもそう書かれています。

```sh
snssharecount > temp.json
mv temp.json sns_count_cache.json
```