### PR TITLE
記事に本文の文字数を表示する

### DIFF
--- a/scripts/char_count.js
+++ b/scripts/char_count.js
@@ -1,0 +1,67 @@
+'use strict';
+
+/**
+ * 記事本文の文字数を数えるヘルパー。
+ *
+ * 読了時間は出さない。読む速度は個人差が大きく、分数で示すと
+ * かえって誠実さを欠くため、客観的な文字数だけを示す。
+ *
+ * 「読む労力の目安」として意味のある数字にするため、以下を除外する。
+ *
+ * - コードブロック … 一字一句読むものではなく、本文の文章量とは性質が違う
+ * - <details> の中身 … 既定で閉じており、初期状態の「読む量」に含めるのは不自然
+ *
+ * インラインコード（<code> 単体）は本文の流れの一部なので含める。
+ */
+
+// hexo の highlight は figure.highlight を出す。pre は Markdown 由来の
+// コードブロックや、ハイライトされなかったコードを拾うために併記する
+const BLOCKS = [
+  /<figure\b[^>]*\bclass="[^"]*\bhighlight\b[^"]*"[\s\S]*?<\/figure>/gi,
+  /<details\b[\s\S]*?<\/details>/gi,
+  /<pre\b[\s\S]*?<\/pre>/gi,
+  // mermaid 図は pre.mermaid で出るが、上の pre で拾えなかった場合の保険
+  /<script\b[\s\S]*?<\/script>/gi,
+  /<style\b[\s\S]*?<\/style>/gi
+];
+
+const ENTITIES = {
+  '&nbsp;': ' ', '&amp;': '&', '&lt;': '<', '&gt;': '>',
+  '&quot;': '"', '&#39;': "'", '&apos;': "'"
+};
+
+function countChars(html) {
+  if (!html) return 0;
+
+  let text = html;
+  for (const re of BLOCKS) {
+    text = text.replace(re, '');
+  }
+
+  // 残った要素を落とす。ブロック要素は前後が繋がらないよう空白に置き換える
+  text = text.replace(/<[^>]*>/g, ' ');
+
+  text = text.replace(/&(?:nbsp|amp|lt|gt|quot|#39|apos);/g, m => ENTITIES[m]);
+  // 上で拾えなかった数値参照・名前付き参照はまとめて1文字とみなす
+  text = text.replace(/&#?\w+;/g, '*');
+
+  // 日本語の本文は空白をほとんど含まないため、空白は数えない。
+  // 含めると英語主体の記事だけ水増しされて比較できなくなる
+  return text.replace(/\s+/g, '').length;
+}
+
+// 端数まで出しても読者の判断は変わらないので、100文字単位に丸める。
+// 1000未満は丸めが効きすぎるので50文字単位にする
+function round(n) {
+  if (n < 100) return n;
+  const unit = n < 1000 ? 50 : 100;
+  return Math.round(n / unit) * unit;
+}
+
+function label(post) {
+  const n = round(countChars(post.content));
+  if (n === 0) return '';
+  return `約 ${n.toLocaleString('en-US')} 文字`;
+}
+
+hexo.extend.helper.register('char_count', label);

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -817,6 +817,15 @@ code {
 .blog-info-item.blog-info-chars {
   padding-left: 28px;
 }
+/* 数え方の補足が title にあることを示す。点線と help カーソルは abbr で
+   使われる慣習で、これが無いとツールチップの存在に気づけない。
+   li ではなく span に掛けるのは、li だと padding-left の空白にまで
+   点線が伸びてしまうため */
+.blog-info-chars span {
+  cursor: help;
+  text-decoration: underline dotted #bbb;
+  text-underline-offset: 3px;
+}
 .blog-info-item:first-child {
   padding-left: 0;
   border-left: none;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -811,6 +811,12 @@ code {
  .blog-info-item {
   padding-left: 8px;
 }
+/* 日付・著者・カテゴリ・タグはリンクで、a 側の padding 16px が間隔を作る。
+   PV と文字数は素のテキストでその余白が無く、8px しか離れないため
+   「1,234 View 約 5,400 文字」が続きの語のように読めてしまう */
+.blog-info-item.blog-info-chars {
+  padding-left: 28px;
+}
 .blog-info-item:first-child {
   padding-left: 0;
   border-left: none;

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -16,7 +16,8 @@
             <%# 読了時間ではなく文字数。読む速度は個人差が大きく、分数で示すと誠実さを欠く。
                 コードブロックと <details> の中身は除外している（scripts/char_count.js） %>
             <% if (!index) { %>
-            <li class="blog-info-item blog-info-chars"><%= char_count(post) %></li>
+            <%# 数え方は title 属性で補足する。ネイティブのツールチップなので JS を足さずに済む %>
+            <li class="blog-info-item blog-info-chars"><span title="コードブロックと折りたたみ（details）の中身、空白を除いた本文の文字数です。インラインコードは含みます"><%= char_count(post) %></span></li>
             <% } %>
           </ul>
           </header>

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -13,6 +13,11 @@
             <% } %>
             <li class="blog-info-item"><%- partial('post/tag') %></li>
             <li class="blog-info-item"><%= get_ga4_pv(post.path) %> View</li>
+            <%# 読了時間ではなく文字数。読む速度は個人差が大きく、分数で示すと誠実さを欠く。
+                コードブロックと <details> の中身は除外している（scripts/char_count.js） %>
+            <% if (!index) { %>
+            <li class="blog-info-item"><%= char_count(post) %></li>
+            <% } %>
           </ul>
           </header>
         <% } %>

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -16,7 +16,7 @@
             <%# 読了時間ではなく文字数。読む速度は個人差が大きく、分数で示すと誠実さを欠く。
                 コードブロックと <details> の中身は除外している（scripts/char_count.js） %>
             <% if (!index) { %>
-            <li class="blog-info-item"><%= char_count(post) %></li>
+            <li class="blog-info-item blog-info-chars"><%= char_count(post) %></li>
             <% } %>
           </ul>
           </header>


### PR DESCRIPTION
close #1944

読者が「今読むか、後で読むか」を判断できるようにする。

## 読了時間ではなく文字数

読む速度は個人差が大きく、分数で示すとかえって誠実さを欠くため、客観的な文字数だけを示す。

## 除外するもの

「読む労力の目安」として意味のある数字にするため、以下を除外している。

| 除外対象 | 理由 |
| --- | --- |
| コードブロック（`figure.highlight` / `pre`） | 一字一句読むものではなく、本文の文章量とは性質が違う |
| `<details>` の中身 | 既定で閉じており、初期状態の「読む量」に含めるのは不自然 |
| `<script>` / `<style>` | 本文ではない |

インラインコード（`<code>` 単体）は本文の流れの一部なので**含める**。

## 数え方

- **空白は数えない。** 日本語の本文は空白をほとんど含まないため、含めると英語主体の記事だけ水増しされて比較できなくなる
- タグは空白に置き換えてから除去する。`<p>あ</p><p>い</p>` が「あい」ではなく2文字として正しく数えられるようにするため
- 実体参照はデコードして1文字として数える

## 丸め

端数まで出しても読者の判断は変わらないので丸める。

| 文字数 | 表示 |
| --- | --- |
| 1000以上 | 100文字単位（`3,849` → 約 3,800 文字） |
| 100〜999 | 50文字単位（`780` → 約 800 文字） |
| 100未満 | そのまま |

## 表示位置

日付・著者・カテゴリ・タグ・PV が並ぶ `blog-info` の末尾。

一覧ページでは全記事分の本文を走査することになるため、**記事ページ（`index` が false）でのみ**出す。カテゴリの表示と同じ条件。

## 検証

ロジックの単体確認:

```
OK 素の文章 / インラインコードは含む / コードブロック除外 / details 除外
OK pre 除外 / 実体参照 / 空白は数えない / タグ間が繋がらない
```

生成結果:

```
public/articles/20260525a/index.html: 約 11,200 文字
public/articles/20260806a/index.html: 約 8,000 文字
public/index.html:                    表示なし（0件）
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)