### PR TITLE
本文見出しの文字サイズを px から em に寄せる

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ bootstrap-subset → metronic → theme-styles.styl の順で `/css/site.css` �
   | `body` | 13px | `theme-styles.styl` |
   | 本文（`p` / `li` / `summary`） | `1.2em` = 15.6px | 〃 |
   | 記事タイトル | `clamp(24px, 1.325rem + 0.9vw, 32px)` | 〃（1箇所のみ） |
-  | 本文見出し h1〜h5 | 26 / 24 / 22 / 20 / 18px | 〃 |
+  | 本文見出し h1〜h5 | `2.0 / 1.85 / 1.7 / 1.55 / 1.4em` = 26 / 24.05 / 22.1 / 20.15 / 18.2px | 〃 |
   | コードブロック | 13px（`line-height` は `font-size × 1.6` で追従） | `highlight.styl` の変数 |
 
 - コードブロックのサイズは本文との相対バランスを見て 15px → 14px → 13px と

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -99,9 +99,15 @@ h4 {
 blockquote p {
   margin: 0.5rem 0 0.5rem 0;
 }
+/* 見出しは body の 13px を基準に em で決める。px 直指定だと body を
+   変えたときに追従せず、本文（1.2em = 15.6px）との相対関係も崩れる。
+   0.15em 刻みの等差で h1 26px / h2 24.05px / h3 22.1px / h4 20.15px /
+   h5 18.2px となり、従来の 26/24/22/20/18px から 0.2px 以内に収まる。
+   UI 部品（ページャ・タグ・サイドバー等）は本文と連動させる必要が無く、
+   継承の影響も受けたくないため px のままにしている */
 .article-entry h1 {
   border-bottom: solid 2px #ECEBEB;
-  font-size: 26px;
+  font-size: 2.0em;
   line-height: 1.2;
   margin-bottom: 8px;
   margin-top: 64px;
@@ -110,7 +116,7 @@ blockquote p {
 }
 .article-entry h2 {
   margin-top: 40px;
-  font-size: 24px;
+  font-size: 1.85em;
   border-bottom: solid 1px #ECEBEB;
   line-height: 1.225;
   margin-bottom: 12px;
@@ -119,16 +125,16 @@ blockquote p {
 }
 .article-entry h3 {
   margin-top: 20px;
-  font-size: 22px;
+  font-size: 1.7em;
   font-weight: 700;
 }
 .article-entry h4 {
   margin-top: 20px;
-  font-size: 20px;
+  font-size: 1.55em;
 }
 .article-entry h5 {
   margin-top: 20px;
-  font-size: 18px;
+  font-size: 1.4em;
 }
 .blog-item img {
   max-width: 100%;


### PR DESCRIPTION
#1953 の続き。#1983 で記事タイトルを片付けたので、本文見出しの単位を揃える。

## 問題

`.article-entry h1`〜`h5` が px 直指定で、`body` の 13px を変えても追従せず、本文（`1.2em` = 15.6px）との相対関係も崩れる状態だった。

## 変更

0.15em 刻みの等差にして `em` で表す。

| | 変更後 | 実効 | 従来 | 差 |
| --- | --- | --- | --- | --- |
| h1 | `2.0em` | 26.00px | 26px | ±0 |
| h2 | `1.85em` | 24.05px | 24px | +0.05 |
| h3 | `1.7em` | 22.10px | 22px | +0.10 |
| h4 | `1.55em` | 20.15px | 20px | +0.15 |
| h5 | `1.4em` | 18.20px | 18px | +0.20 |

**差は最大 0.2px** で見た目はほぼ変わらないまま、スケールが式として読めるようになる。

## UI 部品は px のまま

ページャ・タグ・サイドバー等は **px を維持**した。本文と連動させる必要が無く、継承の影響も受けたくないため。この使い分けを CLAUDE.md に方針として明記した。

> 単位は「記事本文まわりは `em`、UI 部品は `px`」で使い分ける

一律に em へ寄せると、入れ子の深さで意図しない縮小が起きる（`.article-entry li p { font-size: 1em }` のような打ち消しが既に複数ある）ため、機械的な統一はしない判断。

## 見つかった地雷（今回は手を入れない）

`theme-styles.styl` に以下が残っている。

```styl
@media (max-width: 1024px) {
  .h1, h1 { font-size: 28px; }
  .h2, h2 { font-size: 24px; }
}
```

**裸の要素セレクタ**（詳細度 0,0,1）なので、クラス付きの指定に負ける。

- `.article-entry h1`（0,1,1）→ 勝つので**今回の変更には影響しない**
- `.article-title`（0,1,0）→ 勝つので #1983 の `clamp` も無事
- クラスの無い `h1` / `h2`（サイドバーの見出しなど）→ **ここだけ効く**

「効いたり効かなかったりする」状態で、#1927 / #1928 と同種の事故の温床。CLAUDE.md に記録し、影響範囲の確認が必要なため今回は触っていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)