### PR TITLE
テーブルのヘッダに地色を敷き、ゼブラを廃止する

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -285,7 +285,7 @@ body.page-header-fixed .header {
   display: flex;
   gap: 12px;
   align-items: flex-start;
-  padding: 12px;
+  padding: 18px;
   margin: 0;
   border: 1px solid #eee;
 }

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -552,12 +552,14 @@ th, td {
 th {
   // 900 は Hiragino / Yu Gothic に該当ウェイトが無く、ブラウザの合成太字になって輪郭が濁る
   font-weight: 700;
-  background-color: #edf2f7;
+  // 従来のゼブラと同じ中立グレー。Zenn は青みのある #edf2f7 だが、
+  // 本ブログの配色では水色に寄って浮くため、見慣れた無彩色をそのまま使う
+  background-color: #f2f2f2;
 }
 // インラインコードの地色 #eee はヘッダの地色とほぼ同じ明度で、そのままだと溶ける。
 // ヘッダ内では一段暗くして、本文セル（白地に #eee）と同じ「浮いて見える」関係を保つ
 .article-entry th code {
-  background: #dde4ec;
+  background: #e2e2e2;
 }
 .highlight .pre {
   margin-bottom: 50px;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -528,40 +528,36 @@ ul.social-button li a {
 .scroll {
   overflow-x: auto;
 }
+/*
+  テーブルはヘッダに地色を敷き、本文行は白で揃える（Zenn と同じ構成）。
+
+  以前はヘッダが白でデータ1行目に縞が入っていたため、構造の起点である
+  ヘッダより下の行の方が目立つ逆転が起きていた。
+  行を目で追う役割は全セルの罫線がすでに果たしており、縞は二重の仕掛けだった。
+  記事中のテーブル789個を数えると中央値4行・73%が6行以下で、
+  縞が効く長さの表はそもそも少ない。
+*/
+table-border = #ccc
+
 table {
-  table-layout:auto;
+  table-layout: auto;
   border-collapse: collapse;
-  border-left-width: 1px;
-  border-left-style: solid;
-  border-left-color: #d9d9d9;
-  margin-top: 0em;
-  margin-right: 2px;
-  margin-bottom: 2em;
-  margin-left: 2px;
+  margin: 0 2px 2em;
   background-color: white; // :::info の中で背景が塗りつぶされるため
 }
-.thead td, th {
-  font-weight: 900;
-  background-color: #fff;
-  border-top: solid 1px #ccc;
-  border-right: solid 1px #ccc;
+th, td {
+  border: solid 1px table-border;
   padding: 8px 10px;
 }
-tr {
-  display: table-row;
-  border-bottom: solid 1px #ccc;
-  border-right: solid 1px #ccc;
-  padding: 8px 10px;
-  padding-top: 8px;
+th {
+  // 900 は Hiragino / Yu Gothic に該当ウェイトが無く、ブラウザの合成太字になって輪郭が濁る
+  font-weight: 700;
+  background-color: #edf2f7;
 }
-td {
-  border-bottom: solid 1px #ccc;
-  border-right: solid 1px #ccc;
-  padding: 8px 10px;
-  padding-top: 8px;
-}
-tbody tr:nth-child(odd) {
-    background-color: rgba(0,0,0,0.05);
+// インラインコードの地色 #eee はヘッダの地色とほぼ同じ明度で、そのままだと溶ける。
+// ヘッダ内では一段暗くして、本文セル（白地に #eee）と同じ「浮いて見える」関係を保つ
+.article-entry th code {
+  background: #dde4ec;
 }
 .highlight .pre {
   margin-bottom: 50px;


### PR DESCRIPTION
close #1972

記事のテーブルは**ヘッダが白でデータ1行目に縞**が入っており、構造の起点であるヘッダより下の行の方が目立つ逆転が起きていた。

## 主要サービスの実CSS

出典は `zenn-content-css` / `github-markdown-css` / Qiita の配信CSS（`.it-MdContent`）。

| | ヘッダ背景 | ゼブラ | 着色開始 | 縞の色 | 罫線 |
| --- | --- | --- | --- | --- | --- |
| 本ブログ（変更前） | `#fff` | あり | データ**1行目** | `#f2f2f2` | 全セル |
| Qiita | `#fff` | あり | データ**1行目** | `#edeeee` | 全セル |
| GitHub | 白（bold 600） | あり | データ**2行目** | `#f6f8fa` | 全セル |
| **Zenn** | `#edf2f7` | **なし** | — | — | 全セル |

本ブログの現状は Qiita とほぼ同一で、縞の位相まで一致していた。「他サービスと違う」状態ではなかった。

## 構成は Zenn 型、色は従来のゼブラ色

構成（ヘッダに地色・本文は白・縞なし）は Zenn に合わせた。

- 本ブログは**全セルに罫線がある**ため、行を目で追う役割はすでに罫線が担っており、縞は二重の仕掛けになっていた
- 記事中のテーブル**789個**を数えると、データ行数は**中央値4行・73%が6行以下**（11行以上は11%）。縞が効く長さの表がそもそも少ない
- ヘッダに地色が入ることで、構造の起点が正しく際立つ

ただし色は Zenn の `#edf2f7` ではなく、**従来のゼブラと同じ `#f2f2f2`**（`rgba(0,0,0,0.05)` の実効値）を使う。`#edf2f7` は青みが強く、本ブログの配色では水色に寄って浮いたため。読者が見慣れた無彩色をそのままヘッダに移す形になる。

## 変更内容

```diff
-.thead td, th { font-weight: 900; background-color: #fff; ... }
-tr { display: table-row; border-bottom: ...; padding: 8px 10px; }
-td { border-bottom: ...; border-right: ...; padding: 8px 10px; }
-tbody tr:nth-child(odd) { background-color: rgba(0,0,0,0.05); }
+th, td { border: solid 1px #ccc; padding: 8px 10px; }
+th   { font-weight: 700; background-color: #f2f2f2; }
```

あわせて、この範囲にあった問題を整理した。

- **`th { font-weight: 900 }` → 700** — Hiragino / Yu Gothic に900のウェイトが無く、ブラウザの**合成太字**になって輪郭が濁っていた。Qiita は 700、GitHub は 600
- **`.thead td` はデッドコード** — markdown-it が出すのは `<thead>` 要素で、`.thead` というクラスは存在しない
- **`tr` の `padding`** — `tr` にパディングは効かないため削除
- **罫線の色の不揃い** — `table` の左だけ `#d9d9d9`、他は `#ccc` だったので統一

## 副作用の確認

- **コードブロック**も内部で `<table>` を使う（13ブロック中13個）が、`highlight.styl` の `.highlight td { border: none; padding: 0 }`（詳細度 0,1,1）が `th, td`（0,0,1）に勝つため影響しない
- **テーブルは全て `.article-entry` 配下**。トップ・タグ・著者ページには `<table>` が無いことを生成HTMLで確認済み
- **インラインコード**の地色 `#eee` はヘッダの `#f2f2f2` とほぼ同じ明度で溶けるため、ヘッダ内だけ `#e2e2e2` に。該当はヘッダ795行中**6行（0.8%）**と稀だが、本文セル（白地に `#eee`）と同じ明度差を保つ
- **コントラスト**（WCAG AA 4.5）: 本文 `#424242` on `#f2f2f2` = **8.98**、`#424242` on `#e2e2e2` = **7.76**、リンク内コード `#0a58ca` on `#e2e2e2` = **4.97**
- `th` の `text-align` は変更していない（Bootstrap Reboot の `th { text-align: inherit }` のまま左揃え）

## 同梱

テーブルとは無関係だが、作業中に手元に残っていた変更を最後のコミットで同梱した。

- **`.career-counseling .article-card` の `padding` を 12px → 18px** — We're hiring カードのサムネイルと見出しがカードの縁に近く窮屈だったため

🤖 Generated with [Claude Code](https://claude.com/claude-code)