### PR TITLE
引用を左ボーダーだけの表現にする

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -94,16 +94,8 @@ h4 {
 /* 引用は左ボーダーだけで示す。以前はグレーの背景も敷いていたが、
    技術ブログ系のサービス（Zenn / Qiita / はてなブログ）はいずれも
    左ボーダーのみで、背景を敷く例は少ない。
-   文字サイズも本文と揃える。引用は補足ではなく本文の一部なので、
-   小さくすると読み飛ばされやすくなる */
-/* 文字色は blockquote ではなく中の p / li に指定する。
-   .article-entry p が color: #424242 を持っており、blockquote 側に
-   指定しても中身の p には届かないため */
-.article-entry blockquote,
-.article-entry blockquote p,
-.article-entry blockquote li {
-  color: #555;
-}
+   文字サイズ・文字色とも本文と同じにする。引用は補足ではなく本文の
+   一部であり、色数を増やさないほうが指定漏れの事故も起きにくい */
 blockquote p {
   margin: 0.5rem 0 0.5rem 0;
 }

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -96,7 +96,12 @@ h4 {
    左ボーダーのみで、背景を敷く例は少ない。
    文字サイズも本文と揃える。引用は補足ではなく本文の一部なので、
    小さくすると読み飛ばされやすくなる */
-.article-entry blockquote {
+/* 文字色は blockquote ではなく中の p / li に指定する。
+   .article-entry p が color: #424242 を持っており、blockquote 側に
+   指定しても中身の p には届かないため */
+.article-entry blockquote,
+.article-entry blockquote p,
+.article-entry blockquote li {
   color: #555;
 }
 blockquote p {

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -91,11 +91,13 @@ h4 {
 .article-entry li li {
   font-size: 1.0em;
 }
+/* 引用は左ボーダーだけで示す。以前はグレーの背景も敷いていたが、
+   技術ブログ系のサービス（Zenn / Qiita / はてなブログ）はいずれも
+   左ボーダーのみで、背景を敷く例は少ない。
+   文字サイズも本文と揃える。引用は補足ではなく本文の一部なので、
+   小さくすると読み飛ばされやすくなる */
 .article-entry blockquote {
-  font-size: 0.9em;
-}
-.blog-item blockquote {
-  background-color: #f8f9fa;
+  color: #555;
 }
 blockquote p {
   margin: 0.5rem 0 0.5rem 0;
@@ -770,8 +772,8 @@ code {
   margin: 6px 0 25px;
 }
 .blog-item blockquote {
-  padding: 6px 10px;
-  border-left: 4px solid #adb5bd;
+  padding: 2px 0 2px 16px;
+  border-left: 4px solid #d9d9d9;
 }
 .blog-item .blog-info {
   margin: 20px 0;


### PR DESCRIPTION
Closes #1958

## 現状

引用にグレーの背景を敷き、さらに左ボーダーもあり、文字サイズも本文より小さいという三重の装飾になっていました。

```styl
.article-entry blockquote { font-size: 0.9em; }
.blog-item blockquote {
  background-color: #f8f9fa;        /* 背景 */
  padding: 6px 10px;
  border-left: 4px solid #adb5bd;   /* 左ボーダー */
}
```

技術ブログ系のサービス（Zenn / Qiita / はてなブログ）はいずれも**左ボーダーのみ**で、背景を敷く例は少数派です。読み手が読み慣れた形に合わせます。

## 変更内容

| | 変更前 | 変更後 |
| --- | --- | --- |
| 背景色 | `#f8f9fa` | **廃止** |
| 左ボーダー | `#adb5bd` 4px | `#d9d9d9` 4px |
| padding | `6px 10px` | `2px 0 2px 16px` |
| 文字サイズ | `0.9em`（本文より小） | **本文と同じ** |
| 文字色 | 本文と同じ | **本文と同じ（変更なし）** |

ボーダーを薄くしたのは、背景が無くなるぶん相対的に強く見えるためです。padding は左を広げて、ボーダーと文字の距離を確保しました。

**文字サイズを本文に揃えた**のは、引用が補足ではなく本文の一部だからです。小さくすると読み飛ばされやすくなります。

**引用であることは左ボーダーだけで示します。** 途中で文字色を `#555` にする案を試しましたが、本文の `#424242` との差が実際にはほとんど判別できず、区別の役に立っていませんでした。色数を増やさないほうが指定漏れの事故も起きにくいため、色指定は入れていません。

## 影響範囲

**引用を使っている記事は340件**（全1466記事の23%）と広範です。デプロイ後、引用が長い記事・短い記事の両方でご確認ください。

引用の中にコードブロックや箇条書きを含む記事もあるため、背景が無くなったことで区切りが分かりにくくなっていないかが確認ポイントです。弱すぎる場合は、ボーダーの色（`#d9d9d9`）を濃くするか `padding-left` を広げるかで調整できます。

## 動作確認

`hexo clean` からフルビルド、エラー0件。生成CSSから背景色と文字色指定が消え、左ボーダーのみになっていることを確認しました。