### PR TITLE
diff_[language] で言語側の強調色を落とす

### DIFF
--- a/scripts/diff_language_highlight.js
+++ b/scripts/diff_language_highlight.js
@@ -10,7 +10,11 @@
  *
  * - 追加行（+）・削除行（-）は行全体を差分の色にする。ただし色だけを
  *   上書きし font-weight は触らないので、キーワードの太字は残る
- * - それ以外の行は指定された言語の構文ハイライトがそのまま出る
+ * - 言語側の「強調を足す」色は落とす。差分の赤緑と構文の色が同時に出ると
+ *   色数が多すぎて、どこが変わったのかが読み取りにくくなる
+ * - ただし「優先度を下げる」色は残す。コメントを地の文より暗くするのは
+ *   情報量を減らす方向なので、差分の読み取りを邪魔しない
+ * - キーワードの太字も残す。色を持たせなくても構造は伝わる
  *
  * hexo 標準のハイライタを通さず、terraform 用（register_hljs_terraform.js）と
  * 同じやり方でコードブロックを横取りして自前で組み立てる。
@@ -56,6 +60,27 @@ function highlightLines(code, language) {
   return lines;
 }
 
+/**
+ * 言語側の色を落とす。
+ *
+ * 差分の赤緑と構文の色が同時に出ると色数が多すぎて読み取りにくいため、
+ * 強調を足すだけのクラス（キーワード・型・文字列・数値など）は
+ * クラスを外して地の文の色に戻す。
+ *
+ * 例外は2つ。
+ * - comment は地の文より暗くする「優先度を下げる」色なので残す
+ * - keyword は色を外したうえで太字だけ残したいので、専用クラスに移す
+ *
+ * span の数は変えないので、行またぎの開き直しとも整合する。
+ */
+function neutralize(html) {
+  return html.replace(/<span class="([^"]*)">/g, (tag, cls) => {
+    if (cls === 'comment') return tag;
+    if (cls === 'keyword') return '<span class="keyword-plain">';
+    return '<span>';
+  });
+}
+
 function render(code, language) {
   // 差分マーカーを外した素のコードにしてからハイライトする。
   // マーカーが残っていると言語として解釈できず、全体が崩れる
@@ -71,7 +96,7 @@ function render(code, language) {
 
   return rows.map((r, i) => {
     // テーマの CSS は hljs- 接頭辞の付かないクラス名を前提にしている
-    const body = highlighted[i].replace(/hljs-/g, '');
+    const body = neutralize(highlighted[i].replace(/hljs-/g, ''));
     const cls = r.cls ? `line ${r.cls}` : 'line';
     return `<span class="${cls}">${escapeHtml(r.marker)}${body}</span><br>`;
   }).join('');

--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -214,6 +214,10 @@ pre
   .javascript .function
     color: highlight-orange
     font-weight: bold
+  // diff_[language] ではキーワードから色を外し、太字だけ残す。
+  // 差分の赤緑と構文の色が同時に出ると色数が多すぎて読み取りにくいため
+  .keyword-plain
+    font-weight: bold
   // diff_[language]（scripts/diff_language_highlight.js）では、差分行の中にも
   // 言語の構文ハイライトの span が入る。差分であることの方が重要なので、
   // 行内の子要素まで色を上書きして差分の色を優先する。


### PR DESCRIPTION
#2000 / #2002 の続き。実際に使ってみたところ、**差分の赤緑と構文の色が同時に出ると色数が多すぎて、どこが変わったのかが読み取りにくかった。**

1つのブロックに赤・緑・オレンジ・黄・青が同居していた。

## 色の役割で切り分ける

「色を減らす」のではなく、**差分と競合する色だけを減らす**。

| 種類 | 例 | 扱い | 理由 |
| --- | --- | --- | --- |
| **強調を足す色** | キーワード・型・関数名・文字列・数値 | **落とす** | 差分の赤緑と注意を奪い合う |
| **優先度を下げる色** | コメント | **残す** | 情報量を減らす方向なので、差分の読み取りを邪魔しない |
| **色以外の強調** | キーワードの太字 | **残す** | 色を使わずに構造を伝えられる |

コードの構造情報は失われない。太字とコメントの減光が残るため、`func` や `var` の位置も、コメントが補足であることも読み取れる。

## 結果

```
 func main() {            ← func は太字・色なし、main/() は地の文の色
 	// 事前チェック        ← コメントだけ暗いグレーで残る
 	var s = "keep"         ← var は太字、"keep" は地の文の色
-	fmt.Println("old")     ← 行全体が赤
+	log.Printf("new")      ← 行全体が緑
 }
```

生成されるマークアップ:

```html
<span class="line"> <span><span class="keyword-plain">func</span> <span>main</span><span>()</span></span> {</span>
<span class="line">	<span class="comment">// 事前チェック</span></span>
<span class="line deletion">-	fmt.Println(<span>&quot;old&quot;</span>)</span>
```

## 実装

`keyword` は `keyword-plain` という専用クラスに移し、CSS では `font-weight` だけを持たせる。それ以外の強調クラスは `<span>` からクラスを外すだけ。

```js
function neutralize(html) {
  return html.replace(/<span class="([^"]*)">/g, (tag, cls) => {
    if (cls === 'comment') return tag;
    if (cls === 'keyword') return '<span class="keyword-plain">';
    return '<span>';
  });
}
```

**span の数は変えない**ので、行またぎで span を開き直す処理とも整合する。適用は行分割の後なので、開き直しで再出力された span にも同じ規則が効く。

CSS 側は1ルールの追加のみ。

```styl
.keyword-plain
  font-weight: bold
```

`pre .deletion, pre .deletion *`（差分色）はこの後ろに定義されているため、差分行では `.comment` も含めて赤緑に上書きされる。差分優先という方針どおり。

## 影響範囲

**`diff_[language]` を使ったブロックのみ。** 素の ```` ```go ```` や ```` ```gomod ```` はフルカラーのままで、通常のコードブロックの見え方は変わらない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)