### PR TITLE
カテゴリを著者名と同じテキストリンクにする

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -786,27 +786,20 @@ code {
   font-size: 0.5em;
   margin-left:5px;
 }
-/* 以前は青の塗りに白抜き文字で、記事タイトルより目立っていた。
-   タグと同じ行に並ぶので、見た目もタグ（.tag-list-link）と完全に揃える。
-   塗りや色で差を付けるとそこだけ視線を奪ってしまう。
-   種別は表示名が「Programmingカテゴリ」のように自ら名乗っているため、
-   見た目が同じでもタグと取り違えることはない */
+/* カテゴリは著者名（.post-author）と同じテキストリンクにする。
+
+   以前はタグ（.tag-list-link）と同じ丸みのあるチップにしていたが、
+   タグそのものに見えてしまい、一覧から記事ページへ移動したときに
+   「タグが1つ増えた」と誤認する原因になっていた。
+   著者名と同じ素のテキストなら、タグとは別の種類の情報だと一目で分かる */
 .article-category-link {
-  display: inline-block;
-  padding: 2px 8px 1px 8px;
-  font-weight: bold;
-  font-size: 12px;
-  line-height: 1.4;
   color: #616161;
-  background-color: #f5f5f3;
-  border-radius: 14px;
+  font-weight: bold;
 }
 .article-category-link:hover,
 .article-category-link:focus {
-  color: #fff;
-  background-color: var(--main-font-color);
-  text-decoration: none;
-  transition-duration: 0.3s;
+  color: var(--main-font-color);
+  text-decoration: underline;
 }
 .sidebar-categories li a {
   padding: 10px 0;


### PR DESCRIPTION
close #1960

Issue のコメントより。

> タグと同じ形式なのは違和感（タグに見える）。また、トップページから個別ページに飛んだときに、タグが増えたかのように誤認してしまう。であれば、著者名のように全く異なる形式で追加したほうが、サプライズは小さいと思う。

## 変更

```diff
 .article-category-link {
-  display: inline-block;
-  padding: 2px 8px 1px 8px;
   font-weight: bold;
-  font-size: 12px;
-  line-height: 1.4;
   color: #616161;
-  background-color: #f5f5f3;
-  border-radius: 14px;
 }
 .article-category-link:hover, .article-category-link:focus {
-  color: #fff;
-  background-color: var(--main-font-color);
-  text-decoration: none;
-  transition-duration: 0.3s;
+  color: var(--main-font-color);
+  text-decoration: underline;
 }
```

`.post-author`（著者名）と同じ `color: #616161` / `font-weight: bold` の素のテキストリンクになる。

| | 変更前 | 変更後 |
| --- | --- | --- |
| 見た目 | タグと同じ丸いチップ | 著者名と同じテキスト |
| サイズ | 12px 固定 | 周囲（`blog-info` の 13px）に追従 |
| ホバー | 塗りが反転 | 下線 |

## 経緯

#1967 / #1968 でカテゴリの主張を弱める際、**タグと完全に同じ見た目に揃える**方針を採った。当時は「表示名が『Programmingカテゴリ』と自ら名乗るので取り違えない」と判断したが、実際に使うと**一覧から記事へ移動したときにタグが増えたように見える**ことが分かった。

種別の違いは文字列ではなく**形式**で示すべきだった。著者名という既存の前例に寄せる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)