### PR TITLE
記事ページのサイドバーからカテゴリ一覧を外す

### DIFF
--- a/themes/future/layout/_partial/sidebar.ejs
+++ b/themes/future/layout/_partial/sidebar.ejs
@@ -15,11 +15,14 @@
   <%- toc(page.content, {list_number:false, max_depth:4}) %>
 </section>
 <% } %>
+<%# カテゴリは記事ページでは出さない。記事を読んでいる最中のサイドバーでは
+    目次と並んで導線が競合し、本文から目を逸らすノイズになる。
+    記事からの回遊は、記事末の「関連記事」「この記事を参照している記事」が担う %>
+<% if (!is_post()) { %>
 <section class="category">
 <h2 class="margin-top-30">カテゴリー</h2>
 <%- partial('_widget/category.ejs') %>
 </section>
-<% if (!is_post()) { %>
 <section class="podcast-link">
 <h2 class="margin-top-30">Tech Cast</h2>
 <%- generate_techcast_post() %>


### PR DESCRIPTION
Closes #1964

## 現状

`sidebar.ejs` を見ると、**カテゴリだけが `is_post()` の分岐の外**にあり、全ページで表示されていました。

```
記事ページ    目次(22件) → カテゴリー(16件)
一覧ページ    検索 → カテゴリー(16件) → Tech Cast → アドベントカレンダー
```

記事ページでは目次のすぐ下にカテゴリ16件が続きます。PCではサイドバーに目次があるため、**同じ場所に2種類のナビゲーションが並ぶ**状態でした。

## 判断

記事を読んでいる最中にカテゴリをクリックする可能性は低く、本文から目を逸らすノイズになっていると考えます。

記事からの回遊は、記事末の**「関連記事」「この記事を参照している記事」**が担っています。この2つは直近の作業（#1907 / #1908 / #1954）でスコアリングとレイアウトを整えたところで、そちらに集約するほうが筋が通ります。

カテゴリ一覧は、トップ・一覧・タグページなど**これから読む記事を探す文脈**でのみ表示します。

## 変更後

| ページ | サイドバー |
| --- | --- |
| 記事ページ | 目次のみ |
| トップ・一覧 | 検索 → カテゴリー → Tech Cast → アドベントカレンダー |
| カテゴリ・タグページ | 検索 → カテゴリー → Tech Cast → アドベントカレンダー |

既にあった `is_post()` の分岐にカテゴリを移すだけで、他のページの表示は変わりません。

## 動作確認

`hexo clean` からフルビルド、エラー0件。記事ページで目次のみになること、トップ・カテゴリ・タグの各ページは従来どおりであることを確認しました。

## 補足

記事ページのサイドバーが目次だけになるので、目次が短い記事（見出しが数個）では**サイドバーに余白が目立つ**可能性があります。デプロイ後、見出しの少ない記事もあわせてご確認ください。気になる場合は、代わりに何を置くか（あるいは何も置かないか）を別途検討できます。