### PR TITLE
We're hiring のカードを横並びのコンパクトな構成にする

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -277,6 +277,39 @@ body.page-header-fixed .header {
   margin: 0 0 32px 0;
   border-radius: 8px
 }
+/* We're hiring のカード。以前は画像がカード幅の半分を占め、さらに
+   .article-card の padding と Bootstrap の p-3 が二重にかかっていて、
+   場所を取る割に情報量が薄かった。
+   サムネイルを左に小さく固定し、見出しと説明を右に積む横並びにする */
+.career-counseling .article-card {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 12px;
+  margin: 0;
+  border: 1px solid #eee;
+}
+.hiring-card-thumb {
+  flex: 0 0 88px;
+  line-height: 0;
+}
+.hiring-card-thumb img {
+  width: 88px;
+  height: auto;
+  border-radius: 4px;
+}
+.hiring-card-body {
+  min-width: 0;
+}
+.hiring-card-label {
+  display: block;
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+.career-counseling .lede {
+  font-size: 0.9em;
+  line-height: 1.6;
+}
 /******************************
  見出し
 ******************************/

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -49,22 +49,16 @@
               <p>フューチャーで一緒に働く仲間を大募集しています！ また、様々なコンテンツも公開中です。</p>
 
               <div class="row g-4">
+                <%# サムネイルを左に小さく置き、見出しと説明を右に積む横並びの構成。
+                    以前は画像がカード幅の半分を占め、場所の割に情報量が薄かった %>
                 <% hiring_panels(post).forEach(function(panel){ %>
                 <div class="col-12 col-md-6">
-                  <div class="article-card h-100 p-3" style="border: 1px solid #eee; border-radius: 8px;">
-                    <div class="row mb-3">
-                      <div class="col-6">
-                        <a href="<%= panel.url %>" title="<%= panel.title %>" class="img_wrap">
-                          <img src="<%= panel.image %>" class="img-fluid" alt="<%= panel.title %>" width="200" height="135" loading="lazy">
-                        </a>
-                      </div>
-                      <div class="col-6 d-flex align-items-center">
-                        <a href="<%= panel.url %>">
-                          <div style="font-weight:bold;"><%= panel.label %></div>
-                        </a>
-                      </div>
-                    </div>
-                    <div>
+                  <div class="article-card h-100">
+                    <a href="<%= panel.url %>" title="<%= panel.title %>" class="img_wrap hiring-card-thumb">
+                      <img src="<%= panel.image %>" alt="<%= panel.title %>" width="200" height="135" loading="lazy">
+                    </a>
+                    <div class="hiring-card-body">
+                      <a href="<%= panel.url %>" class="hiring-card-label"><%= panel.label %></a>
                       <div class="lede"><%= panel.lede %></div>
                     </div>
                   </div>


### PR DESCRIPTION
Closes #1963

## 無駄が3か所ありました

**1. パディングの二重がけ**

```html
<div class="article-card h-100 p-3" style="...">
```

`.article-card` が `padding: 24px 20px 0 20px` を持っているうえに、Bootstrap の `p-3`（16px）も付いていました。実質40px前後の余白が四方にかかっていました。

**2. 画像がカード幅の半分を占有**

`col-6` にサムネイル、`col-6` にラベルという構成で、**説明文はその下に押し出されて**いました。カードの上半分が画像とラベルだけに使われていた形です。

**3. インライン `style` の重複**

`border` と `border-radius` がインラインで書かれており、CSS 側と二重管理になっていました。

## 変更内容

サムネイルを左に **88px 固定**で置き、見出しと説明を右に積む横並びにします。

```
変更前                    変更後
┌──────────────┐         ┌──────────────────┐
│ [ 画像 ] ラベル │         │ [小] ラベル        │
│              │         │      説明文……     │
│ 説明文……      │         └──────────────────┘
└──────────────┘
```

| | 変更前 | 変更後 |
| --- | --- | --- |
| パディング | `24px 20px` ＋ `p-3`（二重） | `12px`（一重） |
| サムネイル | カード幅の50% | 88px 固定 |
| 説明文の位置 | 画像・ラベルの下 | ラベルの直下（右側） |
| `border` 指定 | インライン `style` | CSS へ集約 |
| 説明文のサイズ | 本文と同じ | `0.9em` |

`margin: 0 0 32px 0` も外しました。`row g-4` が既にカード間の余白を持っているためです。

## 動作確認

`hexo clean` からフルビルド、エラー0件。2枚のカードが意図した構造で出力され、インライン `style` が消えていることを確認しました。

```
1. フューチャー採用ページ ／ 私たちは、多様なバックグラウンドを持つ人材が…
2. コーディング規約     ／ フューチャー株式会社が作成するエンタープライズ…
```

## 確認のお願い

デプロイ後、**スマートフォン表示**をご確認ください。`col-md-6` なので幅768px未満では2枚が縦に並びます。サムネイル88pxが小さすぎないか、説明文の折り返しが窮屈でないかが確認ポイントです。

サムネイルの寸法は `.hiring-card-thumb` の1箇所で調整できます。