### PR TITLE
X フォローボタンのラベルを「フォロー」にする

### DIFF
--- a/themes/future/layout/_partial/footer.ejs
+++ b/themes/future/layout/_partial/footer.ejs
@@ -8,13 +8,17 @@
           <p><%- theme.about %></p>
           <div class="social-btn x-btn-follow x-btn-follow">
             <a
-              href="https://x.com/intent/follow?screen_name=future_techblog %>"
+              href="https://x.com/intent/follow?screen_name=future_techblog"
               target="_blank"
               rel="nofollow noopener"
             >
               <i></i
-              ><span class="x-btn-follow-label"
-                > フューチャー技術ブログをフォロー</span
+              <%# social-btn-label は Feedly 側と同じアイコンとの間隔（margin-left 6px）を
+                  与えるために併用する。無いとテキスト開始位置が Feedly とズレる %>
+              ><span class="social-btn-label x-btn-follow-label"
+                <%# X アイコンが「X」と読めるため「Xでフォロー」だと X が重複して見える。
+                    サービス名はアイコンに任せて動詞だけにする (#2036) %>
+                > フォロー</span
               >
             </a>
           </div>


### PR DESCRIPTION
## 概要

Fixes #2036

フッターの X フォローボタンのラベル「フューチャー技術ブログをフォロー」を「フォロー」にしました。

## 対応

- 当初「Xでフォロー」にしたところ、X の SVG アイコンが「X」と読めるため「X Xでフォロー」と重複して見えるという指摘があり、サービス名はアイコンに任せて動詞だけの「フォロー」にしました
- **アイコンとテキストの間隔を Feedly と統一**: Feedly のラベルは `.social-btn-label`（`margin-left: 6px`）を持つのに対し、X のラベルは半角スペース1個分（約3px）しかなく、テキスト開始位置が微妙にズレていました。X のラベルにも `social-btn-label` を併用して同じ仕組みで揃えています
- バグ修正1件: `href="...screen_name=future_techblog %>"` と EJS の閉じタグ残骸がテンプレートに残っており、レンダリング後の URL 末尾に空白が混入していました。除去しています

## 動作確認

- ローカルでフッターの描画を確認: ラベル「フォロー」、アイコンとの間隔が Feedly ボタンと同一（6px + スペース）、href が末尾空白なしの正しい URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
