### PR TITLE
被参照記事を全件表示し、多いときは残りを details で畳む

### DIFF
--- a/scripts/reference_posts.js
+++ b/scripts/reference_posts.js
@@ -18,17 +18,29 @@ hexo.extend.helper.register('list_reference_posts', function() {
 
   // 件数で打ち切らない。参照されていることは記事が積み上げてきた事実で、
   // 隠すと「参照しても表示されないなら書かなくてよい」という方向に働きうる。
-  // 実データでは被参照が6件以上の記事は70本（5.7%）、最大でも29件のため、
-  // 全件出してもページが極端に伸びることはない
-  let result = "";
-  for (const post of referencePosts) {
-    // マークアップは lib/post_list.js に集約している
-    result += postListItem(post, 'reference-posts-item');
-  }
+  //
+  // ただし全件をそのまま並べると、最大32件の記事では記事末尾が長くなりすぎる。
+  // 先頭だけ常に見せ、残りは details で畳んでクリックで開けるようにする。
+  // details ならJSを足さずに済む。
+  const VISIBLE = 5;
+  // 残りが1件だけなら畳む意味がないので、そのまま出す
+  const collapses = referencePosts.length > VISIBLE + 1;
+  const shown = collapses ? referencePosts.slice(0, VISIBLE) : referencePosts;
+  const hidden = collapses ? referencePosts.slice(VISIBLE) : [];
+
+  // マークアップは lib/post_list.js に集約している
+  const items = posts => posts.map(p => postListItem(p, 'reference-posts-item')).join('');
+
+  // ul の直下に details は置けないため、畳む分は別の ul にして details で包む
+  const more = hidden.length === 0 ? '' : `
+    <details class="reference-post-more">
+      <summary>残り ${hidden.length} 件を表示</summary>
+      <ul class="reference-post-link">${items(hidden)}</ul>
+    </details>`;
 
   return `
   <div class="card">
     <div id="reference" class="reference-lede"><a href="#reference" class="headerlink" title="参照されている記事"></a>この記事を参照している記事</div>
-    <ul class="reference-post-link">${result}</ul>
+    <ul class="reference-post-link">${items(shown)}</ul>${more}
   </div>`;
 });

