### PR TITLE
ランキングのタブと本体を1枚のカードに収める

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1257,42 +1257,53 @@ code {
 
    タブと本体を1つの枠で囲む一般的な形にする。選択タブだけ本体と同じ白地に
    なり、下辺を本体の枠線に重ねて繋がって見せる */
+/* タブと本体を1枚のカードに収める。
+
+   以前はタブと本体がそれぞれ影を持つ別々の面で、境目で接していた。
+   その形だと境目に落ちうるものが次々に出てきて（本体の枠線、タブの下向きの
+   影、本体の上向きの影、タブ左右の影）、1つ潰すたびに別の要因が現れる。
+   接している限り終わらないので、面そのものを1つにする。
+
+   float したタブを含めるのは flow-root。overflow: hidden だと影が親の箱の
+   外側で切り取られ、角丸も四角く削られる */
 .tabs {
-  /* float したタブを含める。overflow: hidden だと本体の影が親の箱の外側で
-     切り取られ、左右と下の影が消えて角丸も四角く切られてしまう。
-     flow-root なら切り取らずに含包できる */
   display: flow-root;
+  /* カード全体の地色はタブ帯の色にする。タブは操作であってコンテンツでは
+     ないので、本体と同じ白地に浮かせると用途のない余白に見える。
+     帯として右端まで塗り、選択タブだけ白にして本体とつなげる。
+
+     コードブロックのファイル名タブのように内容ぶんで止める案も試したが、
+     帯が途中で切れるとカードの影と地色の整合が崩れ、タブだけが浮いて
+     見えてしまった。帯は端まで伸ばす */
+  background-color: #f5f5f3;
+  border-radius: card-radius;
+  box-shadow: card-shadow;
 }
 .tab_item {
   float: left;
   padding: 10px 22px;
-  margin: 0 4px -1px 0; /* -1px で本体の上辺に重ねる */
+  /* 本体の枠線に重ねるための -1px は、枠線を廃止したので不要になった */
+  margin: 0 4px 0 0;
   font-size: 1.15em;
   line-height: 1.4;
   letter-spacing: 0.02em;
   color: #616161;
-  background-color: #f5f5f3;
-  /* 未選択タブは枠線を出さない。地色より濃いグレーの線が縁取ると、
-     タブの面と線が食い違って見えて古びた印象になる。
+  /* 未選択タブは帯の地色をそのまま見せる。塗りを重ねると帯の中で
+     さらに面が分かれて見える */
+  background-color: transparent;
+  /* 枠線は出さない。地色より濃いグレーの線が縁取ると、タブの面と線が
+     食い違って見えて古びた印象になる。
      消すのではなく透明にするのは、選択時にボックスの寸法が変わって
      高さがずれるのを防ぐため */
   border: 1px solid transparent;
   border-top: 3px solid transparent;
   border-radius: card-radius card-radius 0 0;
-  /* 本体と同じ影を持たせて、タブまで含めてひとつの面に見せる。
-     タブだけ影が無いと、本体から浮いた紙が別々に見えて落ち着かない。
-
-     ただし下向きの影がそのまま本体に落ちると、境目に暗い線が出る。
-     clip-path で下端ちょうどに切り、上と左右にだけ影を出す。
-     inset の下辺を 0 にすると border-box の下端で切れるので、
-     タブ自体は削られない */
-  box-shadow: card-shadow;
-  clip-path: inset(-12px -12px 0 -12px);
+  /* 影と地色はカード（.tabs）が持つ。ここで面を分けない */
   cursor: pointer;
   transition: background-color 0.1s ease, border-top-color 0.1s ease, color 0.1s ease;
 }
 .tab_item:hover {
-  background-color: #ececea;
+  background-color: #e8e8e6;
   /* 押せることは上辺の色で伝える。枠線全体は出さない */
   border-top-color: #ccc;
   color: #424242;
@@ -1321,20 +1332,13 @@ input[name="tab_item"] {
 .tab_content {
   display: none;
   clear: both;
-  padding: 18px 22px;
+  /* 本体だけ白。選択タブ（白）とそのままつながり、未選択タブは帯に沈む。
+     影はカード（.tabs）が持つので、ここでは持たない */
   background-color: #fff;
-  /* 枠線は持たない。記事カードと同じく影だけで面を成立させる。
-     枠線があると、タブの隙間や右側で本体の上辺が細いグレーの線として
-     露出し、タブと本体の境目に見えてしまう。
-     選択タブと本体はどちらも白なので、地色が continuous につながる */
-  border-radius: 0 card-radius card-radius card-radius;
-  /* 位置指定はしない。float したタブは位置指定の無いこのブロックより後に
-     描かれるので、本体の影が上方向にはみ出してもタブの地色が隠してくれる。
-     z-index で本体を上に重ねると、逆にその影がタブの下端に落ちて線になる */
-  /* 新着記事のカードと同じ影にする。ランキングだけ影が薄いと
-     素材感がそろわず、ホームの中で浮いて見えていた */
-  box-shadow: card-shadow;
+  border-radius: 0 0 card-radius card-radius;
+  padding: 18px 22px;
 }
+
 /*選択されているタブのコンテンツのみを表示*/
 #weekly:checked ~ #popular_weekly,
 #monthly:checked ~ #popular_monthly,

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1279,6 +1279,15 @@ code {
   border: 1px solid transparent;
   border-top: 3px solid transparent;
   border-radius: card-radius card-radius 0 0;
+  /* 本体と同じ影を持たせて、タブまで含めてひとつの面に見せる。
+     タブだけ影が無いと、本体から浮いた紙が別々に見えて落ち着かない。
+
+     ただし下向きの影がそのまま本体に落ちると、境目に暗い線が出る。
+     clip-path で下端ちょうどに切り、上と左右にだけ影を出す。
+     inset の下辺を 0 にすると border-box の下端で切れるので、
+     タブ自体は削られない */
+  box-shadow: card-shadow;
+  clip-path: inset(-12px -12px 0 -12px);
   cursor: pointer;
   transition: background-color 0.1s ease, border-top-color 0.1s ease, color 0.1s ease;
 }
@@ -1304,10 +1313,9 @@ input[name="tab_item"] {
 .tabs input:checked + .tab_item {
   background-color: #fff;
   color: #424242;
-  /* 選択タブだけ枠線を出して、本体とひと続きの面に見せる */
-  border-color: #ddd;
+  /* 本体と同じ白地になることでひと続きに見える。枠線は使わない。
+     上辺のアクセントだけ残して選択状態を示す */
   border-top-color: #424242;
-  border-bottom-color: #fff;
   font-weight: bold;
 }
 .tab_content {
@@ -1315,8 +1323,14 @@ input[name="tab_item"] {
   clear: both;
   padding: 18px 22px;
   background-color: #fff;
-  border: 1px solid #ddd;
+  /* 枠線は持たない。記事カードと同じく影だけで面を成立させる。
+     枠線があると、タブの隙間や右側で本体の上辺が細いグレーの線として
+     露出し、タブと本体の境目に見えてしまう。
+     選択タブと本体はどちらも白なので、地色が continuous につながる */
   border-radius: 0 card-radius card-radius card-radius;
+  /* 位置指定はしない。float したタブは位置指定の無いこのブロックより後に
+     描かれるので、本体の影が上方向にはみ出してもタブの地色が隠してくれる。
+     z-index で本体を上に重ねると、逆にその影がタブの下端に落ちて線になる */
   /* 新着記事のカードと同じ影にする。ランキングだけ影が薄いと
      素材感がそろわず、ホームの中で浮いて見えていた */
   box-shadow: card-shadow;


### PR DESCRIPTION
close #2020

タブに影が無く、本体から浮いた紙が別々に見えるという指摘から始めた。

## 症状を追うのではなく構造を変えた

タブと本体が**それぞれ影を持つ別々の面で境目に接している**限り、境目に落ちうるものが次々に現れた。

| 試行 | 対処 | 結果 |
| --- | --- | --- |
| 1 | タブに影を足し、`z-index` で本体を上に重ねる | 本体の上向きの影（約8px）がタブに落ちて**暗い線** |
| 2 | 本体の枠線（`#ddd`）を廃止 | 要因の1つだったが**主因ではなく、線が残る** |
| 3 | `clip-path` でタブの下向き／本体の上向きの影を対称に切る | まだ**薄い線**が見える |
| 4 | **面そのものを1つにする** | 解決 |

1つ潰すたびに別の要因が出るため、**2回目の時点で構造を疑うべきだった。**

## 変更

ラッパーの `.tabs` にカードの地色・角丸・影を持たせ、タブと本体はその中の**塗り分け**にした。

```
┌──────────────────────────────┐
│▒[トレンド]▒[年間人気]▒[SNS]▒│ ← 帯（#f5f5f3）
├─────────┘                    │
│ 1. 記事タイトル               │ ← 本体（白）
└──────────────────────────────┘
        影はカード全体に1つ
```

| 要素 | 地色 |
| --- | --- |
| `.tabs`（カード） | `#f5f5f3` ＋ 角丸 ＋ **影** |
| 未選択タブ | **透明**（帯の地色をそのまま見せる） |
| 選択タブ | **白**（本体とつながる） |
| `.tab_content` | 白 |

タブは操作であってコンテンツではないので、本体と同じ白地に浮かせると用途のない余白に見える。帯として塗ることで**カードのヘッダ**という役割が明確になる。

未選択タブを `transparent` にしたのは、帯と同じ色を重ねて塗ると帯の中でさらに面が分かれて見えるため。

## 帯を内容ぶんで止める案は不採用

コードブロックのファイル名タブのように帯を最後のタブで止める案も試したが、**カードの影は矩形の外周に落ちる**ので、中の塗りが途中で切れると影の形と地色の形が食い違い、タブだけが浮いて見えた。

ファイル名タブが `fit-content` で成立するのは、**あちらが影を持たない独立した面**だから。同じ見た目でも成立条件が違う。この理由はコードコメントに残した。

## 結果として消えたもの

境目のために積み上げていた仕掛けが**すべて不要**になった。

| 仕掛け | 目的 |
| --- | --- |
| `clip-path` ×2 | 影が境目に落ちるのを防ぐ |
| `z-index` | 重ね順の制御 |
| `margin-bottom: -1px` | 本体の枠線に重ねる |
| `border-bottom-color: #fff` | 枠線の継ぎ目を隠す |
| 枠線 `1px solid #ddd` | 面の輪郭 |

```
影       : .tabs の1箇所のみ
clip-path: 0箇所
z-index  : なし
枠線     : なし（選択タブ上辺のアクセントのみ）
```

## コントラスト

| 対象 | 比 |
| --- | --- |
| 未選択タブ `#616161` / 帯 `#f5f5f3` | **5.67** |
| 選択タブ `#424242` / 白 | **10.05** |
| ホバー `#424242` / `#e8e8e6` | **8.19** |

いずれも AA（4.5）を満たす。

🤖 Generated with [Claude Code](https://claude.com/claude-code)