### PR TITLE
ホーム2ページ目以降のパンくずの Home をリンクにする

### DIFF
--- a/themes/future/layout/index.ejs
+++ b/themes/future/layout/index.ejs
@@ -6,7 +6,10 @@
       <% if (page.current === 1) { %>
       <li class="active">Home</li>
       <% } else { %>
-      <li>Home</li>
+      <%# 2ページ目以降は Home が現在地ではないのでリンクにする。
+          他のレイアウト（post / tag / category など）は元からリンクで、
+          ここだけ取り残されていた %>
+      <li><a href="/">Home</a></li>
       <li class="active"><%= page.current %>ページ目</li>
       <% } %>
     </ul>


### PR DESCRIPTION
close #1989

## 原因

`index.ejs` **だけ**、2ページ目以降の Home が素のテキストだった。

```ejs
<% if (page.current === 1) { %>
<li class="active">Home</li>
<% } else { %>
<li>Home</li>              ← リンクになっていない
<li class="active"><%= page.current %>ページ目</li>
<% } %>
```

`post.ejs` / `tag.ejs` / `category.ejs` など**他のレイアウトは元から `<li><a href="/">Home</a></li>`** で、ここだけ取り残されていた。

## 変更

```diff
 <% } else { %>
-<li>Home</li>
+<li><a href="/">Home</a></li>
 <li class="active"><%= page.current %>ページ目</li>
```

**1ページ目はリンクにしない**（`.active` のまま）。現在地を自分自身にリンクさせないのはパンくずの通例で、Google の BreadcrumbList でも最後の項目にリンクは不要とされている。

## 横断確認

全10レイアウトのパンくずを走査し、**`.active` でもリンクでもない項目が残っていないこと**を確認した。

```
archive.ejs OK / author.ejs OK / authors.ejs OK / categories.ejs OK / category.ejs OK
index.ejs OK / post.ejs OK / tag.ejs OK / tags.ejs OK / techcasts.ejs OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)