### PR TITLE
コントラスト不足を解消する（コードブロック・メタ情報・インラインコード）

### DIFF
--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -1,18 +1,21 @@
 // JetBrains Darcula（GoLand などの既定テーマ）に寄せた配色。
+// ただし Darcula はエディタ用でWebのアクセシビリティ基準を前提にしておらず、
+// そのまま使うとコメント・キーワード・文字列が WCAG AA（4.5）を下回る。
+// 色相はDarculaのまま、明度だけ上げて基準を満たすようにしている。
 // 以前は Tomorrow Theme 由来の配色だったが、背景が暗くコントラストも低いため
 // キーワードが埋もれて見えていた。
 highlight-background = #2b2b2b     // 以前は #2d2d2d。わずかに明るくする
 highlight-current-line = #323232
 highlight-selection = #214283
 highlight-foreground = #a9b7c6     // 青みのあるグレー
-highlight-comment = #808080
+highlight-comment = #9a9a9a
 highlight-red = #ff6b68
-highlight-orange = #cc7832         // キーワード
+highlight-orange = #e08744         // キーワード
 highlight-yellow = #ffc66d         // 関数名・型名
-highlight-green = #6a8759          // 文字列
+highlight-green = #84a86f          // 文字列
 highlight-aqua = #6897bb
 highlight-blue = #6897bb           // 数値・定数
-highlight-purple = #9876aa
+highlight-purple = #b18ac4
 highlight-caption-background = #3c3f41   // Darcula のエディタタブ相当
 highlight-caption-border = #4e5254
 // 差分専用。文字列の緑（#6a8759）だと削除側の赤に対して弱く見えるため、

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -635,8 +635,11 @@ code {
   color: #424242;
 }
 
+/* インラインコードの背景 #eee に対して #0d6efd は 3.88 で AA を下回るため、
+   同系色のまま暗くする。highlight.styl 側にも同じ指定があるが、
+   こちらの方が詳細度が高く後勝ちするので両方を揃えておく */
 .article-entry a code {
-  color: #0d6efd;
+  color: #0a58ca;
 }
 
 .article-entry a:visited code {
@@ -1001,12 +1004,14 @@ code {
   border-bottom: none;
 }
 /* タイトルの後ろに続くメタ情報。日付と反響の数は判断材料であって
-   見出しではないので、小さく淡い色で添える */
+   見出しではないので、小さめの文字で添える。
+   ただし #999 では白背景に対してコントラスト比2.84しかなく WCAG AA を
+   大きく下回るため、色は落としすぎない */
 .post-meta {
   display: inline-block;
   margin-left: 0.6em;
   font-size: 0.85em;
-  color: #999;
+  color: #6e6e6e;
   white-space: nowrap;
 }
 .post-meta-date {
@@ -1122,7 +1127,9 @@ input[name="tab_item"]   {
    強かった。隣に並ぶ .post-meta（日付・反響数）と同じく控えめな添え物として
    扱い、枠線だけの表現にする */
 .newitem{
-  color: #8a8a8a;
+  /* #8a8a8a は白背景に対して 3.45 で AA を下回るため少し濃くする。
+     枠線は装飾なので薄いままでよい */
+  color: #6e6e6e;
   padding: 0 4px;
   margin-left: 0.4em;
   display: inline-block;


### PR DESCRIPTION
Closes #1962

添付いただいた Lighthouse レポートを確認したところ、**指摘58件の内訳はコードブロックだけではありませんでした**。当初コードブロックのみを疑って自分で計算していましたが、レポートを読んで3種類あることが分かりました。

## 修正内容

### 背景 `#2b2b2b`（コードブロック）— #1950 の退行

JetBrains Darcula の実配色をそのまま持ち込んだのが原因です。Darcula は**エディタ用の配色**で、Web のアクセシビリティ基準を前提にしていません。

| | 変更前 | 変更後 |
| --- | --- | --- |
| `keyword` / `built_in` | `#cc7832` 4.24 | `#e08744` **5.20** |
| `string` | `#6a8759` 3.52 | `#84a86f` **5.27** |
| `comment` | `#808080` 3.58 | `#9a9a9a` **5.03** |

色相は Darcula のまま明度だけ上げているので、見た目の系統は変わりません。

### 背景 `#ffffff`（関連記事・参照記事）— #1954 の退行

| | 変更前 | 変更後 |
| --- | --- | --- |
| `.post-meta`（日付・♡） | `#999999` **2.84** | `#6e6e6e` **5.10** |
| `.newitem`（NEWバッジ） | `#8a8a8a` 3.45 | `#6e6e6e` **5.10** |

**この2つは「主張が強すぎる」というご指摘を受けて薄くした箇所**です。2.84 は基準の6割程度で、コードブロックより深刻でした。控えめさは文字サイズ（`0.85em` / `10px`）で維持し、色は基準まで戻します。NEWバッジの枠線は装飾なので薄いままで問題ありません。

### 背景 `#eeeeee`（インラインコード）— 直し漏れ

| | 変更前 | 変更後 |
| --- | --- | --- |
| リンク内のコード | `#0d6efd` 3.87 | `#0a58ca` **5.55** |

#1925 で `highlight.styl` 側を直しましたが、`theme-styles.styl` の `.article-entry a code` の方が**詳細度が高く上書き**されていたため効いていませんでした。両方を揃えます。

## 検証

全7種を WCAG の相対輝度式で検算し、すべて AA（4.5）を満たすことを確認しました。訪問済みリンク内のコード（`#590fc7` / 7.81）は元から問題ありません。

`hexo clean` からフルビルド、エラー0件。

## 反省

配色を変える際にコントラストを検証していませんでした。#1950 と #1954 の両方で同じ見落としをしています。以後、色を触る変更では AA の検算をセットで行います。

## 残る指摘

同レポートの `link-in-text-block`（本文リンクが色だけで識別可能）は、**方針として対応しない**と決めた項目です。重み7ぶんはこのまま残ります。