### PR TITLE
techcasts のパンくずラベルと、見出しの閉じタグを直す

### DIFF
--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -5,9 +5,9 @@
   </ul>
   <main class="col-xs-12 col-sm-12 col-md-10">
     <section id="main" class="margin-top-30">
-      <h2>人気のタグから記事を探す</h1>
+      <h2>人気のタグから記事を探す</h2>
       <%- ranking_tags() %>
-      <h2>タグクラウドから記事を探す <%= count_tags() %>件</h1>
+      <h2>タグクラウドから記事を探す <%= count_tags() %>件</h2>
       <div class="tag-cloud">
       <%- custom_tagcloud({min_font:12, max_font:36}) %>
       </div>

--- a/themes/future/layout/techcasts.ejs
+++ b/themes/future/layout/techcasts.ejs
@@ -1,12 +1,12 @@
 <div class="container">
   <ul class="breadcrumb">
     <li><a href="/">Home</a></li>
-    <li class="active">Authors</li>
+    <li class="active">Tech Cast</li>
   </ul>
   <section id="main" class="margin-top-30">
     <div>
       <h2 class="list-page">Future Tech Cast</h2>
-      <h3 class="list-page margin-top-50">エピソード一覧</h2>
+      <h3 class="list-page margin-top-50">エピソード一覧</h3>
 
         <iframe style="border-radius:12px" src="https://open.spotify.com/embed/episode/2tRu2zATOCk0XYD61TjVa5?utm_source=generator" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
 


### PR DESCRIPTION
close #1993

## 1. パンくずのラベル

```diff
 <ul class="breadcrumb">
   <li><a href="/">Home</a></li>
-  <li class="active">Authors</li>
+  <li class="active">Tech Cast</li>
 </ul>
```

`/techcasts/` は Future Tech Cast のページなのに `Authors` と表示されていた。ページ内の `h2` は「Future Tech Cast」と正しく、パンくずだけがコピー元の名残でずれていた。

読者の現在地認識を誤らせ、構造化データとしても誤情報になる。

## 2. 見出しの閉じタグ

全レイアウトを走査したところ **3件** あった。Issue に書いた1件だけでなく、`tags.ejs` にも同種の誤りが2件あった。

| ファイル | 変更前 | 変更後 |
| --- | --- | --- |
| `techcasts.ejs` | `<h3>エピソード一覧</h2>` | `</h3>` |
| `tags.ejs` | `<h2>人気のタグから記事を探す</h1>` | `</h2>` |
| `tags.ejs` | `<h2>タグクラウドから記事を探す …件</h1>` | `</h2>` |

ブラウザは寛容にパースするため表示は崩れていなかったが、**見出し階層が壊れており、スクリーンリーダーの見出しジャンプで正しく辿れない**。

## 確認

修正後、全レイアウト（`themes/future/layout/**/*.ejs`）を再走査して**不一致ゼロ**を確認した。EJS のコンパイルも通っている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)