### PR TITLE
コードブロックのファイル名をZenn風のバーにし、差分の追加色を強める

### DIFF
--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -13,6 +13,12 @@ highlight-green = #6a8759          // 文字列
 highlight-aqua = #6897bb
 highlight-blue = #6897bb           // 数値・定数
 highlight-purple = #9876aa
+highlight-caption-background = #3c3f41   // Darcula のエディタタブ相当
+highlight-caption-border = #4e5254
+// 差分専用。文字列の緑（#6a8759）だと削除側の赤に対して弱く見えるため、
+// 追加・削除を同じくらいの鮮やかさに揃える
+highlight-diff-added = #89d185
+highlight-diff-removed = #ff6b68
 article-padding = 20px
 font-size = 13px
 line-height = 1.6em
@@ -66,12 +72,21 @@ $line-numbers
     td
       border: none
       padding: 0
+    // ファイル名はコードブロック上部のバーとして一体化させる。
+    // 以前は本文と同じ余白の中に小さなグレー文字が浮いているだけで、
+    // どのコードブロックに対する名前なのか分かりにくかった。
+    // figure の padding（15px / article-padding）を負マージンで打ち消し、
+    // 左右いっぱいに広げている
     figcaption
       clearfix()
+      margin: -15px (article-padding * -1) 15px
+      padding: 7px article-padding
+      background: highlight-caption-background
+      border-bottom: 1px solid highlight-caption-border
+      color: highlight-foreground
+      font-family: font-mono
       font-size: 0.85em
-      color: highlight-comment
-      line-height: 1em
-      margin-bottom: 1em
+      line-height: 1.6
       a
         float: right
     .gutter pre
@@ -174,6 +189,6 @@ pre
     color: highlight-orange
     font-weight: bold
   .deletion
-    color: highlight-red
+    color: highlight-diff-removed
   .addition
-    color: highlight-green
+    color: highlight-diff-added


### PR DESCRIPTION
Closes #1931

コードブロック関連の見た目の調整2件です。同じ `highlight.styl` を触るため1本にまとめています。

## 1. ファイル名の表示（#1931）

理想として挙がっていた Zenn のパターン（コードブロック上部に一体化したバー）に寄せます。

**変更前**は、本文と同じ余白の中に小さなグレー文字（`font-size: 0.85em`、色はコメントと同じ `#808080`）が浮いているだけで、`margin-bottom: 1em` で下のコードとも離れており、どのコードブロックに対する名前なのか分かりにくい状態でした。

**変更後**は、`figure` の `padding`（`15px 20px`）を負マージンで打ち消し、左右いっぱいのバーにします。

```styl
figcaption
  margin: -15px (article-padding * -1) 15px
  padding: 7px article-padding
  background: highlight-caption-background   // #3c3f41 = Darcula のエディタタブ相当
  border-bottom: 1px solid highlight-caption-border
  color: highlight-foreground
  font-family: font-mono
```

背景色はコードブロック本体（`#2b2b2b`）よりわずかに明るくし、下線で区切ります。文字はコメント色から前景色に変え、等幅フォントにしてファイル名らしく見せます。

`figure` に `border-radius` と `overflow: auto` が効いているので、角丸もそのまま維持されます。

**対象はファイル名付きコードブロック2210個・426記事**で、想定よりかなり広く使われていました。

## 2. 差分の追加色を強める

追加側（`.addition`）が文字列と同じ `#6a8759` で、削除側（`.deletion` `#ff6b68`）に対して明らかに弱く見えていました。差分専用の色に分離します。

| | 変更前 | 変更後 | 背景 `#2b2b2b` とのコントラスト比 |
| --- | --- | --- | --- |
| 追加 | `#6a8759` | **`#89d185`** | 3.52 → **7.77** |
| 削除 | `#ff6b68` | 据え置き | 5.09 |

追加側が削除側を上回る明度になりますが、緑は赤より暗く見えやすいため、体感ではこのくらいで釣り合います。

## 動作確認

`hexo clean` からフルビルド、エラー0件。生成CSSに意図した値が出力されていることと、コントラスト比を WCAG の相対輝度式で検算しました。

見え方の判断はデプロイ後にお願いします。バーの背景色・差分の色とも、`highlight.styl` 冒頭の変数1箇所で調整できます。