### PR TITLE
記事メタデータの項目間隔を flex の gap 1箇所に集約する

### DIFF
--- a/scripts/author_generator.js
+++ b/scripts/author_generator.js
@@ -131,9 +131,11 @@ hexo.extend.helper.register('count_authors', function(year='all') {
 
 hexo.extend.helper.register('post_author_link', function(post) {
   const authors = [].concat(post.author || 'Anonymous');
+  // li の直下に li を入れるとパーサが外側の li を閉じてしまい、
+  // 著者だけ blog-info-item を持たない li に分割されて間隔が崩れる (#2049)
   const link = authors.map(author =>
-    `<li><a href="/authors/${encodeURI(author)}" title="${author}さんの記事一覧へ" class="post-author">${author}</a></li>`
-  ).join("")
+    `<a href="/authors/${encodeURI(author)}" title="${author}さんの記事一覧へ" class="post-author">${author}</a>`
+  ).join("、")
   return `<li class="blog-info-item">${link}</li>`
 });
 

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -830,15 +830,6 @@ code {
   overflow: hidden;
 }
 
-.blog-info ul {
-  padding-inline-start: 10px;
-}
-.blog-info-item a {
-  padding: 2px 16px 2px 16px;
-}
-.blog-info-item:first-child > a {
-  padding-left:0px;
-}
 .publish-date {
   color: #616161;
   font-weight: bold;
@@ -922,15 +913,17 @@ code {
   margin: 20px 0;
   padding: 8px 0;
 }
-
- .blog-info-item {
-  padding-left: 8px;
-}
-/* 日付・著者・カテゴリ・タグはリンクで、a 側の padding 16px が間隔を作る。
-   PV と文字数は素のテキストでその余白が無く、8px しか離れないため
-   隣の項目と続きの語のように読めてしまう。両方に同じ間隔を与える */
-.blog-info-item.blog-info-metric {
-  padding-left: 28px;
+/* 項目間の間隔は gap の1箇所で決める。
+   以前は a の padding 16px・li の padding 8px・metric 専用の 28px・
+   タグの margin と項目の種類ごとに別の仕組みで間隔を作っており、
+   実効値が 20〜38px までバラついていた (#2049)。
+   28px は PV・文字数の間隔として使っていた値。
+   折り返し時は各行が字下げ無しで頭から始まる */
+.blog-info {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px 28px;
 }
 /* 補足が title にあることを示す。点線と help カーソルは abbr で使われる
    慣習で、これが無いとツールチップの存在に気づけない。
@@ -941,16 +934,6 @@ code {
   cursor: help;
   text-decoration: underline dotted #bbb;
   text-underline-offset: 3px;
-}
-.blog-info-item:first-child {
-  padding-left: 0;
-  border-left: none;
-}
-.blog-info-item ul li:first-child {
-  padding-left: 4px;
-}
-.blog-info-item ul li {
-  margin-right: 10px;
 }
 
 
@@ -1075,7 +1058,6 @@ code {
 .post-author {
   color: #616161;
   font-weight: bold;
-  padding-right: 10px;
 }
 .author-list {
   padding-inline-start: 0px;


### PR DESCRIPTION
## 概要

Fixes #2049

記事メタデータ（日付・著者・タグ・PV・文字数）の間隔がバラついて見える問題の修正です。

## 根本原因

`post_author_link` ヘルパーが `<li class="blog-info-item"><li><a>著者</a></li></li>` という **li の入れ子（不正な HTML）** を出力していました。ブラウザのパーサは li 直下の li を許さず外側の li を閉じるため、著者だけ `blog-info-item` クラスを持たない li に分割され、間隔用の padding が一切効いていませんでした。

さらに、間隔が項目の種類ごとに**4つの別々の仕組み**で作られていました。

| 間隔 | 実効値 | 由来 |
| --- | --- | --- |
| 日付 → 著者 | 約20px | バグにより padding 無し（inline-block の空白のみ） |
| 著者 → タグ | 約26px | `.post-author` の 10px + li の 8px + チップ margin 4px |
| タグ → PV | 約38px | チップ margin 6px + metric の 28px |
| PV → 文字数 | 約32px | metric の 28px |

## 対応

1. **ヘルパー修正**: 1つの li 内に a を並べる正しい HTML に（共著は「、」区切り。#2049 の根本原因）
2. **間隔の一本化**: `.blog-info` を `display: flex` にし、`gap: 4px 28px` の1箇所で全項目の間隔を決める。28px は Issue で「いい感じ」とされた PV・文字数の間隔の既存値。a の padding 16px / li の padding 8px / metric 専用 28px / `.post-author` の padding-right はすべて削除
3. **死んだルールの削除**: `blog-info` 内に ul は存在しないため `.blog-info ul` / `.blog-info-item ul li` 系を削除

## 副次効果

- `.blog-info-item a` の padding 16px が、タグチップの意図した padding 8px を詳細度（0,1,1 > 0,1,0）で潰していたのが解消され、記事ページのチップがタグページ等と同じ見た目に戻ります
- flex 化により折り返し時に各行が字下げ無しで頭から始まるため、#2050（モバイルでタグ折り返し時の不要な隙間）の症状にも効いている可能性があります。マージ後にモバイル幅で確認してください

## 動作確認

- 記事ページ・共著記事（/articles/20190627/）・トップページで正しい HTML が生成されることを確認
- 生成された site.css で gap ルールの出力と旧ルールの消滅を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
