### PR TITLE
ランキングを記事カードと同じ質感にする

### DIFF
--- a/themes/future/css-src/_variables.styl
+++ b/themes/future/css-src/_variables.styl
@@ -42,6 +42,11 @@ banner-url = "images/banner.jpg"
 
 sidebar = hexo-config("sidebar")
 
+// カードの影と角丸。記事カードとランキングで同じものを使う。
+// 値が散ると片方だけ調整されて素材感がずれるため、ここで1箇所にまとめる
+card-shadow = 0 2px 5px 0 rgba(0,0,0,0.16), 0 2px 10px 0 rgba(0,0,0,0.12)
+card-radius = 8px
+
 // Layout
 block-margin = 50px
 article-padding = 20px

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -278,10 +278,10 @@ body.page-header-fixed .header {
   }
 }
 .article-card {
-  box-shadow: 0 2px 5px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12);
+  box-shadow: card-shadow;
   padding: 24px 20px 0px 20px;
   margin: 0 0 32px 0;
-  border-radius: 8px
+  border-radius: card-radius
 }
 /* We're hiring のカード。以前は画像がカード幅の半分を占め、さらに
    .article-card の padding と Bootstrap の p-3 が二重にかかっていて、
@@ -1188,7 +1188,10 @@ code {
    タブと本体を1つの枠で囲む一般的な形にする。選択タブだけ本体と同じ白地に
    なり、下辺を本体の枠線に重ねて繋がって見せる */
 .tabs {
-  overflow: hidden; /* float したタブを含める */
+  /* float したタブを含める。overflow: hidden だと本体の影が親の箱の外側で
+     切り取られ、左右と下の影が消えて角丸も四角く切られてしまう。
+     flow-root なら切り取らずに含包できる */
+  display: flow-root;
 }
 .tab_item {
   float: left;
@@ -1199,16 +1202,20 @@ code {
   letter-spacing: 0.02em;
   color: #616161;
   background-color: #f5f5f3;
-  border: 1px solid #ddd;
-  /* 未選択でも同じ太さの上辺を持たせ、選択時に高さがずれないようにする */
-  border-top: 3px solid #ddd;
-  border-radius: 6px 6px 0 0;
+  /* 未選択タブは枠線を出さない。地色より濃いグレーの線が縁取ると、
+     タブの面と線が食い違って見えて古びた印象になる。
+     消すのではなく透明にするのは、選択時にボックスの寸法が変わって
+     高さがずれるのを防ぐため */
+  border: 1px solid transparent;
+  border-top: 3px solid transparent;
+  border-radius: card-radius card-radius 0 0;
   cursor: pointer;
   transition: background-color 0.1s ease, border-top-color 0.1s ease, color 0.1s ease;
 }
 .tab_item:hover {
   background-color: #ececea;
-  border-top-color: #bbb;
+  /* 押せることは上辺の色で伝える。枠線全体は出さない */
+  border-top-color: #ccc;
   color: #424242;
 }
 .tab_item:focus-visible {
@@ -1227,6 +1234,8 @@ input[name="tab_item"] {
 .tabs input:checked + .tab_item {
   background-color: #fff;
   color: #424242;
+  /* 選択タブだけ枠線を出して、本体とひと続きの面に見せる */
+  border-color: #ddd;
   border-top-color: #424242;
   border-bottom-color: #fff;
   font-weight: bold;
@@ -1237,9 +1246,10 @@ input[name="tab_item"] {
   padding: 18px 22px;
   background-color: #fff;
   border: 1px solid #ddd;
-  border-radius: 0 6px 6px 6px;
-  /* タブと本体がひとつの面として浮いて見えるよう、ごく薄い影を置く */
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  border-radius: 0 card-radius card-radius card-radius;
+  /* 新着記事のカードと同じ影にする。ランキングだけ影が薄いと
+     素材感がそろわず、ホームの中で浮いて見えていた */
+  box-shadow: card-shadow;
 }
 /*選択されているタブのコンテンツのみを表示*/
 #weekly:checked ~ #popular_weekly,


### PR DESCRIPTION
close #2007

ホームのランキングだけ影が薄く、新着記事のカードと素材感がそろわずに浮いて見えていた。

## 記事カードと同じ影・角丸に

| | 変更前 | 変更後 |
| --- | --- | --- |
| 影 | `0 1px 3px rgba(0,0,0,.06)` | **`0 2px 5px rgba(0,0,0,.16), 0 2px 10px rgba(0,0,0,.12)`** |
| 角丸 | 6px | **8px** |

値は `_variables.styl` に切り出し、**記事カードとランキングの両方から参照**する。

```styl
// カードの影と角丸。記事カードとランキングで同じものを使う。
// 値が散ると片方だけ調整されて素材感がずれるため、ここで1箇所にまとめる
card-shadow = 0 2px 5px 0 rgba(0,0,0,0.16), 0 2px 10px 0 rgba(0,0,0,0.12)
card-radius = 8px
```

Issue の趣旨は「整合させると自然になる」なので、値をコピーせず共有した。今後どちらかを調整したときに、もう片方が取り残されない。

## 影が左右・下に出ず、下の角が四角かった原因

`.tabs { overflow: hidden }`。float したタブを含めるために #1988 で入れたものだが、**子要素の影を親の箱の外側で切り取っていた。**

```
        ┌──────────────┐ ← .tabs の箱の境界
上の影  │ ▓▓▓ タブ ▓▓▓ │   タブは箱の内側なので影が見える
        │ ┌──────────┐ │
        │ │ 本体      │ │ ← 左右・下の影は箱の外にはみ出す
        └─┴──────────┴─┘ ← 切り取られ、角丸も四角く削られる
```

`display: flow-root` に置き換えた。含包だけを行い、はみ出すものを切り取らない。

`overflow: hidden` は float 対策の古い定番だが、**影・角丸・ツールチップなど「外にはみ出すもの」を巻き添えで消す**。同じ理由で `#page-nav` にも `flow-root` を使っている（#2006）。

## 未選択タブの枠線を消した

地色より濃いグレーの線が縁取ると、タブの面と線が食い違って見える。

```diff
-  border: 1px solid #ddd;
-  border-top: 3px solid #ddd;
+  border: 1px solid transparent;
+  border-top: 3px solid transparent;
```

**削除ではなく透明にした。** `border` を消すとボックスの寸法が 1px（上辺は 3px）縮み、選択を切り替えるたびに高さがガタつくため。

かわりに選択タブへ `border-color: #ddd` を明示した。選択タブを本体とひと続きの面に見せる役割は枠線が担っているので、そちらには残す。結果として Bootstrap の `nav-tabs` と同じ挙動になる。

```
  トレンド   年間人気   SNS人気     ← 未選択は面だけ（枠線なし）
┏━━━━━━━━┓
┃ トレンド ┃                        ← 選択タブだけ枠線＋上辺のアクセント
┡━━━━━━━━┷━━━━━━━━━━━━━━━━━━━┓
│ 1. 記事タイトル                  │
```

## 確認

ma91n さんの環境で確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)