### PR TITLE
脚注のフォントサイズを本文から一段落として 13px にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,7 @@ bootstrap-subset → metronic → theme-styles.styl の順で `/css/site.css` �
   | 本文見出し h1〜h5 | `2.0 / 1.85 / 1.7 / 1.55 / 1.4em` = 26 / 24.05 / 22.1 / 20.15 / 18.2px | 〃 |
   | 一覧ページの見出し `.list-page` | 記事タイトルと同じ（`.article-title` と同一ルール） | 〃 |
   | 一覧ページの統計（数値 / ラベル） | `clamp(17px, 1rem + 0.4vw, 20px)` / 12px | 〃 |
+  | 脚注（`#footnotelist li`） | `1em` = 13px | 〃 |
   | コードブロック | 13px（`line-height` は `font-size × 1.6` で追従） | `highlight.styl` の変数 |
 
 - コードブロックのサイズは本文との相対バランスを見て 15px → 14px → 13px と

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -952,6 +952,11 @@ code {
 
 #footnotelist li {
   padding-top: 0.2em;
+  /* 脚注は補足情報なので本文（.article-entry li の 1.2em）から一段落とす。
+     Zenn / Qiita / はてなも本文の約0.9倍に縮小している。中間値を新設せず、
+     関連記事など記事末尾ゾーンと同じ body の 13px に乗せる (#2060)。
+     line-height は既存の 1.75em が自身のサイズ基準で再計算されるため触らない */
+  font-size: 1em;
 }
 .toc-section {
   padding: 50px 0px 0px 0px;


### PR DESCRIPTION
## 概要

Fixes #2060

脚注（`#footnotelist li`）に専用のサイズ指定が無く、`.article-entry li` の `1.2em`（15.6px）がそのまま効いて本文と完全に同格でした。補足情報として一段落とします。

## 検討の経緯

他サービスの脚注スタイルを CSS で直接確認しました。

| サービス | 脚注のサイズ | 追加の処理 |
| --- | --- | --- |
| Zenn | `0.9em` | 文字色をグレーに落とす |
| Qiita | `0.9em` | 上に区切り線 + `margin-top: 40px` |
| はてなブログ（共通CSS） | `90%` | `margin-top: 3em` |

3サービスとも「本文の約0.9倍」で一致していますが、0.9倍（約14px）はこのサイトの 13px / 15.6px の2段スケールに無い中間値を新設することになるため、既存の段である **body の 13px（`1em`）** に乗せました。脚注が表示される記事末尾ゾーン（関連記事・参照記事・We're hiring の説明文 #2063）と同じ 13px 基調に揃います。

- **line-height**: 既存の `1.75em !important` が自身のフォントサイズ基準で再計算される（13px × 1.75 = 22.75px）ため触っていません
- **文字色**: Zenn のグレー化は見送り。既存コードの「色数を増やさない」方針に従い、サイズ + `<hr>` で階層を示します
- 詳細度は `#footnotelist li`（1,0,1）>` .article-entry li`（0,1,1）で確実に勝ちます
- CLAUDE.md の実効サイズ基準表に脚注の行を追加しました

## 動作確認

- 生成された site.css に `#footnotelist li { font-size: 1em }` が出力されることを確認
- ローカルサーバで脚注のある記事（/articles/20260122a/ など）の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)