### PR TITLE
「タグから記事を探す」とフッターの間隔を広げる

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1094,6 +1094,10 @@ code {
 /* 人気のタグ */
 .popular-articles {
   margin-top: 40px;
+  /* 下の余白が .margin-bottom-20 の 20px しか無く、上（ページャの下 56px と
+     見出しの上 48px）に比べて狭かった。フッターとの間隔を上側と揃える。
+     ページャの下が 56px なので、それに合わせる */
+  margin-bottom: 56px;
 }
 .popular-tag {
   list-style: none;


### PR DESCRIPTION
close #2021

## 原因: 上下の余白が非対称だった

| 位置 | 変更前 | 変更後 |
| --- | --- | --- |
| ページャ → 「タグから記事を探す」 | 56px | 56px |
| **「タグから記事を探す」→ フッター** | **20px** | **56px** |

上が 56px、下が 20px で **2.8倍の差**があった。

下側の余白は `.margin-bottom-20` の 20px しか無かった。これは Bootstrap 由来の**汎用ユーティリティ**で、「タグ雲とフッターの間隔」を意図した値ではない。ブロック内の要素間隔として使われていたものが、そのまま最後の余白になっていた。

## 変更

```diff
 .popular-articles {
   margin-top: 40px;
+  margin-bottom: 56px;
 }
```

ページャの下（`#page-nav` の `margin-bottom: 56px`）と同じ値にして、**「一覧の終わり → 次のブロック」の間隔を揃える**。

## 背景

#2018 でタグページにもタグ雲を出すようにしたことで、この余白が目に付くようになった。ホームでは以前から同じ状態だった。

## 確認

ma91n さんの環境で確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)