### PR TITLE
タブレット以下はサイドバーを本文の下に落とす

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -991,7 +991,17 @@ code {
 .toc-section a:hover, .toc-section a:focus {
   background-color: #efefef;
 }
-@media screen and (max-width: 768px){
+/* タブレット以下はサイドバーを本文の下に落とす (#2044)。
+   Bootstrap の md（768px〜）で横並びになるが、一覧のサイドバーは col-md-2 で
+   約130pxしかなく窮屈。境界はヘッダーメニューの切替（max-width: 1024px）に揃え、
+   iPad の縦（768px）横（1024px）ともモバイルと同じ縦積みにする */
+@media (max-width: 1024px) {
+  main.blog-posts,
+  aside.blog-sidebar {
+    width: 100%;
+  }
+  /* サイドバーごと本文の下に落ちた目次は末尾に出ても役に立たないため隠す。
+     以前はモバイル（768px）だけ隠していた */
   .toc-section {
     display: none;
   }


### PR DESCRIPTION
## 概要

Fixes #2044

タブレット（768px〜1024px）で PC と同じ2カラムレイアウトになり、サイドバーが窮屈でした。

- 一覧ページ（`archive.ejs`）: `col-md-2` のサイドバーが**約130px幅**（検索ボックス・カテゴリ一覧が押し潰される）
- 記事ページ（`article.ejs`）: `col-md-3` の目次カラム

Bootstrap の md ブレークポイント（768px〜）で横並びになるのが原因です。

## 対応

- `max-width: 1024px` で `.blog-posts` / `.blog-sidebar` を `width: 100%` にし、モバイルと同じ縦積みに落とす
  - 境界の 1024px は、**ヘッダーメニューが既にモバイル表示へ切り替わる境界**に揃えた値です。「≤1024 = ナロー」というサイト既存の区分と一致し、iPad の縦（768px）横（1024px）ともモバイルレイアウトになります
  - 詳細度は `main.blog-posts`（0,1,1）> `.col-md-10`（0,1,0）で、メディアクエリの重なり（768〜1024px）でも確実に勝ちます
- 記事ページの目次（`.toc-section`）はサイドバーごと本文の下に落ちると末尾に出て役に立たないため、非表示の境界を 768px → 1024px に広げました

## 動作確認

- 生成された site.css に `@media (max-width: 1024px)` のルールが出力されることを確認
- ローカルサーバでブラウザ幅を 768〜1024px にし、一覧・記事ページとも縦積みになること、記事ページで目次が出ないことを確認してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)
