### PR TITLE
go.mod 用の言語定義 gomod を追加し、既存記事を切り替える

### DIFF
--- a/scripts/register_hljs_gomod.js
+++ b/scripts/register_hljs_gomod.js
@@ -1,0 +1,79 @@
+'use strict';
+
+/**
+ * go.mod / go.work 用の言語定義を highlight.js に追加する。
+ *
+ * highlight.js に go.mod の定義は無く、記事では proto / hcl / text で
+ * 代用していた。しかしいずれも誤った色を付けていた。たとえば proto では
+ * バージョン v1.19.0 が「19.0」という数値として拾われ、意味の無い単位が
+ * 強調される。go では go キーワードだけ当たり、バージョンが .19 と .0 に
+ * 分割される。何も色を付けないより悪い状態だった。
+ *
+ * hexo-util は同じ highlight.js インスタンスを解決するので registerLanguage が
+ * 効くが、それだけでは足りない。hexo-util は言語名を highlight_alias.json という
+ * 静的な表で検査しており、そこに無い名前は問答無用で plaintext に落とす。
+ *
+ *   if (!lang || !alias.aliases[lang]) lang = 'plaintext';
+ *
+ * 判定に使うのは表の有無だけで、hljs に渡るのはフェンスに書いた名前そのもの。
+ * そのため hljs への登録とあわせて、この表にも名前を通しておく必要がある。
+ * terraform（register_hljs_terraform.js）がコードブロックごと横取りしているのも
+ * 同じ制約が理由だが、表に足すだけなら hexo 本来の描画経路
+ * （行の span、ファイル名、行番号）をそのまま使えるので、そちらを採る。
+ */
+
+const hljs = require('highlight.js');
+
+hljs.registerLanguage('gomod', function() {
+  return {
+    name: 'Go Module',
+    aliases: ['go.mod', 'gowork', 'go.work'],
+    case_insensitive: false,
+    keywords: {
+      keyword: 'module go require replace exclude retract toolchain tool godebug use'
+    },
+    contains: [
+      hljs.COMMENT('//', '$'),
+      {
+        // v1.19.0 / v2.0.0-rc.1 / v0.0.0-20240101120000-abcdef123456 / v1.0.0+incompatible
+        className: 'type',
+        begin: /\bv\d+\.\d+\.\d+(?:-[\w.]+(?:-[0-9a-f]+)?)?(?:\+incompatible)?\b/
+      },
+      {
+        // モジュールパス。ホスト名を含む形（github.com/foo/bar）だけを拾い、
+        // 単なる単語を巻き込まないようにする
+        className: 'string',
+        begin: /\b[\w.-]+\.[a-z]{2,}(?:\/[\w.~-]+)+/
+      },
+      {
+        // toolchain go1.27.0 のようなツールチェイン名。
+        // 先に拾わないと、後続の数値ルールが「27.0」だけを掴んでしまう
+        className: 'number',
+        begin: /\bgo\d+\.\d+(?:\.\d+)?(?:rc\d+|beta\d+)?\b/
+      },
+      {
+        // replace の矢印
+        className: 'operator',
+        begin: /=>/
+      },
+      {
+        // go 1.27 や toolchain の数値
+        className: 'number',
+        begin: /\b\d+\.\d+(?:\.\d+)?\b/
+      }
+    ]
+  };
+});
+
+// hexo-util の言語表に通す。require のキャッシュを共有しているため、
+// ここでの書き換えが hexo-util 側の判定にもそのまま効く。
+// 表の形が変わって読めなくなったら、黙って plaintext に落ちるのではなく
+// ビルドを失敗させて気づけるようにする
+const alias = require('hexo-util/highlight_alias.json');
+if (!alias || !alias.aliases || !Array.isArray(alias.languages)) {
+  throw new Error('hexo-util の highlight_alias.json の形が想定と異なる。gomod の登録方法を見直すこと');
+}
+if (!alias.languages.includes('gomod')) alias.languages.push('gomod');
+for (const name of ['gomod', 'go.mod', 'gowork', 'go.work']) {
+  alias.aliases[name] = 'gomod';
+}

