### PR TITLE
タブのアクセントの飛び出し量を 8px にする

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1297,13 +1297,13 @@ code {
   float: left;
   /* 上辺のアクセントをカードの外に出す。負のマージンで持ち上げた分を
      padding-top で戻すので、文字の位置と下辺は動かない
-     （margin -5 + border 3 + padding 15 = 13。未選択も選択も同じ）。
+     （margin -8 + border 3 + padding 18 = 13。未選択も選択も同じ）。
 
      全タブに掛けるのが要点で、選択やホバーのときだけ持ち上げると
      マウスを乗せるたびにタブが跳ねてしまう。
      未選択時の枠は透明なので、何も起きていないように見える */
-  padding: 15px 22px 10px;
-  margin: -5px 4px 0 0;
+  padding: 18px 22px 10px;
+  margin: -8px 4px 0 0;
   font-size: 1.15em;
   line-height: 1.4;
   letter-spacing: 0.02em;


### PR DESCRIPTION
#2025 の続き。5px では控えめだったため、カードの外に出す量を増やす。

```diff
 .tab_item {
-  padding: 15px 22px 10px;
-  margin: -5px 4px 0 0;
+  padding: 18px 22px 10px;
+  margin: -8px 4px 0 0;
 }
```

## 文字と下辺は動かない

持ち上げた分を `padding-top` で戻している。

| | 変更前 | 変更後 |
| --- | --- | --- |
| `margin-top` | -5px | **-8px** |
| `border-top` | 3px | 3px |
| `padding-top` | 15px | **18px** |
| **文字の位置** | -5+3+15 = **13** | -8+3+18 = **13** |
| 下辺 | — | 変更なし |

未選択・ホバー・選択のいずれも同じ位置に枠が出る点は #2025 のまま。

🤖 Generated with [Claude Code](https://claude.com/claude-code)