### PR TITLE
一覧ページの統計の文字サイズを下げる

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1129,10 +1129,12 @@ code {
 /* 一覧ページ */
 .list-page {
   font-weight: bold;
+  /* ブラウザ既定の h1（2em）に頼っていて、CSS のどこにも書かれていなかった。
+     見た目は変えずに、決まる場所をここ1箇所にする */
+  font-size: 2em;
 }
 .summary {
   font-weight: bold;
-  font-size: 1.2em;
   list-style: none;
   padding-inline-start: 0px;
   display: flex;
@@ -1148,13 +1150,21 @@ code {
 .summary li:first-child {
   padding: 0 5px 0px 0px;
 }
+/* 記事数やシェア数の統計。以前は .summary の 1.2em に 1.6em を掛けた
+   25px で、ページ見出し（26px）とほぼ同じ大きさだった。一覧ページの
+   主役は記事一覧であって統計ではないので、見出しより明確に下げる。
+   em の連鎖をやめ、UI 部品として px で1箇所に書く（CLAUDE.md の方針）。
+   幅で変える分はメディアクエリを重ねず clamp にまとめる */
 .summary-count {
-  font-size: 1.6em;
+  /* Stylus は clamp の中の 1rem + 0.4vw を単位を同一視して 1.4rem に
+     計算してしまうため、unquote でそのまま出す（記事タイトルと同じ事情） */
+  font-size: unquote('clamp(17px, 1rem + 0.4vw, 20px)');
   font-weight: bold;
 }
 .summary-label {
-  font-size: 1.0em;
-  font-weight: lighter;
+  font-size: 12px;
+  /* 親の bold に対する lighter は結局 normal になる。意図を明示する */
+  font-weight: normal;
 }
 .bottom-content-header {
   font-weight: bold;


### PR DESCRIPTION
close #2004

## 現状

`/categories/Programming/` `/tags/Terraform/` `/authors/真野隼記/` に出る統計。

| 要素 | 実効サイズ | 指定 |
| --- | --- | --- |
| ページ見出し `h1.list-page` | **26px** | **CSS に無し**（ブラウザ既定の `h1` = 2em） |
| `.summary-count`（数値） | **25.0px** | `1.2em × 1.6em` の連鎖 |
| `.summary-label`（ラベル） | 15.6px | `1.2em × 1.0em` |

**統計の数値がページ見出しとほぼ同じ大きさ**だった。これが「やたら強調される」の正体。しかも `em` の連鎖で、どこで最終値が決まるか追えない #1953 と同じ形になっていた。

## 変更

| 要素 | 変更前 | 変更後 |
| --- | --- | --- |
| 数値 | 25.0px 固定 | **`clamp(17px, 1rem + 0.4vw, 20px)`** |
| ラベル | 15.6px | **12px** |
| `.summary` の `font-size: 1.2em` | あり（連鎖の元） | **削除** |
| `.list-page` | 指定なし（UA既定） | **`2em` を明示**（見た目は不変） |

実効サイズ:

| 画面幅 | 数値 | 見出し |
| --- | --- | --- |
| 375px（スマホ） | **17.5px** | 26px |
| 768px | 19.1px | 26px |
| 1024px 以上 | 20.0px | 26px |

一覧ページの主役は記事一覧であって統計ではないので、見出しより明確に下げた。モバイルで特に大きく感じるのは7項目が折り返して縦に積まれるためで、幅に応じて 17.5px まで落としている。

## CLAUDE.md の方針に沿った点

- **`em` の連鎖をやめ、UI 部品として `px` で1箇所に書く**
- **メディアクエリを重ねず `clamp` にまとめる**
- **`.list-page` のサイズを明示** — ブラウザ既定に頼っていた箇所を潰す

## 踏んだ罠

`clamp(17px, 1rem + 0.4vw, 20px)` と書いたところ、**Stylus が `1rem + 0.4vw` を単位を同一視して `1.4rem` に計算**し、`clamp(17px, 1.4rem, 20px)` = 常に 20px になっていた。

記事タイトル（#1983）と同じ事情で `unquote()` が必要。描画結果を確認していなければ「可変にしたつもりで固定」のまま出すところだった。既存の `clamp` は記事タイトルの1件のみで、そちらは対処済み。

## 検証

クリーンビルドで `public/css/site.css` を確認。

```
.summary-count { font-size: clamp(17px, 1rem + 0.4vw, 20px); font-weight: bold; }
.summary-label { font-size: 12px; font-weight: normal; }
.list-page { font-weight: bold; font-size: 2em; }
.summary の font-size: 削除済み
```

統計ブロックの出力も確認（tags 7項目 / categories 7項目 / authors 6項目）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)