--- a/source/_posts/2025/20250204a_Go_1.24リリース連載_Go_Modulesにおけるツール管理の進化.md
+++ b/source/_posts/2025/20250204a_Go_1.24リリース連載_Go_Modulesにおけるツール管理の進化.md
@@ -79,7 +79,7 @@ install:
 
 空の `go.mod` に `github.com/sqlc-dev/sqlc/cmd/sqlc@v1.27.0` をツールとして追加します。
 
-```hcl go.mod
+```gomod go.mod
 module sample
 
 go 1.24rc2
@@ -108,7 +108,7 @@ go: added modernc.org/token v1.1.0
 
 コマンドを実行すると `go.mod` の `tool` ディレクティブに `github.com/sqlc-dev/sqlc/cmd/sqlc` が追加されており、バージョンが `require` で管理されていることがわかります。バージョンは `v1.27.0` が入っていますね。
 
-```hcl go.mod
+```gomod go.mod
 module sample
 
 go 1.24rc2
@@ -146,7 +146,7 @@ go: upgraded modernc.org/sqlite v1.31.1 => v1.34.5
 
 `go.mod` を確認すると、たしかにバージョンが2025/01/23現在の最新である `v.1.28.0` に更新されていることがわかります。
 
-```hcl go.mod
+```gomod go.mod
 module sample
 
 go 1.24rc2

--- a/source/_posts/2025/20250603b_Dokployで自宅PaaSを構築する.md
+++ b/source/_posts/2025/20250603b_Dokployで自宅PaaSを構築する.md
@@ -110,7 +110,7 @@ $ curl -sSL https://dokploy.com/install.sh | sudo sh
 
 まずはGoのアプリケーションを作ってみます。ふつうのウェブアプリケーションです。
 
-```text go.mod
+```gomod go.mod
 module goapp
 
 go 1.24

--- a/source/_posts/2026/20260729a_Go_1.27のgo_mod_tidyの更新点.md
+++ b/source/_posts/2026/20260729a_Go_1.27のgo_mod_tidyの更新点.md
@@ -37,7 +37,7 @@ Go 1.27の `go mod tidy` は、`go.mod` 内に散らばった `require` ブロ�
 
 3つに増殖してしまった `require` ブロックが、`go` ディレクティブを `1.27` に上げて `go mod tidy` するだけで、綺麗な2ブロックに整頓されます（2つ目のブロックが消えました）。
 
-```diff
+```diff_gomod go.mod
 --- a/go.mod
 +++ b/go.mod
 @@ -1,23 +1,20 @@
@@ -92,7 +92,7 @@ $ go mod init example.com/tidydemo
 $ go mod tidy
 ```
 
-```proto go.mod
+```gomod go.mod
 require (
 	github.com/fatih/color v1.19.0
 	github.com/stretchr/testify v1.11.1
@@ -114,7 +114,7 @@ require (
 $ go mod edit -require github.com/spf13/cobra@v1.8.1
 ```
 
