### PR TITLE
コードハイライトをJetBrains Darcula寄りの配色にする

### DIFF
--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -1,16 +1,18 @@
-// https://github.com/chriskempson/tomorrow-theme
-highlight-background = #2d2d2d
-highlight-current-line = #393939
-highlight-selection = #515151
-highlight-foreground = #cccccc
-highlight-comment = #999999
-highlight-red = #f2777a
-highlight-orange = #f99157
-highlight-yellow = #ffcc66
-highlight-green = #99cc99
-highlight-aqua = #66cccc
-highlight-blue = #6699cc
-highlight-purple = #cc99cc
+// JetBrains Darcula（GoLand などの既定テーマ）に寄せた配色。
+// 以前は Tomorrow Theme 由来の配色だったが、背景が暗くコントラストも低いため
+// キーワードが埋もれて見えていた。
+highlight-background = #2b2b2b     // 以前は #2d2d2d。わずかに明るくする
+highlight-current-line = #323232
+highlight-selection = #214283
+highlight-foreground = #a9b7c6     // 青みのあるグレー
+highlight-comment = #808080
+highlight-red = #ff6b68
+highlight-orange = #cc7832         // キーワード
+highlight-yellow = #ffc66d         // 関数名・型名
+highlight-green = #6a8759          // 文字列
+highlight-aqua = #6897bb
+highlight-blue = #6897bb           // 数値・定数
+highlight-purple = #9876aa
 article-padding = 20px
 font-size = 13px
 line-height = 1.6em
@@ -119,7 +121,6 @@ $line-numbers
 
 pre
   .comment
-  .title
     color: highlight-comment
   .variable
   .attribute
@@ -135,16 +136,20 @@ pre
   .css .pseudo
     color: highlight-red
   .number
+  .literal
+  .constant
+    color: highlight-blue
   .preprocessor
   .built_in
-  .literal
   .params
-  .constant
     color: highlight-orange
+  // 型名・関数名。以前 .title はコメント色で、関数名が地味に見えていた
   .class
+  .type
+  .title
   .ruby .class .title
   .css .rules .attribute
-    color: highlight-green
+    color: highlight-yellow
   .string
   .value
   .inheritance
@@ -163,9 +168,11 @@ pre
   .javascript .title
   .coffeescript .title
     color: highlight-blue
+  // キーワードは太字にして最も目立たせる（JetBrains と同じ扱い）
   .keyword
   .javascript .function
-    color: highlight-purple
+    color: highlight-orange
+    font-weight: bold
   .deletion
     color: highlight-red
   .addition


### PR DESCRIPTION
Closes #1943

## 概要

背景が暗くコントラストも低いため、キーワードが埋もれて目立たない状態でした。Tomorrow Theme 由来の配色から、GoLand などの既定テーマである **Darcula** に寄せます。ダークテーマは維持します。

## 配色の変更

| | 変更前 | 変更後 |
| --- | --- | --- |
| 背景 | `#2d2d2d` | `#2b2b2b`（わずかに明るく） |
| 前景 | `#cccccc` | `#a9b7c6`（青みのあるグレー） |
| **キーワード** | 紫 `#cc99cc` | **オレンジ `#cc7832` + `font-weight: bold`** |
| 文字列 | `#99cc99` | `#6a8759` |
| 数値・定数 | オレンジ | 青 `#6897bb` |

キーワードの太字が最も効きます。JetBrains と同じ扱いです。

```css
pre .keyword, pre .javascript .function { color: #cc7832; font-weight: bold; }
```

## 実データを見て気づいた2点も直しました

**1. 関数名がコメントと同じ色だった**

```styl
pre
  .comment
  .title          ← 関数名などがコメント色に指定されていた
    color: highlight-comment
```

`.title` は関数名・クラス名に付くクラスです。コメントと同色では地味に見えて当然でした。

**2. 型名（`.type`）に色指定が無かった**

生成HTMLには `type` クラスが出力されているのに、`highlight.styl` に対応する規則が無く**前景色のまま**でした。Goの記事が多いサイトで型が判別できないのは損失が大きいと判断しました。

どちらも黄 `#ffc66d` にまとめています。

```css
pre .class, pre .type, pre .title, ... { color: #ffc66d; }
```

## 実現性の確認

生成HTMLのクラス名を事前に確認しました。Hexo標準のハイライトが `keyword` `function` `built_in` `type` `string` `number` `comment` `literal` `title` `params` を出力しており、既存のセレクタでそのまま指定できます。**JSの追加は不要**です。

## 動作確認

`hexo clean` からフルビルド、エラー0件。統合後の `site.css` に意図した値が出力されていることを確認しました。

見え方の最終判断はデプロイ後にお願いします。「まだ暗い」「キーワードの色を変えたい」といった調整は、`highlight.styl` 冒頭の色変数だけで完結します。

## 補足

#1931（コードブロックのファイル名表示）が同じ `highlight.styl` を触ります。本PRのマージ後に着手すると衝突しません。