### PR TITLE
サイドバーの目次の行間と余白を広げる

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -798,16 +798,22 @@ code {
 }
 .toc-section li > ol{
   list-style-type: none;
-  margin: 4px 0;
-  padding: 0 0 0 0.8em;
+  margin: 2px 0;
+  /* 下位の見出しであることが分かる程度に字下げする */
+  padding: 0 0 0 1em;
 }
+/* 以前は margin だけで上下のパディングが無く、行が詰まって見えるうえ、
+   ホバー時の背景も文字に密着していた。パディングで行の高さを確保し、
+   クリック領域も広げる */
 .toc-section a {
   list-style-type: none;
-  margin: 4px 0;
+  margin: 1px 0;
+  padding: 5px 8px;
   display: block;
   color: #424242;
   text-decoration: none;
-  line-height: 1.5;
+  line-height: 1.6;
+  border-radius: 3px;
 }
 .toc-section a:hover, .toc-section a:focus {
   background-color: #efefef;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -808,7 +808,7 @@ code {
 .toc-section a {
   list-style-type: none;
   margin: 1px 0;
-  padding: 5px 8px;
+  padding: 4px 8px;
   display: block;
   color: #424242;
   text-decoration: none;


### PR DESCRIPTION
Closes #1957

## 現状

目次のリンクは `margin` と `line-height` だけで、**上下のパディングがありませんでした**。

```styl
.toc-section a {
  margin: 4px 0;
  display: block;
  line-height: 1.5;
}
```

このため行が詰まって見えるうえ、ホバー時の背景（`#efefef`）が文字に密着し、どこが1項目なのか分かりにくい状態でした。調べた記事では目次が22項目あり、密度の影響が出やすい構造です。

## 対応

| | 変更前 | 変更後 |
| --- | --- | --- |
| 行の余白 | `margin: 4px 0` のみ | `padding: 5px 8px` を追加、`margin: 1px 0` |
| 行間 | `line-height: 1.5` | `1.6` |
| 入れ子の字下げ | `0.8em` | `1em` |
| ホバー | 文字に密着 | 角丸＋パディング分の領域が反応 |

`margin` ではなく `padding` で高さを確保したので、**ホバー・クリックの領域も広がります**。以前フッターのリンクで対応したタップターゲットの話と同じ考え方です。

入れ子の字下げを少し増やしたのは、`toc-level-2` / `toc-level-3` の階層が視覚的に分かりやすくなるためです。

## 動作確認

`hexo clean` からフルビルド、エラー0件。生成CSSに反映されていることを確認しました。

## 確認のお願い

サイドバーは記事によって項目数が大きく変わります。**項目が多い記事**（20項目以上）で縦に伸びすぎないか、逆に**項目が少ない記事**で間延びしないかをご確認ください。数値は `.toc-section a` の `padding` 1箇所で調整できます。