-```proto //indirectに直接依存のパッケージが混ざったgo.mod
+```gomod //indirectに直接依存のパッケージが混ざったgo.mod
 require (
 	github.com/fatih/color v1.19.0
 	github.com/stretchr/testify v1.11.1
@@ -133,7 +133,7 @@ require (
 
 この状態で cobra をimportするコードを追加して `go mod tidy`（go1.26.5）を実行すると、混在ブロックは「すべて間接依存のブロック」とは見なされないため、cobra が引き込む新しい間接依存（`pflag` と `mousetrap`）の置き場として**3つ目のブロックが誕生**します。
 
-```proto 3つのブロックになったgo.mod
+```gomod 3つのブロックになったgo.mod
 require (
 	github.com/fatih/color v1.19.0
 	github.com/stretchr/testify v1.11.1
@@ -183,7 +183,7 @@ require (
 
 これも動かして確認します。コメント付きのブロックを意図的に分けた `go.mod` を用意しました。
 
-```proto go.mod
+```gomod go.mod
 require (
 	github.com/stretchr/testify v1.11.1
 )
@@ -201,7 +201,7 @@ require (
 
 従来の `go mod tidy` では、このコメント付きブロックの分割は **そのまま温存**されます）。しかし、 `go1.27rc2` ではこうなります。
 
-```proto go.mod
+```gomod go.mod
 // 自分がメンテしているモジュール
 require (
 	github.com/fatih/color v1.19.0


### PR DESCRIPTION
#2000 の相談から。highlight.js に go.mod の定義が無いため、記事では `proto` / `hcl` / `text` で代用していた。

## 代用がうまくいっていなかった

| 指定 | 着色 | 実態 |
| --- | --- | --- |
| `proto`（使用中） | 3箇所 | バージョン `v1.19.0` が **`19.0` という数値**として拾われる |
| `go` | 5箇所 | `go` だけキーワードになり、`v1.19.0` が **`.19` と `.0` に分割** |
| `hcl` / `text` / 指定なし | 0箇所 | 色が付かない |
| **`gomod`（本PR）** | **10箇所** | directive / モジュールパス / バージョン / コメントが正しく分離 |

意味の無い単位が強調されており、何も色を付けないより悪い状態だった。

```
keyword  module  require  replace  exclude  retract  toolchain  go
string   github.com/fatih/color                    ← モジュールパス
type     v1.19.0 / v0.0.0-20240101120000-abcdef123456 / v1.0.0+incompatible
number   1.27 / go1.27.0 / go1.26rc2
operator =>                                        ← replace の矢印
comment  // indirect
```

## hexo-util の言語表にも通す必要がある

`registerLanguage` だけでは足りなかった。**hexo-util は言語名を `highlight_alias.json` という静的な表で検査**しており、そこに無い名前は問答無用で `plaintext` に落とす。

```js
// node_modules/hexo-util/dist/highlight.js
if (!lang || !alias.aliases[lang]) lang = 'plaintext';
```

判定に使うのは表の有無だけで、hljs に渡るのはフェンスに書いた名前そのもの。そのため hljs への登録とあわせて表にも名前を通している。`register_hljs_terraform.js` がコードブロックごと横取りしているのも同じ制約が理由だが、表に足すだけなら **hexo 本来の描画経路（行の span・ファイル名・行番号）をそのまま使える**ので、そちらを採った。

表の形が変わって読めなくなった場合は、**黙って plaintext に落ちるのではなくビルドを失敗させる**ガードを入れている。

`gomod` / `go.mod` / `gowork` / `go.work` のどれでも書ける。

## 記事の切り替え（3記事10ブロック）

2025年以降から go.mod のコードブロックを探して揃えた。

| 記事 | 変更 |
| --- | --- |
| 20250204a Go 1.24 Go Modules | `hcl go.mod` ×3 → `gomod go.mod` |
| 20250603b Dokploy | `text go.mod` ×1 → `gomod go.mod` |
| 20260729a go mod tidy | `proto …` ×5 → `gomod …` |
| 20260729a go mod tidy | `diff` ×1 → **`diff_gomod go.mod`** |

最後の1件は go.mod の unified diff なので、#2000 で入れた `diff_[language]` を使い、差分の色と go.mod の構文ハイライトを両立させている。

変更は**フェンスの言語指定のみ**で、本文には手を入れていない。

### 対象外と判断したもの

| 記事 | 指定 | 理由 |
| --- | --- | --- |
| 20250516a | `tf` | Terraform の `module "EC2" {`。書式が別物 |
| 20260129a | `bash` ×2 | `$ go version` から始まるシェルセッション。`cat go.mod` の出力を含むだけ |
| 20250603b | `text` ×2 | dnsmasq / resolver の設定ファイル |

## 確認時の注意

**`db.json` のキャッシュにより、スクリプトを変えただけでは記事が再描画されない。** 手元で見るときは `make clean` を挟む必要がある。

`deploy.yml` は `db.json` をキャッシュせず毎回クリーンチェックアウトからビルドするため、本番デプロイには影響しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)