### PR TITLE
タグ・カテゴリ・著者ページからランキングとタグ一覧を外す

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -38,10 +38,17 @@
   border-color: #337ab7;
 }
 
+/* ページャ。以前は下にランキングとタグ一覧が続いていて間隔が埋まって
+   いたが、それらをホーム以外から外した（#2006）ことで、記事カードと
+   フッターに挟まれて窮屈に見えるようになった。上下に余白を置く。
+   中の a / span は float しているので、余白が潰れないよう flow-root で
+   包含する（clearfix と同じ効果） */
 #page-nav {
+  display: flow-root;
   float: none !important;
-  margin-bottom: 20px !important;
-  margin-left: 5px;
+  /* 一括指定に !important を付けると、後続の margin-left が負けて 0 になる。
+     左の 5px も含めて1行で書く */
+  margin: 48px 0 56px 5px !important;
 }
 
 /* Extra info topbar tweaks */

--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -54,31 +54,15 @@
   <% } %>
 
 
-    <%# 末尾の導線。ホームの2ページ目以降では、ページを繰っている読者が
-        探し直す段階に無いため何も出さない（スクロール量だけが増える）。
-        ランキングはホーム1ページ目では上に出したので、ここでは繰り返さない %>
-    <% if (!(isHome && page.current > 1)) { %>
+    <%# 「タグから記事を探す」はホームの1ページ目だけに出す。
+        タグ・カテゴリ・著者のページを見ている読者は、すでに絞り込んだ
+        状態で記事を探しているので、そこから全タグの一覧へ戻す導線は
+        読者の意図とズレる。ホームの2ページ目以降も、ページを繰っている
+        最中なので探し直す段階に無い。
+        ランキングは上（isHomeFirst の分岐）に出しているのでここには無い %>
+    <% if (isHomeFirst) { %>
     <aside>
       <section class="popular-articles">
-        <% if (!isHomeFirst) { %>
-        <div class="margin-bottom-20 nav tabs">
-          <input id="monthly" type="radio" name="tab_item" checked>
-          <label tabindex="0" class="tab_item" for="monthly">トレンド</label>
-          <input id="yearly" type="radio" name="tab_item">
-          <label tabindex="0" class="tab_item" for="yearly">年間人気</label>
-          <input id="sns" type="radio" name="tab_item">
-          <label tabindex="0" class="tab_item" for="sns">SNS人気</label>
-          <div class="tab_content" id="popular_monthly">
-            <%- popular_posts('monthly') %>
-          </div>
-          <div class="tab_content" id="popular_yearly">
-            <%- popular_posts('yearly') %>
-          </div>
-          <div class="tab_content" id="popular_sns">
-            <%- sns_popular_posts() %>
-          </div>
-        </div>
-        <% } %>
         <div class="blog-tags margin-bottom-20">
           <h2 id="searchbytag" class="bottom-content-header"><a href="#searchbytag" class="headerlink" title="タグから記事を探す"></a>タグから記事を探す</h2>
           <%- partial('../_widget/tag.ejs') %>


### PR DESCRIPTION
close #2006

## 判断

タグやカテゴリのページに来た読者は、**すでに自分で絞り込みを終えた状態**で記事を探している。そこから「全記事のランキング」や「全タグの一覧」へ戻す導線は、**絞り込みを解除する方向**で読者の意図と逆を向いている。

回遊が必要なら、そのページの記事一覧そのものが担うべき。

## 変更後の出し分け

`_partial/archive.ejs` を使うのは **ホーム / タグ / カテゴリ / 著者** の4種だけ（アーカイブは `archive-all.ejs` で元からランキングなし）。そこで **「ホーム1ページ目のみ」** に単純化した。

| ページ | ランキング | タグから記事を探す |
| --- | --- | --- |
| ホーム 1ページ目 | ○（最上部） | ○（末尾） |
| ホーム 2ページ目以降 | — | — |
| **タグ / カテゴリ / 著者** | **削除** | **削除** |
| アーカイブ | — | — |

## 副次的にコードが単純になった

以前は「上に出したか」を `isHomeFirst` で判定して末尾側を出し分ける必要があったが、**ランキングは1箇所（ホーム最上部）のみ**になったため、その分岐が消えた。

radio の `id` 重複でタブが壊れる懸念も、構造上ありえなくなった。

## ページャの余白

ランキングとタグ一覧が消えたことで、ページャが**記事カードとフッターに挟まれて窮屈**になった。

```diff
 #page-nav {
+  display: flow-root;
   float: none !important;
-  margin-bottom: 20px !important;
-  margin-left: 5px;
+  margin: 48px 0 56px 5px !important;
 }
```

- **`display: flow-root` が要点。** ページャの中身（`a` / `span`）は `float: left` なので、そのままだと親の高さが潰れて余白が効かない
- 一括指定に `!important` を付けると後続の `margin-left` が負けて 0 になるため、左の 5px も含めて1行にまとめた
- 上 48px / 下 56px。ページャは「一覧の終わり」を示す要素でフッターとは役割が違うため、下をやや広めに取っている

## 確認

ma91n さんの環境で確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)