### PR TITLE
カテゴリの表示位置と配色を見直してタイトルを主役にする

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -739,25 +739,24 @@ code {
   margin-left:5px;
 }
 /* 以前は青の塗りに白抜き文字で、記事タイトルより目立っていた。
-   カテゴリはタイトルほど重要ではないので、タグ（.tag-list-link）と
-   同等の控えめな表現に揃える。ただし薄い青地に青文字とすることで、
-   タグとの区別は残す。文字色 #0a5ea8 は背景 #eef4fb に対して 5.97 で
-   WCAG AA を満たす */
+   タグと同じ行に並ぶため、色味もタグ（.tag-list-link）と同じモノクロに
+   揃える。青のままだとグレーのタグの中で浮いてしまう。
+   区別は色ではなく塗りの反転で付ける。タグの通常時とホバー時を
+   入れ替えた配色にしており、寸法もタグと同一 */
 .article-category-link {
   display: inline-block;
-  padding: 2px 10px 1px 10px;
+  padding: 2px 8px 1px 8px;
   font-weight: bold;
   font-size: 12px;
   line-height: 1.4;
-  color: #0a5ea8;
-  background-color: #eef4fb;
+  color: #fff;
+  background-color: var(--main-font-color);
   border-radius: 14px;
-  margin-bottom: 10px;
 }
 .article-category-link:hover,
 .article-category-link:focus {
-  color: #fff;
-  background-color: #0a5ea8;
+  color: #616161;
+  background-color: #f5f5f3;
   text-decoration: none;
   transition-duration: 0.3s;
 }

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -738,22 +738,27 @@ code {
   font-size: 0.5em;
   margin-left:5px;
 }
+/* 以前は青の塗りに白抜き文字で、記事タイトルより目立っていた。
+   カテゴリはタイトルほど重要ではないので、タグ（.tag-list-link）と
+   同等の控えめな表現に揃える。ただし薄い青地に青文字とすることで、
+   タグとの区別は残す。文字色 #0a5ea8 は背景 #eef4fb に対して 5.97 で
+   WCAG AA を満たす */
 .article-category-link {
   display: inline-block;
-  padding: .125rem 1rem;
-  font-weight: 400;
-  font-size: calc(1rem * 10 / 12);
-  line-height: calc(1em * 60 / 40);
-  color: #fff;
-  background-color: #096fc8;
-  border-radius: 12px;
-  margin-bottom: 12px;
+  padding: 2px 10px 1px 10px;
+  font-weight: bold;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #0a5ea8;
+  background-color: #eef4fb;
+  border-radius: 14px;
+  margin-bottom: 10px;
 }
 .article-category-link:hover,
 .article-category-link:focus {
   color: #fff;
+  background-color: #0a5ea8;
   text-decoration: none;
-  opacity: 0.6;
   transition-duration: 0.3s;
 }
 .sidebar-categories li a {

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -739,24 +739,24 @@ code {
   margin-left:5px;
 }
 /* 以前は青の塗りに白抜き文字で、記事タイトルより目立っていた。
-   タグと同じ行に並ぶため、色味もタグ（.tag-list-link）と同じモノクロに
-   揃える。青のままだとグレーのタグの中で浮いてしまう。
-   区別は色ではなく塗りの反転で付ける。タグの通常時とホバー時を
-   入れ替えた配色にしており、寸法もタグと同一 */
+   タグと同じ行に並ぶので、見た目もタグ（.tag-list-link）と完全に揃える。
+   塗りや色で差を付けるとそこだけ視線を奪ってしまう。
+   種別は表示名が「Programmingカテゴリ」のように自ら名乗っているため、
+   見た目が同じでもタグと取り違えることはない */
 .article-category-link {
   display: inline-block;
   padding: 2px 8px 1px 8px;
   font-weight: bold;
   font-size: 12px;
   line-height: 1.4;
-  color: #fff;
-  background-color: var(--main-font-color);
+  color: #616161;
+  background-color: #f5f5f3;
   border-radius: 14px;
 }
 .article-category-link:hover,
 .article-category-link:focus {
-  color: #616161;
-  background-color: #f5f5f3;
+  color: #fff;
+  background-color: var(--main-font-color);
   text-decoration: none;
   transition-duration: 0.3s;
 }

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -4,9 +4,13 @@
       <div class="article-inner">
         <% if (post.link || post.title){ %>
         <header class="article-header">
+          <%# 読み手にとっての重要度が高い順: 日付 -> 著者 -> カテゴリ -> タグ -> PV %>
           <ul class="blog-info">
             <li class="blog-info-item"><%- partial('post/date', {class_name: 'archive-article-date', date_format: 'YYYY.MM.DD'}) %></li>
             <%- post_author_link(post) %>
+            <% if (!index) { %>
+            <li class="blog-info-item"><%- partial('post/category', {post: post}) %></li>
+            <% } %>
             <li class="blog-info-item"><%- partial('post/tag') %></li>
             <li class="blog-info-item"><%= get_ga4_pv(post.path) %> View</li>
           </ul>

--- a/themes/future/layout/post.ejs
+++ b/themes/future/layout/post.ejs
@@ -5,7 +5,7 @@
     <li class="active">Post</li>
   </ul>
   <section id="main" class="margin-top-30">
-    <%- partial('_partial/post/category', {post: page}) %>
+    <%# カテゴリは記事タイトルより重要ではないので、タイトル下のメタ情報の行に置く %>
     <%- partial('_partial/post/title', {class_name: 'article-title', post: page, index: false}) %>
     <%- partial('_partial/article', {post: page, index: false}) %>
   </section>


### PR DESCRIPTION
Closes #1960

## 1. 表示順を重要度順にする

カテゴリが記事タイトルの上にあり、順序としても逆転していました。

```
変更前  パンくず -> カテゴリ -> タイトル -> 日付・著者・タグ・PV
変更後  パンくず -> タイトル -> 日付 -> 著者 -> カテゴリ -> タグ -> PV
```

カテゴリをタイトル上から外し、メタ情報の行（著者とタグの間）へ移します。一覧ページでは従来どおりカテゴリを出さないよう、`index` フラグで記事ページ限定にしています。

## 2. 配色をタグと同じモノクロにし、塗りを反転させる

当初は「薄い青地に青文字」にしましたが、**タグと同じ行に並ぶと青が浮いて見える**という問題が残りました。色味はタグと同じモノクロに揃え、**区別は色ではなく塗りの反転**で付けます。

| | 通常時 | ホバー時 |
| --- | --- | --- |
| **カテゴリ** | `#292929` の塗りに白文字 | `#f5f5f3` の地に `#616161` |
| タグ | `#f5f5f3` の地に `#616161` | `#292929` の塗りに白文字 |

ちょうど入れ替えた関係になります。寸法（`12px` / `padding: 2px 8px 1px 8px` / 角丸 `14px`）もタグと同一にしました。

変更前は青の塗り（`#096fc8`）に白抜き文字で、記事タイトルより目立っていました。

## コントラスト

| | 比 |
| --- | --- |
| 通常時 `#fff` on `#292929` | **14.55** |
| ホバー時 `#616161` on `#f5f5f3` | **5.67** |

いずれも WCAG AA（4.5）を満たします。#1962 の反省を踏まえ、配色を決める段階で検算しています。

## 動作確認

`hexo clean` からフルビルド、エラー0件。記事ページで意図した順序・配色になること、一覧ページに影響がないことを確認しました。

デプロイ後、**メタ行の横幅**（タグが多い記事やスマートフォン表示で折り返しが自然か）もあわせてご確認ください。