### PR TITLE
連載ナビをモバイルでも 前 | 次 の横並びのまま保つ

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1242,27 +1242,15 @@ a.series-nav-item:hover .series-nav-item-title {
   font-size: 1em;
   line-height: 1.5;
 }
-/* 横に並べると1カラムが狭くなりすぎるため、縦に積む。
-   罫線も左から上に移す */
+/* モバイルでも縦に積まず、前 | 次 の横並び構造を保つ (#2045)。
+   狭い幅で長いタイトルが何行も折り返して縦積みに見えるのが問題だったので、
+   構造ではなくタイトル側を2行で省略して解決する */
 @media (max-width: 767px) {
-  .series-nav-pair {
-    display: block;
-  }
-  .series-nav-next {
-    text-align: left;
-  }
-  .series-nav-prev + .series-nav-next {
-    border-left: none;
-    border-top: 1px solid #ecebeb;
-  }
-  .series-nav-next .series-nav-dir:after {
-    content: none;
-  }
-  .series-nav-next .series-nav-dir:before {
-    content: '› ';
-  }
-  .series-nav-next.series-nav-end {
-    justify-content: flex-start;
+  .series-nav-item-title {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
## 概要

Fixes #2045

モバイルで連載ナビゲーターが折り返され、「前の記事 | 次の記事」の構造が崩れる問題の修正です。

## 現状と対応

従来の CSS は 767px 以下で `.series-nav-pair` を `display: block` にし、**意図的に縦積み**へ切り替えていました（「横に並べると1カラムが狭くなりすぎる」という判断）。Issue の要望は横並び構造の維持なので、方針を反転しています。

- 縦積みへの切り替え（と、それに伴う罫線を左→上へ移す・矢印の向きを変える・寄せを変える上書き群）を削除し、**全幅で 前 | 次 の横並び**を維持
- 狭い幅の問題の実体は「長い記事タイトルの多段折り返し」なので、モバイルではタイトルを **2行の line-clamp で省略**（`-webkit-line-clamp: 2`。リンクプレビューカードの説明文と同じ既存イディオム）
- タイトル全文は DOM に残るためスクリーンリーダーには全文が読まれます

## 動作確認

- 生成された site.css で、縦積み系ルールの消滅と line-clamp ルールの出力を確認
- 連載記事（/articles/20260806a/ など）でナビが描画されることを確認
- モバイル幅（〜767px）で 前 | 次 が横並びのまま、タイトルが2行で「…」省略されることをブラウザで確認してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)
