### PR TITLE
PV の左の間隔を文字数と揃える

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -824,8 +824,8 @@ code {
 }
 /* 日付・著者・カテゴリ・タグはリンクで、a 側の padding 16px が間隔を作る。
    PV と文字数は素のテキストでその余白が無く、8px しか離れないため
-   「1,234 View 約 5,400 文字」が続きの語のように読めてしまう */
-.blog-info-item.blog-info-chars {
+   隣の項目と続きの語のように読めてしまう。両方に同じ間隔を与える */
+.blog-info-item.blog-info-metric {
   padding-left: 28px;
 }
 /* 補足が title にあることを示す。点線と help カーソルは abbr で使われる

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -15,13 +15,13 @@
             <%# 更新タイミングを title で補足する。集計値が無い記事（公開直後など）は項目ごと出さない %>
             <% const pv = get_ga4_pv(post.path); %>
             <% if (pv) { %>
-            <li class="blog-info-item"><span title="Google Analytics による閲覧数です。毎日 9:00 JST に集計が更新され、サイトが再ビルドされます"><%= pv %> View</span></li>
+            <li class="blog-info-item blog-info-metric"><span title="Google Analytics による閲覧数です。毎日 9:00 JST に集計が更新され、サイトが再ビルドされます"><%= pv %> View</span></li>
             <% } %>
             <%# 読了時間ではなく文字数。読む速度は個人差が大きく、分数で示すと誠実さを欠く。
                 コードブロックと <details> の中身は除外している（scripts/char_count.js） %>
             <% if (!index) { %>
             <%# 数え方は title 属性で補足する。ネイティブのツールチップなので JS を足さずに済む %>
-            <li class="blog-info-item blog-info-chars"><span title="コードブロックと折りたたみ（details）の中身、空白を除いた本文の文字数です。インラインコードは含みます"><%= char_count(post) %></span></li>
+            <li class="blog-info-item blog-info-metric"><span title="コードブロックと折りたたみ（details）の中身、空白を除いた本文の文字数です。インラインコードは含みます"><%= char_count(post) %></span></li>
             <% } %>
           </ul>
           </header>


### PR DESCRIPTION
close #1995

## 原因

文字数だけが `.blog-info-chars { padding-left: 28px }` を持っており、PV は `.blog-info-item` の既定 **8px** のままだった。

```
日付   著者   カテゴリ   タグ   1,234 View    約 5,400 文字
                              ↑ 8px      ↑ 28px
```

日付・著者・カテゴリ・タグは `a` 側の `padding: 2px 16px` が間隔を作るが、**PV と文字数は素のテキスト**でその余白が無い。#1977 で文字数にだけ対処し、PV が取り残されていた。

## 変更

両者は「素のテキストで表す指標」という同じ性格なので、専用クラスをやめて共通の `.blog-info-metric` にした。

```diff
-<li class="blog-info-item"><span title="Google Analytics …">… View</span></li>
+<li class="blog-info-item blog-info-metric"><span title="Google Analytics …">… View</span></li>

-<li class="blog-info-item blog-info-chars"><span title="コードブロックと…">…</span></li>
+<li class="blog-info-item blog-info-metric"><span title="コードブロックと…">…</span></li>
```

```diff
-.blog-info-item.blog-info-chars { padding-left: 28px; }
+.blog-info-item.blog-info-metric { padding-left: 28px; }
```

今後 `blog-info` に同種の指標が増えても、このクラスを付けるだけで揃う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)