### PR TITLE
diff_[language] でコードハイライトを重ねられるようにする

### DIFF
--- a/scripts/diff_language_highlight.js
+++ b/scripts/diff_language_highlight.js
@@ -1,0 +1,95 @@
+'use strict';
+
+/**
+ * ```diff_go のように書くと、diff 表示に加えて言語の構文ハイライトも効かせる。
+ *
+ * 素の ```diff は差分の色しか付かず、コードとしては読みにくい。
+ * かといって ```go では差分が分からない。両方を出したい。
+ *
+ * 見せ方は差分を優先する。
+ *
+ * - 追加行（+）・削除行（-）は行全体を差分の色にする。ただし色だけを
+ *   上書きし font-weight は触らないので、キーワードの太字は残る
+ * - それ以外の行は指定された言語の構文ハイライトがそのまま出る
+ *
+ * hexo 標準のハイライタを通さず、terraform 用（register_hljs_terraform.js）と
+ * 同じやり方でコードブロックを横取りして自前で組み立てる。
+ */
+
+const hljs = require('highlight.js');
+
+// ```diff_go / ```diff-go のどちらでも受ける。後ろにファイル名を書ける点は
+// hexo 標準のコードブロックと同じ
+const FENCE = /^([ \t]*)```diff[_-]([A-Za-z0-9#+.-]+)[ \t]*(.*)\n([\s\S]*?)\n[ \t]*```/gm;
+
+const escapeHtml = s => String(s)
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;');
+
+/**
+ * コードを一括でハイライトしたうえで行に分割する。
+ *
+ * 行ごとに hljs を呼ぶとブロックコメントや raw string のように
+ * 複数行にまたがる構文が壊れる。まとめてハイライトしてから、
+ * 行境界で開いたままの span を閉じ直し、次の行の先頭で開き直す。
+ */
+function highlightLines(code, language) {
+  const html = hljs.highlight(code, {language, ignoreIllegals: true}).value;
+  const lines = [];
+  let open = [];
+
+  for (const line of html.split('\n')) {
+    const carried = open.slice();
+    const re = /<span class="([^"]*)">|<\/span>/g;
+    let m;
+    while ((m = re.exec(line))) {
+      if (m[1]) carried.push(m[1]);
+      else carried.pop();
+    }
+    lines.push(
+      open.map(c => `<span class="${c}">`).join('')
+      + line
+      + '</span>'.repeat(carried.length)
+    );
+    open = carried;
+  }
+  return lines;
+}
+
+function render(code, language) {
+  // 差分マーカーを外した素のコードにしてからハイライトする。
+  // マーカーが残っていると言語として解釈できず、全体が崩れる
+  const rows = code.split('\n').map(line => {
+    const head = line.charAt(0);
+    if (head === '+' || head === '-') {
+      return {marker: head, body: line.slice(1), cls: head === '+' ? 'addition' : 'deletion'};
+    }
+    return {marker: '', body: line, cls: ''};
+  });
+
+  const highlighted = highlightLines(rows.map(r => r.body).join('\n'), language);
+
+  return rows.map((r, i) => {
+    // テーマの CSS は hljs- 接頭辞の付かないクラス名を前提にしている
+    const body = highlighted[i].replace(/hljs-/g, '');
+    const cls = r.cls ? `line ${r.cls}` : 'line';
+    return `<span class="${cls}">${escapeHtml(r.marker)}${body}</span><br>`;
+  }).join('');
+}
+
+hexo.extend.filter.register('before_post_render', function(data) {
+  if (data.layout !== 'post' && data.layout !== 'page') return;
+  if (data.content.indexOf('```diff') === -1) return;
+
+  data.content = data.content.replace(FENCE, (match, indent, lang, caption, code) => {
+    // hljs が知らない言語はそのまま素の diff として hexo に任せる
+    if (!hljs.getLanguage(lang)) return match;
+
+    const caption_ = caption.trim();
+    return indent
+      + `<figure class="highlight diff_${escapeHtml(lang)}">`
+      + (caption_ ? `<figcaption><span>${escapeHtml(caption_)}</span></figcaption>` : '')
+      + `<table><tbody><tr><td class="code"><pre>${render(code, lang)}</pre></td></tr></tbody></table>`
+      + `</figure>`;
+  });
+}, 9);

