### PR TITLE
PV表示に更新タイミングの補足を出し、値が無いときは表示しない

### DIFF
--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -10,7 +10,10 @@ load.pv.forEach((obj) => {
 
 const getGA4PV = url => map.get(url)?.pv || 0;
 
+// 実測値が無いときは 0 を返す。以前は 100 を返していたが、実際に pv が 100 の
+// 記事も 55 件あり、表示上どちらか区別できなかった。公開直後の記事に
+// 架空の「100 View」が出るのは、読了時間を出さないのと同じ理由で避けたい
 hexo.extend.helper.register("get_ga4_pv", url => {
-  return (getGA4PV("/" + url) || 100).toLocaleString();
+  const pv = getGA4PV("/" + url);
+  return pv > 0 ? pv.toLocaleString() : '';
 });
-

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -817,11 +817,12 @@ code {
 .blog-info-item.blog-info-chars {
   padding-left: 28px;
 }
-/* 数え方の補足が title にあることを示す。点線と help カーソルは abbr で
-   使われる慣習で、これが無いとツールチップの存在に気づけない。
+/* 補足が title にあることを示す。点線と help カーソルは abbr で使われる
+   慣習で、これが無いとツールチップの存在に気づけない。
    li ではなく span に掛けるのは、li だと padding-left の空白にまで
-   点線が伸びてしまうため */
-.blog-info-chars span {
+   点線が伸びてしまうため。
+   タグは a に title を持つので span[title] なら巻き込まない */
+.blog-info-item span[title] {
   cursor: help;
   text-decoration: underline dotted #bbb;
   text-underline-offset: 3px;

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -12,7 +12,11 @@
             <li class="blog-info-item"><%- partial('post/category', {post: post}) %></li>
             <% } %>
             <li class="blog-info-item"><%- partial('post/tag') %></li>
-            <li class="blog-info-item"><%= get_ga4_pv(post.path) %> View</li>
+            <%# 更新タイミングを title で補足する。集計値が無い記事（公開直後など）は項目ごと出さない %>
+            <% const pv = get_ga4_pv(post.path); %>
+            <% if (pv) { %>
+            <li class="blog-info-item"><span title="Google Analytics による閲覧数です。毎日 9:00 JST に集計が更新され、サイトが再ビルドされます"><%= pv %> View</span></li>
+            <% } %>
             <%# 読了時間ではなく文字数。読む速度は個人差が大きく、分数で示すと誠実さを欠く。
                 コードブロックと <details> の中身は除外している（scripts/char_count.js） %>
             <% if (!index) { %>


### PR DESCRIPTION
close #1979

文字数（#1944）と同じく `title` 属性でツールチップを出す。読者にとって「いつ時点の数字なのか」が分からなかった。

## 更新タイミング

Issue に「キャッシュ更新と表示更新がズレる」と書いたが、**これは誤りだった**。実際は毎日更新される。

1. `update-cache.yml`（cron `0 0 * * *` = 9:00 JST）が `ga4_pv.json` を再生成し、**`main` へ直接 push**する
2. その push で `deploy.yml` が起動する（トリガは `push: branches: [main]`、`paths-ignore` は README のみ）

したがってツールチップの文言は次のようにした。

> Google Analytics による閲覧数です。毎日 9:00 JST に集計が更新され、サイトが再ビルドされます

## フォールバック 100 の廃止

`scripts/ga4_pv.js` は該当パスが無いとき **100 を返していた**。

```js
return (getGA4PV("/" + url) || 100).toLocaleString();
```

| 区分 | 件数 |
| --- | --- |
| `ga4_pv.json` のエントリ | 1473 |
| 記事のうち `ga4_pv.json` に無い（100と表示されていた） | 4 |
| 実際に `pv: 100` のエントリ | 55 |

**「100 View」が実測値かフォールバックか区別できない**状態だった。公開直後の記事には必ず架空の 100 が出る。

ツールチップで「Google Analytics による閲覧数です」と書く以上、ここは嘘になってはいけないので、**値が無いときは View の項目ごと出さない**ようにした。読了時間を出さないのと同じ判断。

これは表示の変更なので、意図と違えば戻せる。

## 装飾の一般化

点線と `cursor: help` を `.blog-info-chars span` から **`.blog-info-item span[title]`** に一般化した。タグは `a` 側に `title` を持つので巻き込まない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)