### PR TITLE
連載ナビのレイアウトを整え、連載の本数を出す

### DIFF
--- a/scripts/series.js
+++ b/scripts/series.js
@@ -16,9 +16,14 @@
  * 日目 / 第N弾）や、連載を束ねる年間企画との区別を推測に頼るため、
  * 実行時には残していない。判定はフロントマターだけを見る。
  *
- * 番号は出さない。本文が名乗る番号（「6本目です」）と日付順の位置は、
- * 70連載中37件でズレていた。索引記事を1本目に数えるかが連載ごとに違い、
- * 本文と食い違う番号を機械が示す方が、番号が無いより害が大きい。
+ * 出すのは全何本かまでで、今何本目かは出さない。
+ * 本文が名乗る番号（「6本目です」）は、索引記事を1本目に数えるかが
+ * 連載ごとに違う。実測では 43連載が数えず / 23連載が数え / 4連載は連載内でも
+ * 不統一だった。機械が一方の流儀で番号を振ると、他方の114記事で
+ * 本文の「4本目です」と食い違う。番号が無いより害が大きい。
+ *
+ * 全何本かはこの流儀に依存しないので出せる。索引は連載の目次であって
+ * 本編ではないため、本数には数えない。
  */
 
 let cache = null;
@@ -35,10 +40,13 @@ function build(site) {
   const series = new Map(); // 記事のパス -> その記事から見た連載
   for (const [name, posts] of groups) {
     const index = posts.find(p => p.tags && p.tags.some(t => t.name === 'インデックス'));
+    // 索引は本編に数えない。索引記事自身から見た本数も同じ値になる
+    const total = posts.length - (index ? 1 : 0);
 
     posts.forEach((post, i) => {
       series.set(post.path, {
         name,
+        total,
         index: index && index !== post ? index : null,
         prev: i > 0 ? posts[i - 1] : null,
         next: i < posts.length - 1 ? posts[i + 1] : null

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1127,44 +1127,136 @@ code {
   padding: 0;
 }
 
-/* 連載の前 / 次。関連記事・参照記事と同じ card に揃え、
-   自動生成のブロックであることを見た目でも一致させる */
-.series-nav .card > .series-nav-title {
-  padding: 0.8em 0.8em 0.4em;
+/* 連載の前 / 次。関連記事・参照記事と同じ card を使いつつ、
+   中身は記事ナビの形にする。前を左・次を右に置いて進行方向を示す */
+/* 本文のすぐ後ろに来るので、本文との間隔を空けて別のブロックだと分かるようにする */
+.series-nav {
+  margin-top: 40px;
+}
+.series-nav .card {
+  padding: 0;
+  overflow: hidden;
+}
+.series-nav-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.8em;
+  padding: 0.7em 0.9em;
+  border-bottom: 1px solid #ecebeb;
+}
+.series-nav-title {
   margin: 0;
   font-size: 1.2em;
   font-weight: bold;
 }
-.series-nav-list {
-  padding: 0 0.8em 0.6em;
-  margin: 0;
-  list-style: none;
-}
-.series-nav-list > li {
-  display: flex;
-  align-items: baseline;
-  gap: 0.6em;
-  padding: 0.5em 0;
-  border-bottom: 1px solid #ecebeb;
-}
-.series-nav-list > li:last-child {
-  border-bottom: none;
-}
-/* ラベルの幅を揃えて、記事名の開始位置を縦に並べる。
-   2文字（索引）と1文字（前・次）が混ざるため固定幅にする */
-.series-nav-label {
-  flex: 0 0 auto;
-  min-width: 2.6em;
-  padding: 0.1em 0.4em;
-  background: #f5f5f3;
+/* 「連載」は見出しの一部ではなくラベル。塗りつぶすと連載名より目立つので、
+   NEW ラベル（.newitem）と同じ薄い枠線だけの作りに揃える */
+.series-nav-kicker {
+  display: inline-block;
+  margin-right: 0.6em;
+  padding: 0 4px;
+  background-color: transparent;
+  border: 1px solid #dcdcdc;
   border-radius: 3px;
-  color: #555;
-  font-size: 0.85em;
-  text-align: center;
+  color: #6e6e6e;
+  font-size: 10px;
+  font-weight: normal;
+  line-height: 1.6;
+  vertical-align: middle;
 }
-.series-nav-list > li > a {
-  font-size: 1em;
+/* 連載の規模。連載名の対角に置く。長い連載名に押されて折り返すと
+   「全 7」「本」に割れて読めなくなるので nowrap で縮ませない */
+.series-nav-count {
+  flex: none;
+  margin: 0;
+  color: #777;
+  font-size: 0.9em;
+  white-space: nowrap;
+}
+/* 索引へは連載名そのものから辿る。別途「索引を見る」を置くと導線が二重になる */
+.series-nav-title > a {
   color: #424242;
+}
+.series-nav-title > a:hover {
+  color: #424242;
+  text-decoration: underline;
+}
+.series-nav-pair {
+  display: flex;
+}
+/* flex: 1 なので、片方しか無いときはその一方が幅いっぱいに広がる */
+.series-nav-item {
+  flex: 1 1 0;
+  display: block;
+  min-width: 0;
+  padding: 0.8em 0.9em;
+  color: #424242;
+}
+/* 背景色が変わることで押せると分かるので、文字色は本文と同じ黒のままにする。
+   a:hover のリンク色がここまで効くと、記事タイトルが青くなって落ち着かない */
+a.series-nav-item:hover,
+a.series-nav-item:hover .series-nav-item-title {
+  background: #f5f5f3;
+  color: #424242;
+  text-decoration: none;
+}
+.series-nav-next {
+  text-align: right;
+}
+.series-nav-prev + .series-nav-next {
+  border-left: 1px solid #ecebeb;
+}
+/* 行き先が無い側。リンクではないので薄く、上下は中央に置いて
+   隣のリンク（見出し＋タイトルの2行）と釣り合わせる */
+.series-nav-end {
+  display: flex;
+  align-items: center;
+  color: #777;
+  font-size: 0.9em;
+}
+.series-nav-next.series-nav-end {
+  justify-content: flex-end;
+}
+.series-nav-dir {
+  display: block;
+  margin-bottom: 0.2em;
+  color: #777;
+  font-size: 0.85em;
+}
+.series-nav-prev .series-nav-dir:before {
+  content: '‹ ';
+}
+.series-nav-next .series-nav-dir:after {
+  content: ' ›';
+}
+.series-nav-item-title {
+  display: block;
+  font-size: 1em;
+  line-height: 1.5;
+}
+/* 横に並べると1カラムが狭くなりすぎるため、縦に積む。
+   罫線も左から上に移す */
+@media (max-width: 767px) {
+  .series-nav-pair {
+    display: block;
+  }
+  .series-nav-next {
+    text-align: left;
+  }
+  .series-nav-prev + .series-nav-next {
+    border-left: none;
+    border-top: 1px solid #ecebeb;
+  }
+  .series-nav-next .series-nav-dir:after {
+    content: none;
+  }
+  .series-nav-next .series-nav-dir:before {
+    content: '› ';
+  }
+  .series-nav-next.series-nav-end {
+    justify-content: flex-start;
+  }
 }
 
 /* 関連記事は著者が書いた本文ではなく自動生成のブロックなので、

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -47,19 +47,36 @@
           <% if (series) { %>
           <nav class="series-nav margin-bottom-40" data-nosnippet aria-label="連載">
             <div class="card">
-              <p class="series-nav-title">連載：<%= series.name %></p>
-              <ul class="series-nav-list">
+              <div class="series-nav-head">
+                <%# 索引へは連載名から辿る。全記事は索引に並んでいるので、
+                    ここで一覧を再掲したり別のリンクを置いたりはしない %>
+                <p class="series-nav-title"><span class="series-nav-kicker">連載</span><% if (series.index) { %><a href="<%- url_for(series.index.path) %>"><%= series.name %></a><% } else { %><%= series.name %><% } %></p>
+                <%# 全何本かは索引を除いた本編の数。「今何本目」は出さない。
+                    本文が名乗る番号と流儀が割れており一致させられない（scripts/series.js） %>
+                <p class="series-nav-count">全 <%= series.total %> 本</p>
+              </div>
+              <%# 前を左、次を右に置いて進行方向を示す。片方しか無いときは
+                  その一方が幅いっぱいに広がる（初回は次だけ、最終回は前だけ） %>
+              <div class="series-nav-pair">
+                <%# 端では行き先が無いことを明示する。連載が完結したのか執筆中なのかは
+                    データから分からないので、事実として言える「いま時点で最新」に留める %>
                 <% if (series.prev) { %>
-                <li><span class="series-nav-label">前</span><a href="<%- url_for(series.prev.path) %>"><%= series.prev.title %></a></li>
+                <a class="series-nav-item series-nav-prev" href="<%- url_for(series.prev.path) %>">
+                  <span class="series-nav-dir">前の記事</span>
+                  <span class="series-nav-item-title"><%= series.prev.title %></span>
+                </a>
+                <% } else { %>
+                <span class="series-nav-item series-nav-prev series-nav-end">この連載の最初の記事です</span>
                 <% } %>
                 <% if (series.next) { %>
-                <li><span class="series-nav-label">次</span><a href="<%- url_for(series.next.path) %>"><%= series.next.title %></a></li>
+                <a class="series-nav-item series-nav-next" href="<%- url_for(series.next.path) %>">
+                  <span class="series-nav-dir">次の記事</span>
+                  <span class="series-nav-item-title"><%= series.next.title %></span>
+                </a>
+                <% } else { %>
+                <span class="series-nav-item series-nav-next series-nav-end">この連載の最新の記事です</span>
                 <% } %>
-                <%# 索引には全記事が並んでいる。ここで一覧を再掲すると重複する %>
-                <% if (series.index) { %>
-                <li><span class="series-nav-label">索引</span><a href="<%- url_for(series.index.path) %>"><%= series.index.title %></a></li>
-                <% } %>
-              </ul>
+              </div>
             </div>
           </nav>
           <% } %>


### PR DESCRIPTION
#2040 で入れた連載ナビのレイアウトを整え、あわせて連載の本数を出します。

## before

連載名・索引へのリンク・前・次を縦に並べたリストでした。前後関係が形から伝わらず、索引への導線も本文リンクと見分けが付きませんでした。

## after

```
┌──────────────────────────────────────────────┐
│ [連載] Go1.27リリース                 全 8 本 │
├───────────────────────┬──────────────────────┤
│ ‹ 前の記事             │          次の記事 › │
│ Go 1.27のgoroutine…   │  Go 1.27の構造体リ… │
└───────────────────────┴──────────────────────┘
```

- **前を左・次を右の2カラム**にして、進行方向を形で示す
- **索引へは連載名そのものからリンク**する。「索引を見る」を別に置くと導線が二重になる
- **「連載」ラベルは NEW ラベル（`.newitem`）と同じ枠線だけ**の作りに揃える。塗りつぶしは連載名より目立ってしまう
- **ホバーで文字色は変えず背景色だけ変える**。リンク色がタイトルまで効くと記事タイトルが青くなって落ち着かない
- 本文との間に **40px** 空け、別ブロックだと分かるようにする
- 768px 未満では縦に積む。横並びだと1カラムが狭くなりすぎる

## 端の表示

```
│ この連載の最初の記事です │          次の記事 › │
```

連載が完結したのか執筆中なのかはデータから分からないので、**「最終回」とは書きません**。事実として言える「この連載の最新の記事です」に留めています。セルが常に2つ揃うので、片方だけのときに幅いっぱいへ伸びる不自然さも消えます。

## 全 N 本

連載名の対角に置きます。索引は連載の目次であって本編ではないので、本数には数えません。

## 「今何本目」を出さない理由

本文が名乗る番号（「4本目です」）は、**索引を1本目に数えるかが連載ごとに違います**。71連載の実測:

| 流儀 | 連載数 |
| --- | --- |
| 索引を数えない | 43 |
| 索引を1本目に数える | 23 |
| 連載内でも不統一 | 4 |
| 番号を名乗る記事なし | 1 |

機械が一方の流儀で番号を振ると、**114記事**でナビの「3 / 7」と本文の「4本目です」が食い違います。全何本かはこの流儀に依存しないので出せます。

## 確認

`hexo clean && hexo generate` で 10471 files。連載ナビの付いた記事 **620件すべて**に「全 N 本」が入り、途中 / 最初 / 最新の3状態を目視確認しました。記事本文は1件も変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
