### PR TITLE
サイドバーのアドベントカレンダーをホーム1ページ目だけにする

### DIFF
--- a/themes/future/layout/_partial/sidebar.ejs
+++ b/themes/future/layout/_partial/sidebar.ejs
@@ -27,9 +27,16 @@
 <h2 class="margin-top-30">Tech Cast</h2>
 <%- generate_techcast_post() %>
 </section>
+<%# アドベントカレンダーはホームの1ページ目だけに出す。
+    カテゴリ・タグ・著者のページを見ている読者は、すでに自分で絞り込んだ
+    状態で記事を探している。そこへ Qiita の外部リンク11本を並べると意図が
+    ぼやける。ホームの2ページ目以降も、新着記事をページで繰っている最中で
+    同じことが言える %>
+<% if (is_home() && page.current === 1) { %>
 <section class="advent-calendar">
 <h2 class="margin-top-30">アドベントカレンダー</h2>
 <%- partial('_widget/advent-calendar.ejs') %>
 </section>
+<% } %>
 <% } %>
 <!-- END SIDEBAR -->


### PR DESCRIPTION
close #2016

## 判断

カテゴリ・タグ・著者のページを見ている読者は、**すでに自分で絞り込んだ状態**で記事を探している。そこへ Qiita への外部リンク11本を並べると、絞り込みを解除する方向に引っ張ることになり、意図がぼやける。

ホームの2ページ目以降も同じで、**新着記事をページで繰っている最中**の読者は、別の入口を探している段階にない。

タグ・カテゴリ・著者ページからランキングとタグ一覧を外した #2006 と同じ考え方で、**読者がそのページに来た意図に沿って出し分ける**。

## 変更

```diff
+<% if (is_home() && page.current === 1) { %>
 <section class="advent-calendar">
   <h2>アドベントカレンダー</h2>
   <%- partial('_widget/advent-calendar.ejs') %>
 </section>
+<% } %>
```

| ページ | アドベントカレンダー |
| --- | --- |
| **ホーム 1ページ目** | **表示** |
| ホーム 2ページ目以降 | 非表示 |
| **タグ / カテゴリ / 著者** | **非表示** |
| 記事ページ | 非表示（元から `!is_post()` で除外） |

## サイドバーの構成

| ページ | 表示内容 |
| --- | --- |
| ホーム1ページ目 | 検索 / カテゴリー / Tech Cast / **アドベントカレンダー** |
| ホーム2ページ目以降 | 検索 / カテゴリー / Tech Cast |
| タグ・カテゴリ・著者 | 検索 / カテゴリー / Tech Cast |
| 記事ページ | 目次のみ |

## 補足

Tech Cast にも同じ理屈が当てはまりそうだが、この Issue の対象がアドベントカレンダーなので触っていない。#2013（モバイルで Tech Cast が2ページ目以降にも表示される）で扱うのが自然。

## 確認

ma91n さんの環境で確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)