### PR TITLE
概要文 .lede のスタイルを1箇所に定義する

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -318,8 +318,10 @@ body.page-header-fixed .header {
   font-weight: bold;
   margin-bottom: 4px;
 }
-.career-counseling .lede {
-  font-size: 0.9em;
+/* 記事の概要文。トップページの一覧と We're hiring カードで共用。
+   サイズは body の 13px を継承させ、関連記事リンクなど記事末尾ゾーンと揃える (#2048)。
+   line-height は normal だとフォント依存で環境により 1.4〜1.7 程度に揺れるため明示する */
+.lede {
   line-height: 1.6;
 }
 /******************************


### PR DESCRIPTION
## 概要

Fixes #2048

We're hiring カードの説明文が `0.9em`（11.7px）で、周辺テキストより小さく読みづらい状態でした。

Issue の「1em に揃える」をそのまま実装する前に役割から整理したところ、トップページの記事概要文が**同じ `div.lede`** で、そちらは無指定（body の 13px 継承・line-height はフォント依存の normal）だと分かりました。同じクラス・同じ役割なので、スタイルを1箇所に統一しています。

## 対応

カード限定の `.career-counseling .lede` を廃止し、`.lede` を1箇所で定義しました。

- **font-size**: 宣言なし（body の 13px を継承）。`1em` は継承と同値の no-op なので書きません。関連記事リンク・トップページ概要文と同じ実効値になり、カード内はラベルの太字で階層が付きます
- **line-height**: `1.6` を明示。トップページ側は従来 `normal` でフォント環境により約1.4〜1.7に揺れていたため、固定されます

## 影響範囲

- We're hiring カードの説明文: 11.7px → 13px
- トップページ・一覧の概要文: サイズ変わらず、line-height が normal → 1.6 に固定（微小な行送りの変化）

## 動作確認

- 生成された site.css で `.lede { line-height: 1.6 }` の1箇所のみになり、`.career-counseling .lede` が消えていることを確認
- ローカルサーバ（トップページ・記事ページ）で表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)