### PR TITLE
フッターの X と Feedly のアイコン位置を揃える

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -492,6 +492,9 @@ ul.social-button li a {
   display: block;
   width: fit-content;
   margin-top: 8px;
+  /* .feedly-btn は padding-left: 10px を持っており、.social-btn の 6px を
+     上書きしてしまう。隣の X ボタンと開始位置がずれるので戻す */
+  padding-left: 6px;
 }
 /* .feedly-btn（緑）はこの後ろに書かれており、詳細度が同じ (0,1,0) だと
    記述順で負けて緑の枠が残る。クラスを2つ重ねて順序に依存させない */
@@ -510,6 +513,13 @@ ul.social-button li a {
 /* 背面の菱形を透明にして、フレームとシェブロンだけを白で出す。
    両方を白にすると内部の造形が潰れて、ただの白い塊になる */
 .feedly-btn.feedly-btn-follow i {
+  /* .x-btn-follow i と同じ寸法・同じ収め方にして、アイコンの見た目の
+     大きさと位置を揃える。.social-btn i の既定は 14px で 3px 大きい */
+  width: 11px;
+  height: 11px;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
   background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjUxLjYyMiAyMDUuMzg5IDQ4Ny4zODUgNDMxLjM0NiI+PHBhdGggZmlsbD0ibm9uZSIgZD0iTTExMS42MTUgNDIwLjk0NUwyOTcuNjQgMjM0LjkybDE4Ni4wMjUgMTg2LjAyNUwyOTcuNjQgNjA2Ljk3IDExMS42MTUgNDIwLjk0NXoiLz48cGF0aCBmaWxsPSIjZmZmIiBkPSJNMjAxLjgzNyA2MjIuNzgyTDY0LjE3OSA0ODQuMTkzYy0xNi43NDItMTYuNzQyLTE2Ljc0Mi01My4wMTcgMC02OC44MjlsMTk3LjE4Ny0xOTguMTE3YzE1LjgxMi0xNS44MTIgNTEuMTU2LTE1LjgxMiA2Ni45NjkgMEw1MjYuNDUgNDE1LjM2NGMxNi43NDIgMTYuNzQyIDE2Ljc0MiA1My4wMTggMCA2OC44MjlMMzg4Ljc5MiA2MjIuNzgyYy04LjM3MSA4LjM3MS0yMS4zOTMgMTMuOTUyLTM0LjQxNSAxMy45NTJIMjM0LjM5MmMtMTIuMDkyIDAtMjQuMTg0LTUuNTgxLTMyLjU1NS0xMy45NTJ6bTEyNS41NjctNTMuOTQ3YzIuNzkxLTIuNzkgMi43OTEtOC4zNzEgMC0xMS4xNjFMMzAwLjQzIDUzMC43Yy0yLjc5LTIuNzkxLTguMzctMi43OTEtMTEuMTYxIDBsLTI2Ljk3NCAyNi45NzRjLTIuNzkgMi43OS0yLjc5IDguMzcxIDAgMTEuMTYxbDIxLjM5MyAyMC40NjNoMjIuMzIzbDIxLjM5My0yMC40NjN6bTAtMTE0LjQwNWMxLjg2LTEuODYgMS44Ni02LjUxMSAwLTguMzcxbC0yOC44MzQtMjguODM0Yy0xLjg1OS0xLjg2LTYuNTEtMS44Ni04LjM3IDBsLTgzLjcxMiA4My43MTFjLTIuNzkgMi43OTEtMi43OSA5LjMwMiAwIDEyLjA5MmwxOS41MzMgMTkuNTMzaDIyLjMyM2w3OS4wNi03OC4xMzF6bTAtMTEzLjQ3NmMxLjg2LTEuODYgMi43OTEtNy40NDEgMC05LjMwMUwyOTkuNSAzMDMuNzQ5Yy0xLjg2LTEuODYtNy40NC0xLjg2LTEwLjIzMSAwTDE0OC44MiA0NDQuMTk4Yy0xLjg1OSAxLjg2LTIuNzkgNy40NDEtLjkzIDkuMzAxbDIyLjMyMyAyMS4zOTRoMjEuMzkzbDEzNS43OTgtMTMzLjkzOXoiLz48L3N2Zz4=");
 }
 /* フッターの背景は #313030。ホバーで #333 にすると背景とのコントラストが


### PR DESCRIPTION
close #2022

## 原因: コミットが main に入っていなかった

#2015 で「アイコン位置を揃えた」と報告したが、**そのコミット（`54496ed5`）が `main` に含まれていない。**

```
$ git merge-base --is-ancestor 54496ed5 main
  含まれていない
```

`drop-home-social` ブランチに commit / push したものの、**PR #2015 がマージされたのはそれより前の状態**だった。私は `push OK` を確認しただけで、PR に反映されたかを確かめていなかった。

このPRで cherry-pick して取り込む。

## 内容（#2015 で入れそこねたもの）

ズレの原因は2つあり、どちらも**別クラスの既定値が残っていた**もの。

| 項目 | X | Feedly（修正前） | Feedly（修正後） |
| --- | --- | --- | --- |
| `padding-left` | 6px | **10px** | **6px** |
| アイコン `width/height` | **11px** | 14px | **11px** |
| `background-size` | contain | （未指定） | **contain** |
| `background-position` | center | （未指定） | **center** |

- `padding-left: 10px` … `.feedly-btn`（元のシェアボタン群用）の値。**横に複数アイコンを並べる前提**の余白で、単独のボタンには合わない
- アイコン 14px … `.social-btn i` の既定。`.x-btn-follow i` は 11px に絞っていたが、Feedly 側に同じ指定が無かった

`background-size` / `background-position` も揃えたのは、幅を合わせても**アイコンの余白の取り方が違うと見た目の重心がずれる**ため。

縦位置（`top: 2px`）は共通の `.social-btn i` から両方に効いており、元から揃っている。

## 検証

```
X ボタン     : padding-left 6px（.social-btn の既定）
Feedly ボタン: padding-left 6px（明示）

X アイコン     : width 11px / height 11px / contain / center
Feedly アイコン: width 11px / height 11px / contain / center
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)