--- a/scripts/reference_posts.js
+++ b/scripts/reference_posts.js
@@ -4,17 +4,26 @@ const {postListItem} = require('./lib/post_list');
 
 hexo.extend.helper.register('list_reference_posts', function() {
 
-  const referencePosts = this.site.posts.data.filter(p => p.content.includes(this.post.path))
-    .filter(p => p.path !== this.post.path).reverse();; // その記事で自分セルフリンクされている場合は除去
+  const referencePosts = this.site.posts.data
+    .filter(p => p.content.includes(this.post.path))
+    .filter(p => p.path !== this.post.path) // その記事で自分がセルフリンクされている場合は除去
+    // site.posts.data は日付順に並んでいない。以前は reverse() を掛けるだけで
+    // 順序が不定のまま先頭5件を出しており、「新しい5件」ですら無かった。
+    // 新しい順に並べて、参照の広がりを新しいものから辿れるようにする
+    .sort((a, b) => b.date.valueOf() - a.date.valueOf());
 
-  if (referencePosts.length == 0) {
+  if (referencePosts.length === 0) {
     return "";
   }
 
+  // 件数で打ち切らない。参照されていることは記事が積み上げてきた事実で、
+  // 隠すと「参照しても表示されないなら書かなくてよい」という方向に働きうる。
+  // 実データでは被参照が6件以上の記事は70本（5.7%）、最大でも29件のため、
+  // 全件出してもページが極端に伸びることはない
   let result = "";
-  for (let i = 0; i < Math.min(5, referencePosts.length); i++) {
+  for (const post of referencePosts) {
     // マークアップは lib/post_list.js に集約している
-    result += postListItem(referencePosts[i], 'reference-posts-item');
+    result += postListItem(post, 'reference-posts-item');
   }
 
   return `

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1072,6 +1072,31 @@ code {
 .featured-posts-item:last-child {
   border-bottom: none;
 }
+/* 被参照が多い記事では先頭5件だけ見せ、残りは details で畳む。
+   全件を並べると記事末尾が長くなりすぎるが、件数で打ち切ると
+   参照された事実そのものが隠れてしまうため、開けば全部見える形にする。
+   JS は使わない */
+.reference-post-more {
+  padding: 0 0.8em 0.6em;
+}
+.reference-post-more > summary {
+  padding: 0.5em 0;
+  border-top: 1px solid #ecebeb;
+  color: #6e6e6e;
+  font-size: 0.9em;
+  cursor: pointer;
+}
+.reference-post-more > summary:hover {
+  color: #424242;
+}
+/* 畳んだ側の ul は details 側で余白を持つので、二重に付けない */
+.reference-post-more .reference-post-link {
+  padding: 0;
+}
+/* 直前の ul の最終行は、summary の上線と重なって二重線になる */
+.reference-post-link:has(+ .reference-post-more) .reference-posts-item:last-child {
+  border-bottom: none;
+}
 /* metronic の `.featured-post-link li { padding: 8px 0 6px }` は
    .featured-posts-item の padding と競合するので、こちらに揃える */
 .featured-post-link .featured-posts-item {


### PR DESCRIPTION
close #1999

## 規模の実測

Issue の「せいぜい20〜30件程度」という見立ては実データと一致した。**6件以上は99記事、最大32件。**

## 想定より状況は悪かった

**表示されていた5件は「新しい5件」ですらなかった。**

```
2026.04.21, 2026.02.19, 2025.05.29, 2025.05.22, 2025.05.28
```

`site.posts.data` は日付順に整列されておらず、`.reverse()` はその任意順を反転しているだけだった。つまり**事実上ランダムな5件**が出ていた。

これは Issue が指摘する「参照するインセンティブが下がる」問題を悪化させる。どの記事が表示されるか予測できないため、参照した側から見て報われ方が読めない。

## 対応

全件表示にしたところ、32件の記事では記事末尾が長すぎて逆に読みにくかった。かといって件数で打ち切ると、参照された事実そのものが隠れる。

**先頭5件は常に見せ、残りは `<details>` で畳む。**

```
┌─ この記事を参照している記事 ────────┐
│ 記事タイトル A        2026.04.21 ♡12 │
│ 記事タイトル B        2026.02.19 ♡ 8 │
│ 記事タイトル C        2025.05.29      │  ← 常に見える5件
│ 記事タイトル D        2025.05.28 ♡ 3 │
│ 記事タイトル E        2025.05.27      │
├──────────────────────────────────────┤
│ ▸ 残り 24 件を表示                    │  ← クリックで展開
└──────────────────────────────────────┘
```

- **JS は使わない。** `<details>` だけで実現している
- **summary に件数を出す。** 畳んでいても参照の規模は数として見えるので、参照するインセンティブを損なわない
- **残りが1件のときは畳まない。** 開く手間の方が大きく割に合わないため、`VISIBLE + 1` 以下はそのまま全件出す
- あわせて**新しい順に明示的にソート**した

| 総件数 | 表示 |
| --- | --- |
| 〜6件 | 全件そのまま |
| 7件以上 | 5件 ＋「残り N 件を表示」 |

## 実装上の注意

`<ul>` の直下に `<details>` は置けない（`<ul>` の子は `<li>` のみ）。先頭は通常の `<ul>`、残りは `<details>` 内の別の `<ul>` に分けている。

```html
<ul class="reference-post-link">…先頭5件…</ul>
<details class="reference-post-more">
  <summary>残り 24 件を表示</summary>
  <ul class="reference-post-link">…残り…</ul>
</details>
```

直前の `<ul>` 最終行の下線が `summary` の上線と二重になるため `:has()` で打ち消した。未対応のブラウザでは線が1本増えるだけで機能には影響しない。

## スクロール量の方針との関係

これまで「スクロール量を減らす」方向で改善してきた（ランキング15→10、関連記事6→3）が、性質が違うと整理した。

| | 関連記事・ランキング | この記事を参照している記事 |
| --- | --- | --- |
| 生成元 | **自動推薦**（タグ類似度・PV） | **書き手が実際に張ったリンク** |
| 増える条件 | 記事が増えれば無限に増える | 誰かが参照したときだけ増える |
| 切る影響 | 推薦候補が減るだけ | **事実が隠れる／執筆行動に影響しうる** |

自動推薦は絞ってよいが、被参照は積み上げた事実なので隠さない。ただし一度に見せる量は抑える、という折衷。

## 検証

クリーンビルドで確認。

```
20250413a: summary「残り 24 件を表示」/ 常時表示 5件 / 畳んだ側 24件 = 計29件
全記事: 畳んだ記事 85本 / そのまま表示 970本
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)