### PR TITLE
/categories/ のカテゴリ一覧リンクをサイドバーと同じ黒色にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ bootstrap-subset → metronic → theme-styles.styl の順で `/css/site.css` �
   | クラス無しの `h2`（関連記事・We're hiring 等） | `1.85em` = 24.05px | 〃 |
   | サイドバーの `h2` | `1.4em` = 18.2px | 〃 |
   | 本文見出し h1〜h5 | `2.0 / 1.85 / 1.7 / 1.55 / 1.4em` = 26 / 24.05 / 22.1 / 20.15 / 18.2px | 〃 |
-  | 一覧ページの見出し `.list-page` | `2em` = 26px | 〃 |
+  | 一覧ページの見出し `.list-page` | 記事タイトルと同じ（`.article-title` と同一ルール） | 〃 |
   | 一覧ページの統計（数値 / ラベル） | `clamp(17px, 1rem + 0.4vw, 20px)` / 12px | 〃 |
   | コードブロック | 13px（`line-height` は `font-size × 1.6` で追従） | `highlight.styl` の変数 |
 

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -730,7 +730,11 @@ code {
   font-size: 20px;
   font-weight: bold;
 }
-.article-title {
+/* .list-page はテンプレート上すべての h1 に付くページ見出し。
+   記事タイトルより小さく細い独自サイズ（2em / bold）を持っていたが、
+   「ページの主題を名乗る h1」という役割は同じなので見た目ごと揃える */
+.article-title,
+.list-page {
   color: #424242;
   /* 新しいフォントスタックでは実際の太字フェイス（Hiragino Sans の W8 など）が
      当たるため、700 より太くしても潰れずに出る */
@@ -1357,12 +1361,6 @@ a.series-nav-item:hover .series-nav-item-title {
   padding-right: 0.1em;
 }
 /* 一覧ページ */
-.list-page {
-  font-weight: bold;
-  /* ブラウザ既定の h1（2em）に頼っていて、CSS のどこにも書かれていなかった。
-     見た目は変えずに、決まる場所をここ1箇所にする */
-  font-size: 2em;
-}
 .summary {
   font-weight: bold;
   list-style: none;

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -32,7 +32,7 @@
     <div class="widget">
       <h2 class="list-page">カテゴリから記事を探す</h2>
       <div class="widget">
-        <ul class="nav margin-bottom-40">
+        <ul class="nav sidebar-categories margin-bottom-40">
         <%
           const compareFunc = (a, b) => b.posts.length - a.posts.length;
           const categoryRanks = site.categories.data.sort(compareFunc)

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -6,7 +6,7 @@
 
   <section id="main" class="margin-top-30">
 
-    <div class="widget">
+    <div class="widget margin-bottom-40">
       <h2 class="list-page">カテゴリ別 投稿数の推移（四半期ごと）</h2>
       ※2018年以前は年単位で表示
       <div id="category-chart" style="width: 100%; height: 400px;"></div>
@@ -28,7 +28,6 @@
       myChart.setOption(option);
     </script>
 
-    <br>
     <div class="widget">
       <h2 class="list-page">カテゴリから記事を探す</h2>
       <div class="widget">

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -6,8 +6,10 @@
 
   <section id="main" class="margin-top-30">
 
+    <h1 class="list-page">カテゴリ一覧</h1>
+
     <div class="widget margin-bottom-40">
-      <h2 class="list-page">カテゴリ別 投稿数の推移</h2>
+      <h2>カテゴリ別 投稿数の推移</h2>
       ※四半期ごとの投稿数を表示（2018年以前は年単位）
       <div id="category-chart" style="width: 100%; height: 400px;"></div>
     </div>
@@ -29,7 +31,7 @@
     </script>
 
     <div class="widget">
-      <h2 class="list-page">カテゴリから記事を探す</h2>
+      <h2>カテゴリから記事を探す</h2>
       <div class="widget">
         <ul class="nav sidebar-categories margin-bottom-40">
         <%

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -7,8 +7,8 @@
   <section id="main" class="margin-top-30">
 
     <div class="widget margin-bottom-40">
-      <h2 class="list-page">カテゴリ別 投稿数の推移（四半期ごと）</h2>
-      ※2018年以前は年単位で表示
+      <h2 class="list-page">カテゴリ別 投稿数の推移</h2>
+      ※四半期ごとの投稿数を表示（2018年以前は年単位）
       <div id="category-chart" style="width: 100%; height: 400px;"></div>
     </div>
 

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -6,7 +6,7 @@
 
   <section id="main" class="margin-top-30">
 
-    <h1 class="list-page">カテゴリ一覧</h1>
+    <h1 class="list-page margin-bottom-20">カテゴリ一覧</h1>
 
     <div class="widget margin-bottom-40">
       <h2>カテゴリ別 投稿数の推移</h2>


### PR DESCRIPTION
## 概要

Fixes #2051

/categories/ ページの見た目・構造の修正です。レビュー中の指摘を随時取り込んでいます。

## 対応内容

1. **リンク色の不一致（#2051）**: サイドバー版（`_widget/category.ejs`）の `ul` には `sidebar-categories` クラスがあり `color: #424242` が効いていますが、`/categories/` ページ側の `ul` にはクラスが無く、リンク既定の青のままでした。同じクラスを付与し、色・区切り線・余白ごとサイドバーと統一しました。
2. **セクション間隔**: グラフとカテゴリ一覧の間が `<br>` 1つ（約19px）で詰まって見えていたため、metronic の既存ユーティリティ `margin-bottom-40` に置き換えました。
3. **見出しの表現**: 「カテゴリ別 投稿数の推移（四半期ごと）」の「（四半期ごと）」を注記行へ移し、見出しは対象を名乗るだけにしました。
4. **h1 の欠落**: 一覧ページの中で /categories/ だけ h1 がありませんでした。他の一覧ページと同じ `h1.list-page` で「カテゴリ一覧」を追加し、セクション見出しはクラス無し `h2` にして階層を付けました。`<title>`・パンくずとも表記が揃います。
5. **h1 の下余白**: h1 直後にセクション見出しが続くこのページでは Bootstrap 既定の `.5rem` では詰まって見えるため、`margin-bottom-20` を付けました。
6. **ページ見出しの見た目統一**: `.list-page`（テンプレート上すべての h1 に付くページ見出し）が `2em` / `bold` で記事タイトル（`clamp(24px, 1.325rem + 0.9vw, 32px)` / `800`）より小さく細かったため、`.article-title` のルールに統合しました。**タグ・カテゴリ・著者・アーカイブページの h1 も同様に変わります。** CLAUDE.md の実効サイズ基準表も更新済みです。

## 動作確認

- ローカルで hexo clean → hexo server を実行し、`/categories/` で以下を確認
  - カテゴリ一覧リンクが黒色になること
  - h1「カテゴリ一覧」（記事タイトルと同サイズ・同ウェイト）→ セクション h2 の階層と余白
  - 生成された site.css で clamp が Stylus に潰されず出力されていること（`unquote` 済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)