### PR TITLE
一覧の記事概要文を本文と同じ 1.2em にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,7 @@ bootstrap-subset → metronic → theme-styles.styl の順で `/css/site.css` �
   | 一覧ページの見出し `.list-page` | 記事タイトルと同じ（`.article-title` と同一ルール） | 〃 |
   | 一覧ページの統計（数値 / ラベル） | `clamp(17px, 1rem + 0.4vw, 20px)` / 12px | 〃 |
   | 脚注（`#footnotelist li`） | `1em` = 13px | 〃 |
+  | 記事概要文 `.lede`（一覧 / We're hiring カード） | `1.2em` = 15.6px / 継承 = 13px | 〃 |
   | コードブロック | 13px（`line-height` は `font-size × 1.6` で追従） | `highlight.styl` の変数 |
 
 - コードブロックのサイズは本文との相対バランスを見て 15px → 14px → 13px と

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -318,11 +318,15 @@ body.page-header-fixed .header {
   font-weight: bold;
   margin-bottom: 4px;
 }
-/* 記事の概要文。トップページの一覧と We're hiring カードで共用。
-   サイズは body の 13px を継承させ、関連記事リンクなど記事末尾ゾーンと揃える (#2048)。
+/* 記事の概要文。一覧（トップ・タグ・カテゴリ・著者）と We're hiring カードで共用。
    line-height は normal だとフォント依存で環境により 1.4〜1.7 程度に揺れるため明示する */
 .lede {
   line-height: 1.6;
+}
+/* 一覧の概要文はメインコンテンツなので本文と同じ 1.2em にする (#2064)。
+   We're hiring カード側は宣伝の補足なので body の 13px 継承のまま (#2048) */
+.archive-post-item .lede {
+  font-size: 1.2em;
 }
 /******************************
  見出し


### PR DESCRIPTION
## 概要

Fixes #2064

トップページなど一覧の記事概要文（`div.lede`）が body の 13px 継承のままで、メインコンテンツなのに本文（15.6px）より小さい状態でした。本文と同じ `1.2em` にします。

## 対応

Issue の検討事項だったスコープ設計は次の整理にしました。

- `.lede` の共通部分（`line-height: 1.6`）はそのまま1箇所
- 一覧側だけ `.archive-post-item .lede { font-size: 1.2em }` を追加。`archive-post.ejs` は**トップ・タグ・カテゴリ・著者**の一覧ページで使われており、いずれも「一覧＝メインコンテンツ」の文脈なので、このスコープで過不足なく効きます
- We're hiring カード側の `.lede` は宣伝の補足テキストなので 13px 継承のまま（#2063 の判断を維持）
- CLAUDE.md の実効サイズ基準表に概要文の行を追加

## 残る確認ポイント（レビュー時に見てください）

- 記事タイトル（`.archive-post-title` 20px 太字）との差が縮まるので、一覧での階層感
- 概要文の行数が増えることによる一覧のカード高さ・モバイル表示

## 動作確認

- 生成された site.css に `.archive-post-item .lede { font-size: 1.2em }` が出力されることを確認
- トップページ・タグページの一覧に lede が描画されることを確認（各25件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)