### PR TITLE
選択中のタブのアクセントをカードの外に出す

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1281,9 +1281,15 @@ code {
 }
 .tab_item {
   float: left;
-  padding: 10px 22px;
-  /* 本体の枠線に重ねるための -1px は、枠線を廃止したので不要になった */
-  margin: 0 4px 0 0;
+  /* 上辺のアクセントをカードの外に出す。負のマージンで持ち上げた分を
+     padding-top で戻すので、文字の位置と下辺は動かない
+     （margin -5 + border 3 + padding 15 = 13。未選択も選択も同じ）。
+
+     全タブに掛けるのが要点で、選択やホバーのときだけ持ち上げると
+     マウスを乗せるたびにタブが跳ねてしまう。
+     未選択時の枠は透明なので、何も起きていないように見える */
+  padding: 15px 22px 10px;
+  margin: -5px 4px 0 0;
   font-size: 1.15em;
   line-height: 1.4;
   letter-spacing: 0.02em;


### PR DESCRIPTION
#2020 の続き。選択中を示す上辺の黒線がカードの内側に収まっていて、タブが手前に引き出されている感じが出なかった。

## 変更

```
変更前                              変更後
                                     ███                  ← 5px 外に出る
┌──────────────────────┐           ┌───────────────────┐
│███[トレンド] [年間]  │           │  [トレンド] [年間] │
├──────────┘           │           ├──────────┘        │
│ 1. 記事タイトル       │           │ 1. 記事タイトル    │
└──────────────────────┘           └───────────────────┘
```

```diff
 .tab_item {
-  padding: 10px 22px;
-  margin: 0 4px 0 0;
+  padding: 15px 22px 10px;
+  margin: -5px 4px 0 0;
 }
```

## 持ち上げは全タブに掛ける

選択やホバーのときだけ持ち上げると、**マウスを乗せるたびにタブが跳ねる**。全タブを同じだけ持ち上げ、上辺の 3px 枠を常にカードの外に置く。

未選択時の枠は `transparent` なので、**上に空間はあっても何も見えない**。そこにホバーと選択で色が入る。

| 状態 | 上辺の3px |
| --- | --- |
| 未選択 | 透明（見えない） |
| **ホバー** | **`#ccc`** |
| **選択** | **`#424242`** ＋ 太字 ＋ 白地 |

いずれもカードの上辺より **5px 外の同じ位置**に出る。位置は動かない。

## 文字と下辺は動かない

持ち上げた分を `padding-top` で戻している。

| | 変更前 | 変更後 |
| --- | --- | --- |
| `margin-top` | 0 | **-5px** |
| `border-top` | 3px | 3px |
| `padding-top` | 10px | **15px** |
| **文字の位置** | 0+3+10 = **13** | -5+3+15 = **13** |
| 下辺 | — | 変更なし |

## はみ出せる理由

`.tabs` は #2020 で `overflow: hidden` から `display: flow-root` に変えている。BFC を作って float を含めるだけで**切り取りはしない**ため、負のマージンではみ出した分がそのまま描画される。

`overflow: hidden` のままだったら、この表現はできなかった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)