### PR TITLE
関連記事と参照記事のブロックを統合する

### DIFF
--- a/scripts/reference_posts.js
+++ b/scripts/reference_posts.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const {getSNSCnt} = require('./lib/sns');
+
 hexo.extend.helper.register('list_reference_posts', function() {
 
   const referencePosts = this.site.posts.data.filter(p => p.content.includes(this.post.path))
@@ -24,7 +26,8 @@ hexo.extend.helper.register('list_reference_posts', function() {
   let result = "";
   for (let i = 0; i < Math.min(5, referencePosts.length); i++) {
     const related = referencePosts[i];
-    result += `<li class="reference-posts-item"><a href=/${related.path} title="${related.lede}">${related.title}${label(related)}</a></li>`;
+    // 関連記事（related_posts.js）とマークアップを揃える
+    result += `<li class="reference-posts-item"><a href=/${related.path} title="${related.lede}">${related.title}</a>${label(related)}<span class="post-meta"><span class="post-meta-date">${related.date.format('YYYY.MM.DD')}</span><span class="snscount">&#9825;${getSNSCnt(related.permalink)}</span></span></li>`;
   }
 
   return `

--- a/scripts/reference_posts.js
+++ b/scripts/reference_posts.js
@@ -2,6 +2,12 @@
 
 const {getSNSCnt} = require('./lib/sns');
 
+// 反響が0のときは何も出さない（related_posts.js と揃える）
+const snsLabel = permalink => {
+  const n = getSNSCnt(permalink);
+  return n > 0 ? `<span class="snscount">&#9825;${n}</span>` : '';
+};
+
 hexo.extend.helper.register('list_reference_posts', function() {
 
   const referencePosts = this.site.posts.data.filter(p => p.content.includes(this.post.path))
@@ -27,7 +33,7 @@ hexo.extend.helper.register('list_reference_posts', function() {
   for (let i = 0; i < Math.min(5, referencePosts.length); i++) {
     const related = referencePosts[i];
     // 関連記事（related_posts.js）とマークアップを揃える
-    result += `<li class="reference-posts-item"><a href=/${related.path} title="${related.lede}">${related.title}</a>${label(related)}<span class="post-meta"><span class="post-meta-date">${related.date.format('YYYY.MM.DD')}</span><span class="snscount">&#9825;${getSNSCnt(related.permalink)}</span></span></li>`;
+    result += `<li class="reference-posts-item"><a href=/${related.path} title="${related.lede}">${related.title}</a>${label(related)}<span class="post-meta"><span class="post-meta-date">${related.date.format('YYYY.MM.DD')}</span>${snsLabel(related.permalink)}</span></li>`;
   }
 
   return `

--- a/scripts/related_posts.js
+++ b/scripts/related_posts.js
@@ -5,6 +5,12 @@
 const maxCount = 3;
 const {getSNSCnt} = require('./lib/sns');
 
+// 反響が0のときは何も出さない。0と表示されると寂しく見えるため
+const snsLabel = permalink => {
+  const n = getSNSCnt(permalink);
+  return n > 0 ? `<span class="snscount">&#9825;${n}</span>` : '';
+};
+
 // HTMLを生成するロジックを共通関数として外に切り出す
 function generateRelatedPostsHtml(posts) {
   const count = Math.min(maxCount, posts.length);
@@ -26,13 +32,13 @@ function generateRelatedPostsHtml(posts) {
         // タイトル -> 日付 -> SNS数の順。読み手は「何の記事か」を見てから
       // 「古くないか」「評判はどうか」を確認する。「この記事を参照している記事」
       // （reference_posts.js）とマークアップを揃えている
-      result += `<li class="related-posts-item"><a href=/${related.path} title="${titleAttr}">${related.title}</a>${label(related)}<span class="post-meta"><span class="post-meta-date">${related.date.format('YYYY.MM.DD')}</span><span class="snscount">&#9825;${getSNSCnt(related.permalink)}</span></span></li>`;
+      result += `<li class="related-posts-item"><a href=/${related.path} title="${titleAttr}">${related.title}</a>${label(related)}<span class="post-meta"><span class="post-meta-date">${related.date.format('YYYY.MM.DD')}</span>${snsLabel(related.permalink)}</span></li>`;
     }
   }
 
   return `
     <div class="widget">
-      <ul class="nav related-post-link">${result}</ul>
+      <ul class="related-post-link">${result}</ul>
     </div>`;
 }
 

--- a/scripts/related_posts.js
+++ b/scripts/related_posts.js
@@ -23,7 +23,10 @@ function generateRelatedPostsHtml(posts) {
     if (related) {
       const scoreText = related.score ? `スコア: ${related.score.toFixed(4)}` : '';
       const titleAttr = `${related.lede} ${scoreText}`.trim();
-      result += `<li class="related-posts-item"><span>${related.date.format('YYYY.MM.DD')}</span><span class="snscount">&#9825;${getSNSCnt(related.permalink)}</span><a href=/${related.path} title="${titleAttr}">${related.title}${label(related)}</a></li>`;
+        // タイトル -> 日付 -> SNS数の順。読み手は「何の記事か」を見てから
+      // 「古くないか」「評判はどうか」を確認する。「この記事を参照している記事」
+      // （reference_posts.js）とマークアップを揃えている
+      result += `<li class="related-posts-item"><a href=/${related.path} title="${titleAttr}">${related.title}</a>${label(related)}<span class="post-meta"><span class="post-meta-date">${related.date.format('YYYY.MM.DD')}</span><span class="snscount">&#9825;${getSNSCnt(related.permalink)}</span></span></li>`;
     }
   }
 

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -952,6 +952,18 @@ code {
 .tag-cloud a {
   margin: 0 0 5px 5px;
 }
+/* 関連記事は著者が書いた本文ではなく自動生成のブロックなので、
+   「この記事を参照している記事」と同じ card で囲って区別する。
+   見出しは card の中に収め、参照ブロックの .reference-lede と余白を揃える */
+.related-post .card > h2 {
+  padding: 0.6em 0 0 0.6em;
+  margin: 0;
+  font-size: 1.2em;
+  border-bottom: none;
+}
+.related-post .card .widget {
+  padding: 0 0.6em;
+}
 .related-post-link li {
   border-bottom: 1px solid #ecebeb;
 }

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -982,6 +982,14 @@ code {
   padding: 0.5em 0;
   border-bottom: 1px solid #ecebeb;
 }
+/* metronic に `.related-post-link a { font-size: 1.2em }` があり、関連記事の
+   タイトルだけ大きくなっていた。参照記事側には同じ指定が無い。
+   両者を本文と同じ大きさに揃える */
+.related-posts-item > a,
+.reference-posts-item > a {
+  font-size: 1em;
+  color: #424242;
+}
 .related-posts-item:last-child,
 .reference-posts-item:last-child {
   border-bottom: none;
@@ -999,8 +1007,11 @@ code {
   margin-right: 0.5em;
 }
 /* ♡（U+2661）は細い輪郭の記号で、小さくすると線が潰れて欠けて見える。
-   メタ情報の中では少し大きめにし、字送りにも余裕を持たせる */
+   メタ情報の中では少し大きめにし、字送りにも余裕を持たせる。
+   metronic の `.snscount { padding: 0 10px }` は日付との間隔が空きすぎるので
+   ここで打ち消す */
 .snscount {
+  padding: 0;
   font-size: 1.15em;
   letter-spacing: 0.03em;
   padding-right: 0.1em;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -954,21 +954,42 @@ code {
 }
 /* 関連記事は著者が書いた本文ではなく自動生成のブロックなので、
    「この記事を参照している記事」と同じ card で囲って区別する。
-   見出しは card の中に収め、参照ブロックの .reference-lede と余白を揃える */
-.related-post .card > h2 {
-  padding: 0.6em 0 0 0.6em;
+   2つのブロックが並ぶため、見出し・余白・行の作りを完全に揃える */
+.related-post .card > h2,
+.reference-lede {
+  padding: 0.8em 0.8em 0.4em;
   margin: 0;
   font-size: 1.2em;
+  font-weight: bold;
   border-bottom: none;
 }
-.related-post .card .widget {
-  padding: 0 0.6em;
+.related-post-link,
+.reference-post-link {
+  padding: 0 0.8em 0.6em;
+  margin: 0;
+  list-style: none;
 }
-.related-post-link li {
+.related-posts-item,
+.reference-posts-item {
+  list-style: none;
+  padding: 0.5em 0;
   border-bottom: 1px solid #ecebeb;
 }
-.related-post-link li:last-child {
+.related-posts-item:last-child,
+.reference-posts-item:last-child {
   border-bottom: none;
+}
+/* タイトルの後ろに続くメタ情報。日付と反響の数は判断材料であって
+   見出しではないので、小さく淡い色で添える */
+.post-meta {
+  display: inline-block;
+  margin-left: 0.6em;
+  font-size: 0.85em;
+  color: #999;
+  white-space: nowrap;
+}
+.post-meta-date {
+  margin-right: 0.5em;
 }
 /* 一覧ページ */
 .list-page {
@@ -1123,19 +1144,8 @@ input[name="tab_item"]   {
 .news-title {
   padding-left: 0.5em;
 }
-.reference-lede {
-  padding: 1em 0 0 0.6em;
-  font-weight: bold;
-}
-.reference-posts-item {
-  list-style: none;
-  padding: 0 0 0 0;
-}
 .reference-posts-item a {
   color: #424242;
-}
-.reference-post-link {
-  padding: 0.4em 0 0 0.6em;
 }
 .list-sub-text {
   font-size: 18px;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -952,6 +952,13 @@ code {
 .tag-cloud a {
   margin: 0 0 5px 5px;
 }
+/* metronic の `.featured-post, .related-post { padding: 20px 0 0 10px }` により
+   関連記事のカードだけ上と左に余白が付き、参照記事のカードとずれていた。
+   card 自体が枠を持つので、section 側の余白は不要 */
+.related-post {
+  padding: 0;
+}
+
 /* 関連記事は著者が書いた本文ではなく自動生成のブロックなので、
    「この記事を参照している記事」と同じ card で囲って区別する。
    2つのブロックが並ぶため、見出し・余白・行の作りを完全に揃える */

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1087,16 +1087,22 @@ input[name="tab_item"]   {
 .techcast li {
   border-bottom: 1px solid #ECEBEB;
 }
+/* 新着の目印。以前は白抜き＋濃い背景の塗りバッジで、タイトルより主張が
+   強かった。隣に並ぶ .post-meta（日付・反響数）と同じく控えめな添え物として
+   扱い、枠線だけの表現にする */
 .newitem{
-  color: rgb(255, 255, 255);
-  padding: 2px 4px 1px 4px;
+  color: #8a8a8a;
+  padding: 0 4px;
+  margin-left: 0.4em;
   display: inline-block;
   box-sizing: border-box;
-  background-color: #424242;
-  border-radius: 14px;
-  font-weight: bold;
-  font-size: 11px;
-  line-height: 1.4;
+  background-color: transparent;
+  border: 1px solid #dcdcdc;
+  border-radius: 3px;
+  font-weight: normal;
+  font-size: 10px;
+  line-height: 1.6;
+  vertical-align: middle;
 }
 .search-wrapper {
   margin: 45px auto 50px auto;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -991,6 +991,13 @@ code {
 .post-meta-date {
   margin-right: 0.5em;
 }
+/* ♡（U+2661）は細い輪郭の記号で、小さくすると線が潰れて欠けて見える。
+   メタ情報の中では少し大きめにし、字送りにも余裕を持たせる */
+.snscount {
+  font-size: 1.15em;
+  letter-spacing: 0.03em;
+  padding-right: 0.1em;
+}
 /* 一覧ページ */
 .list-page {
   font-weight: bold;

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -29,9 +29,12 @@
           <%- partial('social-button', {feed:false}) %>
           </section>
           <aside>
+            <%# 自動生成のブロックであることが分かるよう、「この記事を参照している記事」と同じ card で囲う %>
             <section class="related-post margin-bottom-40 nav" data-nosnippet>
-              <h2 id="related"><a href="#related" class="headerlink" title="関連記事"></a>関連記事</h2>
-              <%- list_related_posts(post) %>
+              <div class="card">
+                <h2 id="related"><a href="#related" class="headerlink" title="関連記事"></a>関連記事</h2>
+                <%- list_related_posts(post) %>
+              </div>
             </section>
             <section class="reference-post margin-bottom-40 nav" data-nosnippet>
               <%- list_reference_posts(post) %>


### PR DESCRIPTION
Closes #1932

## 概要

「関連記事」を card で囲い、あわせて「この記事を参照している記事」とレイアウトを統合します。

## 経緯

当初は #1932 のとおり card で囲うだけでしたが、2つのブロックが並んだ結果、**余白も表示項目も揃っていないことが目立つ**状態になりました。囲いを揃えるだけでは不十分だったため、中身まで統合します。

## 1. 囲い

「この記事を参照している記事」は `scripts/reference_posts.js` が `<div class="card">` を出力していたのに対し、「関連記事」は `_partial/article.ejs` で `<h2>` と `<div class="widget">` を並べているだけでした。同じ自動生成ブロックなのに実装が分かれていたのが原因です。関連記事にも同じ `.card` を適用し、見出しも枠内に収めます。

## 2. 余白のずれ

`ul` の `padding` が両者で異なり、**関連記事だけ右にずれて**いました。

```styl
// 変更前
.reference-post-link { padding: 0.4em 0 0 0.6em; }
.related-post-link   { （指定なし。ul の既定 padding が効く） }
```

見出し・リスト・各行の余白を共通のセレクタで定義し直し、完全に揃えます。

## 3. 表示項目

関連記事は日付と反響数を持ち、参照記事はタイトルのみでした。同じ体裁で並ぶ以上ここも揃えるべきなので、**参照記事側に日付と反響数を追加**します。

## 4. 並び順

**日付 → 反響数 → タイトル** を **タイトル → 日付 → 反響数** に変えます。

読み手はまず「何の記事か」を見て、興味があれば「古くないか」を日付で確認し、最後に「評判はどうか」を反響数で見てクリックします。**日付を先頭に置いても読む理由にはなりません。** 判断の順序に並びを合わせます。

日付と反響数は判断材料であって見出しではないので、`.post-meta` として小さく淡い色（`0.85em` / `#999`）で添えます。

## 出力例

```
関連記事    ゼロから始めるFlutter生活          2020.06.03 ♡10
参照記事    Flutterの使いかた、環境構築から…    2021.12.21 ♡33
```

## 動作確認

`hexo clean` からフルビルド、エラー0件。両ブロックが揃った体裁で出力され、CSSも共通セレクタで適用されていることを確認しました。

## 確認のお願い

2つのブロックが**並んだときの見え方**がポイントです。左端が揃っているか、メタ情報が主張しすぎていないかをご確認ください。`.post-meta` の色・サイズは1箇所で調整できます。