### PR TITLE
.claude/settings.local.json を .gitignore に追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ credential.json
 
 # snssharecount の出力用一時ファイル（update-cache.yml が生成する）
 temp.json
+
+# Claude Code の個人設定（承認済みコマンドの許可リストなど）
+.claude/settings.local.json


### PR DESCRIPTION
Claude Code の個人設定ファイルです。承認済みコマンドの許可リストなど利用者ごとに異なる内容が入るため、追跡対象から外します。

```
# Claude Code の個人設定（承認済みコマンドの許可リストなど）
.claude/settings.local.json
```

なお `.claude/` ディレクトリ自体は除外していません。将来チーム共有の設定（`.claude/settings.json`）を置く可能性を残すためです。