### PR TITLE
コードブロックのファイル名を全幅バーからタブに変える

### DIFF
--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -63,35 +63,55 @@ $line-numbers
       background: none
       text-shadow: none
       padding: 0
+  // コードブロックの構造は figure.highlight > figcaption + table。
+  // 背景を figure ではなく table に持たせる。figure が背景を持つと
+  // ファイル名の行まで幅いっぱいに暗くなり、暗い面積がその分増える
   .highlight
-    @extend $code-block
+    margin: 0
+    overflow: auto
     pre
       border: none
       margin: 0
       padding: 0
+    // 横に長いコードでも背景が途切れないよう、内容幅まで伸ばしたうえで
+    // 最低でも親幅を確保する。スクロールは figure 側が受け持つ
     table
+      @extend $code-block
+      display: block
+      width: max-content
+      min-width: 100%
       margin: 0
-      width: auto
+      border-radius: 5px
     td
       border: none
       padding: 0
-    // ファイル名はコードブロック上部のバーとして一体化させる。
-    // 以前は本文と同じ余白の中に小さなグレー文字が浮いているだけで、
-    // どのコードブロックに対する名前なのか分かりにくかった。
-    // figure の padding（15px / article-padding）を負マージンで打ち消し、
-    // 左右いっぱいに広げている
+    // ファイル名は内容ぶんの幅だけを持つタブにする。
+    // 以前はコードブロック上部の全幅バーだったが、暗い面積を減らしたい。
+    // 本文と同じ余白に小さなグレー文字が浮いていた頃の
+    // 「どのコードブロックの名前か分からない」問題は、タブでも起きない
     figcaption
-      clearfix()
-      margin: -15px (article-padding * -1) 15px
-      padding: 7px article-padding
+      // inline-block だと行ボックスのベースライン分の隙間がタブの下に出るため、
+      // ブロックのまま内容幅に縮める
+      display: block
+      width: fit-content
+      max-width: 100%
+      margin: 0
+      padding: 6px article-padding
       background: highlight-caption-background
-      border-bottom: 1px solid highlight-caption-border
+      border: 1px solid highlight-caption-border
+      border-bottom: none
+      border-radius: 5px 5px 0 0
       color: highlight-foreground
       font-family: font-mono
       font-size: 0.85em
       line-height: 1.6
-      a
-        float: right
+      overflow: hidden
+      text-overflow: ellipsis
+      white-space: nowrap
+      vertical-align: bottom
+    // タブが乗る側だけ角を落として、タブと本体をつなげて見せる
+    figcaption + table
+      border-top-left-radius: 0
     .gutter pre
       @extend $line-numbers
       text-align: right

--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -109,9 +109,12 @@ $line-numbers
       text-overflow: ellipsis
       white-space: nowrap
       vertical-align: bottom
-    // タブが乗る側だけ角を落として、タブと本体をつなげて見せる
+    // タブが乗る側だけ角を落として、タブと本体をつなげて見せる。
+    // $code-block の上辺ボーダー（#ddd）はブロック全体の枠線だった頃の名残で、
+    // タブの直下に来ると明るい線がタブと本体を分断して見えるため落とす
     figcaption + table
       border-top-left-radius: 0
+      border-top: none
     .gutter pre
       @extend $line-numbers
       text-align: right

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -578,7 +578,7 @@ th {
   color: lightgray;
 }
 .article-entry .highlight {
-  border-radius: 5px; // 角丸
+  // 角丸は table 側（highlight.styl）に移した。figure は背景を持たない
   tab-size: 2em;
   margin-bottom: 0.5rem
 }


### PR DESCRIPTION
close #1974

コードブロックの背景が暗いため、暗い面積をできる限り減らしたい。ファイル名は全幅のバーだったので、その行がまるごと暗くなっていた。

```
変更前                              変更後
┌──────────────────────────┐      ┌───────────┐
│ ファイル名                │      │ ファイル名 │
├──────────────────────────┤      ├───────────┴──────────────┐
│ コード本文                │      │ コード本文                │
│ コード本文                │      │ コード本文                │
└──────────────────────────┘      └──────────────────────────┘
```

## 何が原因だったか

構造は `figure.highlight > figcaption + table` で、**背景と余白を `figure` が持っていた**。

```html
<figure class="highlight go">   ← ここに background: #2b2b2b
  <figcaption>SQLバインド</figcaption>
  <table>…コード…</table>
</figure>
```

`figcaption` は `figure` の背景の上に乗るため、幅を縮めても背後は暗いままになる。そこで**背景と余白を `table` 側に移した**。

## 変更内容

- `figcaption` は `width: fit-content` のブロックにして、上の角だけ丸める
  - `inline-block` だと行ボックスのベースライン分の隙間がタブの下に出るため使わない
- `table` は `display: block` + `width: max-content` + `min-width: 100%`
  - 横に長いコードでも背景が途切れず、スクロールは `figure` 側が受け持つ
  - `border-collapse: collapse` のままだと**テーブルの padding が仕様上無視される**ため、`display: block` にする必要がある
- ファイル名が長い場合は `max-width: 100%` と `text-overflow: ellipsis` で切り詰める
- `figcaption + table` で、**タブが乗る左上の角だけ**落としてつなげて見せる
- 角丸は `figure` が背景を持たなくなったので `table` 側へ移した

## 影響範囲

- コードブロックは **7802個**、うち**2210個（28.3%）にファイル名がある**
- **行番号カラムは全7802ブロックで0件**（`_config.yml` の `line_number: false`）。単一セルのテーブルなので `display: block` にしてもレイアウトは崩れない
- `.highlight table`（`theme-styles.styl`、詳細度 0,1,1）の `width: 100%` / `border: none` は、`.article-entry .highlight table`（0,2,1）が勝つため影響しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)