--- a/source/_posts/2026/20260805a_Go_1.27の構造体リテラルのキー拡張で、埋め込みフィールドの初期化が楽になった.md
+++ b/source/_posts/2026/20260805a_Go_1.27の構造体リテラルのキー拡張で、埋め込みフィールドの初期化が楽になった.md
@@ -65,7 +65,7 @@ type User struct {
 
 `u.Version = 2` のように読み書きは昇格フィールドで直接できるのに、Go 1.26までは初期化のときだけ内側の型名を明示する必要がありました。Go 1.27ではフラットに書けます。
 
-```diff
+```diff_go
  u := User{
  	UserID:    "U0001",
  	Name:      "mano",

--- a/source/_posts/2026/20260807a_Go_1.27の_go_fix_アップデート.md
+++ b/source/_posts/2026/20260807a_Go_1.27の_go_fix_アップデート.md
@@ -48,7 +48,7 @@ TIG真野です。
 
 Issueは [#77352](https://github.com/golang/go/issues/77352)です。
 
-```diff before/after
+```diff_go before/after
 -var counter int64
 +var counter atomic.Int64
 
@@ -75,7 +75,7 @@ atomictypesは他のモダナイザーと毛色が違い、式の書き換えで
 
 Issueは[#77965](https://github.com/golang/go/issues/77965)です。
 
-```diff before/after
+```diff_go before/after
  // type User struct { Base; Email string }
  // type Base struct { ID int; Name string }
  return User{
@@ -106,7 +106,7 @@ t := T{x: 1}
 
 Issueは[#78484](https://github.com/golang/go/issues/78484)です。
 
-```diff before/after
+```diff_go before/after
  func printReverse(items []string) {
 -	for i := len(items) - 1; i >= 0; i-- {
 -		fmt.Println(items[i])
@@ -128,7 +128,7 @@ Issueは[#78484](https://github.com/golang/go/issues/78484)です。
 
 Issueは [#76648](https://github.com/golang/go/issues/76648) です。
 
-```diff before/after
+```diff_go before/after
  func secondElem(p unsafe.Pointer, size uintptr) unsafe.Pointer {
 -	return unsafe.Pointer(uintptr(p) + size)
 +	return unsafe.Add(p, size)
@@ -145,7 +145,7 @@ Issueは [#76648](https://github.com/golang/go/issues/76648) です。
 
 rc2の `go tool fix help` を眺めていて気づいたのですが、リリースノートに記載のない `errorsastype` も登録されています。API自体の提案は [#51945](https://github.com/golang/go/issues/51945)、モダナイザーのIssueは [#75692](https://github.com/golang/go/issues/75692)です。
 
-```diff before/after
+```diff_go before/after
  func handle(err error) {
 -	var nf *NotFoundError
 -	if errors.As(err, &nf) {
@@ -167,7 +167,7 @@ Issueは[#77581](https://github.com/golang/go/issues/77581)です。
 
 fmtappendf は `[]byte(fmt.Sprintf(...))` を `fmt.Appendf(nil, ...)` に書き換えるモダナイザーでした。go1.26.5 の `go fix` では次のように書き換えられます。
 
-```diff Go1.26時の書き換え例
+```diff_go Go1.26時の書き換え例
  func formatBytes(n int) []byte {
 -	return []byte(fmt.Sprintf("count=%d", n))
 +	return fmt.Appendf(nil, "count=%d", n)

--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -214,7 +214,13 @@ pre
   .javascript .function
     color: highlight-orange
     font-weight: bold
+  // diff_[language]（scripts/diff_language_highlight.js）では、差分行の中にも
+  // 言語の構文ハイライトの span が入る。差分であることの方が重要なので、
+  // 行内の子要素まで色を上書きして差分の色を優先する。
+  // font-weight には触らないため、キーワードの太字はそのまま残る
   .deletion
+  .deletion *
     color: highlight-diff-removed
   .addition
+  .addition *
     color: highlight-diff-added


### PR DESCRIPTION
close #2000

素の ```` ```diff ```` は差分の色しか付かずコードとしては読みにくく、```` ```go ```` では差分が分からない。```` ```diff_go ```` と書けば両方出るようにする。

## 表示

**差分を優先する。**

| 行 | 表示 |
| --- | --- |
| `-` 行 | 行全体が赤（`#ff6b68`）。**キーワードの太字は残る** |
| `+` 行 | 行全体が緑（`#89d185`）。同上 |
| それ以外 | `diff_[language]` の言語の構文ハイライトがそのまま出る |

```
 func main() {          ← func=オレンジ太字、main=黄（Go の構文色）
-	var old int = 1    ← 全体が赤。var は太字のまま
+	const New = 2      ← 全体が緑。const は太字のまま
 	/* 複数行
 	   コメント */      ← 2行にまたがってコメント色
 }
```

CSS は `pre .deletion, pre .deletion *` で**色だけを上書き**し、`font-weight` に触っていない。そのため `.keyword { font-weight: bold }` が生き残る。

## 実装

**行ごとに hljs を呼ぶと複数行構文が壊れる。** ブロックコメントや raw string が途中で切れる。

差分マーカーを外した素のコードを**一括でハイライト**してから行分割し、行境界で開いたままの `span` を閉じ直して次の行頭で開き直している。

```js
for (const line of html.split('\n')) {
  const carried = open.slice();
  // 行内で開いた span を数え、閉じられていない分を次行へ持ち越す
  lines.push(open.map(c => `<span class="${c}">`).join('') + line
             + '</span>'.repeat(carried.length));
  open = carried;
}
```

hexo 標準のハイライタは通さず、terraform 用（`register_hljs_terraform.js`）と同じやり方でコードブロックを横取りして自前で組み立てる。

## 仕様

- **記法**: `diff_go` / `diff-go` のどちらでも受ける。`diff_sql` `diff_ts` など**hljs が対応する任意の言語**が使える
- **ファイル名**: ` ```diff_go main.go ` と書ける（既存のコードブロックと同じ）
- **依存追加なし**: 既存の highlight.js 11.11.1 をそのまま使う

## 既存への影響

- 素の ```` ```diff ```` **111ブロックには一切触れない**
- hljs が知らない言語名（`diff_nosuchlang` など）もそのまま hexo 標準にフォールバックする

## 検証

境界ケースを単体で確認済み。

```
差分行にキーワード   → .keyword の span が入り、色は差分色・太字は維持
素の diff            → 変換されず素通り
未知の言語           → 変換されず素通り
言語名にハイフン     → diff-sql も変換される
```

実際に `hexo generate` を通し、生成HTMLで `<span class="line deletion">-	<span class="keyword">var</span> …` となることを確認した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)