### PR TITLE
/tags/ に h1・統計・「今年使われ始めたタグ」を追加する

### DIFF
--- a/scripts/tags.js
+++ b/scripts/tags.js
@@ -14,6 +14,25 @@ hexo.extend.helper.register('count_tags', function() {
   return this.site.tags.length;
 });
 
+// 今年になって初めて使われたタグ。新しく登場したトピックの入口として
+// /tags/ に並べる (#2052)。年初は空になりうるので、テンプレート側は
+// 空なら節ごと出さない
+hexo.extend.helper.register('new_tags_of_year', function() {
+  const year = new Date().getFullYear();
+  return this.site.tags
+    .map(tag => {
+      const first = tag.posts.map(p => p.date).reduce((a, b) => (a.isBefore(b) ? a : b));
+      return {name: tag.name, path: tag.path, count: tag.posts.length, first};
+    })
+    .filter(t => t.first.year() === year)
+    .sort((a, b) => b.first - a.first);
+});
+
+hexo.extend.helper.register('median_tags_per_post', function() {
+  const counts = this.site.posts.map(p => (p.tags ? p.tags.length : 0)).sort((a, b) => a - b);
+  return counts[Math.floor(counts.length / 2)] || 0;
+});
+
 hexo.extend.helper.register('ranking_tags', function() {
   const tagPosts = this.site.tags.map(tag => ({tag:tag, posts:tag.posts, count:tag.posts.length, shareCount:totalCount(tag.posts)}));
 

--- a/scripts/tags.js
+++ b/scripts/tags.js
@@ -41,11 +41,13 @@ hexo.extend.helper.register('ranking_tags', function() {
   // 5記事以上、シェア数/投稿数のランキング
   const rankings = tagPosts.filter(tp => tp.count >= 5).sort(compareFunc).slice(0, 30)
 
+  // マークアップは関連タグ・「今年使われ始めたタグ」と同じチップに揃える。
+  // 以前は素のテキストリンクで、同じページ内でタグの見た目が割れていた (#2052)
   let result = "";
   rankings.map(tp => {
-    result += `<li class="popular-tag-list"><a href="/tags/${tp.tag.name}" title="&#9825;${tp.shareCount}">${tp.tag.name} <span class="pupular-tag-count">${tp.count}</span></a></li>`;
+    result += `<li class="tag-list-item"><a class="tag-list-link" href="${this.url_for(tp.tag.path)}" rel="tag" title="${tp.tag.name} の記事 ${tp.count}本（総シェア ${tp.shareCount}）">${tp.tag.name}<span class="tag-list-count">${tp.count}</span></a></li>`;
   });
-  return `<ul class="popular-tag">${result}</ul>`;
+  return `<div class="blog-tags"><div class="widget"><ul class="tag-list">${result}</ul></div></div>`;
 });
 
 const totalCount = (posts) => {

--- a/scripts/tags.js
+++ b/scripts/tags.js
@@ -14,18 +14,17 @@ hexo.extend.helper.register('count_tags', function() {
   return this.site.tags.length;
 });
 
-// 今年になって初めて使われたタグ。新しく登場したトピックの入口として
-// /tags/ に並べる (#2052)。年初は空になりうるので、テンプレート側は
-// 空なら節ごと出さない
-hexo.extend.helper.register('new_tags_of_year', function() {
-  const year = new Date().getFullYear();
+// 初出が新しいタグ。新しく登場したトピックの入口として /tags/ に並べる (#2052)。
+// 「今年初出」だと年明けや更新が止まったときに空になるため、
+// トップページの「新着記事」と同じ発想の件数固定にする
+hexo.extend.helper.register('recent_new_tags', function(limit = 15) {
   return this.site.tags
     .map(tag => {
       const first = tag.posts.map(p => p.date).reduce((a, b) => (a.isBefore(b) ? a : b));
       return {name: tag.name, path: tag.path, count: tag.posts.length, first};
     })
-    .filter(t => t.first.year() === year)
-    .sort((a, b) => b.first - a.first);
+    .sort((a, b) => b.first - a.first)
+    .slice(0, limit);
 });
 
 hexo.extend.helper.register('median_tags_per_post', function() {

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1107,10 +1107,13 @@ code {
   margin-bottom: 56px;
 }
 .tag-cloud {
-  margin: 0 0 40px 15px;
+  /* 以前は左に 15px の字下げがあり、他のセクションより右にズレて始まっていた */
+  margin-bottom: 40px;
 }
 .tag-cloud a {
-  margin: 0 0 5px 5px;
+  display: inline-block;
+  /* 間隔は右と下に取る。左に取ると折り返した行頭にも効いて字下げに見える */
+  margin: 0 14px 10px 0;
 }
 /* metronic の `.featured-post, .related-post { padding: 20px 0 0 10px }` により
    関連記事のカードだけ上と左に余白が付き、参照記事のカードとずれていた。

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1112,8 +1112,9 @@ code {
 }
 .tag-cloud a {
   display: inline-block;
-  /* 間隔は右と下に取る。左に取ると折り返した行頭にも効いて字下げに見える */
-  margin: 0 14px 10px 0;
+  /* 間隔は右と下に取る。左に取ると折り返した行頭にも効いて字下げに見える。
+     クラウドは密度が持ち味なので、チップの一覧より狭めにする */
+  margin: 0 8px 4px 0;
 }
 /* metronic の `.featured-post, .related-post { padding: 20px 0 0 10px }` により
    関連記事のカードだけ上と左に余白が付き、参照記事のカードとずれていた。

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1106,21 +1106,6 @@ code {
      ページャの下が 56px なので、それに合わせる */
   margin-bottom: 56px;
 }
-.popular-tag {
-  list-style: none;
-  padding-inline-start: 10px;
-  display: flex;
-  flex-wrap: wrap;
-  font-size: 1.0em;
-}
-.popular-tag li {
-  list-style: none;
-  margin-bottom: 8px;
-  padding: 0 5px 5px 5px;
-}
-.popular-tag .pupular-tag-count {
-  font-size: 0.5em;
-}
 .tag-cloud {
   margin: 0 0 40px 15px;
 }

--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -69,7 +69,9 @@
     <aside>
       <section class="popular-articles">
         <div class="blog-tags margin-bottom-20">
-          <h2 id="searchbytag" class="bottom-content-header"><a href="#searchbytag" class="headerlink" title="タグから記事を探す"></a>タグから記事を探す</h2>
+          <%# 実体は list_toppagetags のシェア数順・件数上限ありのリストなので
+              「人気のタグ」。/tags/ の同名セクションと表記を揃える (#2052) %>
+          <h2 id="searchbytag" class="bottom-content-header"><a href="#searchbytag" class="headerlink" title="人気のタグから記事を探す"></a>人気のタグから記事を探す</h2>
           <%- partial('../_widget/tag.ejs') %>
         </div>
       </section>

--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -12,10 +12,12 @@
         <li><span class="summary-count"><%= median_tags_per_post() %></span><br><span class="summary-label">記事あたり（中央値）</span></li>
         <li><span class="summary-count"><%= newTags.length %></span><br><span class="summary-label">今年の新タグ</span></li>
       </ul>
-      <h2>人気のタグから記事を探す</h2>
+      <%# セクション見出しはホーム（archive.ejs）と同じ bottom-content-header で
+          上下に余白を取り、節の塊が分かれて見えるようにする %>
+      <h2 class="bottom-content-header">人気のタグから記事を探す</h2>
       <%- ranking_tags() %>
       <% if (newTags.length) { %>
-      <h2>今年使われ始めたタグ</h2>
+      <h2 class="bottom-content-header">今年使われ始めたタグ</h2>
       <%# マークアップは「関連タグ」（archive.ejs）や _widget/tag.ejs と揃える。
           同じ見た目の要素が別の作りだとスタイルの調整が二重になる %>
       <div class="blog-tags">
@@ -28,7 +30,7 @@
         </div>
       </div>
       <% } %>
-      <h2>タグクラウドから記事を探す</h2>
+      <h2 class="bottom-content-header">タグクラウドから記事を探す</h2>
       <div class="tag-cloud">
       <%- custom_tagcloud({min_font:12, max_font:36}) %>
       </div>

--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -5,13 +5,33 @@
       ]}) %>
   <main class="col-xs-12 col-sm-12 col-md-10">
     <section id="main" class="margin-top-30">
+      <h1 class="list-page margin-bottom-20">タグ一覧</h1>
+      <% const newTags = new_tags_of_year(); %>
+      <ul class="summary">
+        <li><span class="summary-count"><%= count_tags() %></span><br><span class="summary-label">タグ</span></li>
+        <li><span class="summary-count"><%= median_tags_per_post() %></span><br><span class="summary-label">記事あたり（中央値）</span></li>
+        <li><span class="summary-count"><%= newTags.length %></span><br><span class="summary-label">今年の新タグ</span></li>
+      </ul>
       <h2>人気のタグから記事を探す</h2>
       <%- ranking_tags() %>
-      <h2>タグクラウドから記事を探す <%= count_tags() %>件</h2>
+      <% if (newTags.length) { %>
+      <h2>今年使われ始めたタグ</h2>
+      <%# マークアップは「関連タグ」（archive.ejs）や _widget/tag.ejs と揃える。
+          同じ見た目の要素が別の作りだとスタイルの調整が二重になる %>
+      <div class="blog-tags">
+        <div class="widget">
+          <ul class="tag-list">
+            <% newTags.forEach(function(t){ %>
+            <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.name %> の記事 <%= t.count %>本"><%= t.name %><span class="tag-list-count"><%= t.count %></span></a></li>
+            <% }) %>
+          </ul>
+        </div>
+      </div>
+      <% } %>
+      <h2>タグクラウドから記事を探す</h2>
       <div class="tag-cloud">
       <%- custom_tagcloud({min_font:12, max_font:36}) %>
       </div>
     </section>
   </main>
 </div>
-

--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -11,8 +11,11 @@
         <li><span class="summary-count"><%= median_tags_per_post() %></span><br><span class="summary-label">記事あたり（中央値）</span></li>
       </ul>
       <%# セクション見出しはホーム（archive.ejs）と同じ bottom-content-header で
-          上下に余白を取り、節の塊が分かれて見えるようにする %>
-      <h2 class="bottom-content-header">人気のタグから記事を探す</h2>
+          上下に余白を取り、節の塊が分かれて見えるようにする。
+          h1「タグ一覧」がページの目的を宣言しているので、見出しは
+          「〜から記事を探す」を繰り返さない体言止めにする（ホーム側は
+          文脈が混在するため説明的な「人気のタグから記事を探す」のまま） %>
+      <h2 class="bottom-content-header">人気のタグ</h2>
       <%- ranking_tags() %>
       <%# 「今年初出」ではなく件数固定の新着。トップページの「新着記事」と同じ語彙 %>
       <h2 class="bottom-content-header">新着タグ</h2>
@@ -27,7 +30,7 @@
           </ul>
         </div>
       </div>
-      <h2 class="bottom-content-header">タグクラウドから記事を探す</h2>
+      <h2 class="bottom-content-header">タグクラウド</h2>
       <div class="tag-cloud">
       <%- custom_tagcloud({min_font:12, max_font:36}) %>
       </div>

--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -6,30 +6,27 @@
   <main class="col-xs-12 col-sm-12 col-md-10">
     <section id="main" class="margin-top-30">
       <h1 class="list-page margin-bottom-20">タグ一覧</h1>
-      <% const newTags = new_tags_of_year(); %>
       <ul class="summary">
         <li><span class="summary-count"><%= count_tags() %></span><br><span class="summary-label">タグ</span></li>
         <li><span class="summary-count"><%= median_tags_per_post() %></span><br><span class="summary-label">記事あたり（中央値）</span></li>
-        <li><span class="summary-count"><%= newTags.length %></span><br><span class="summary-label">今年の新タグ</span></li>
       </ul>
       <%# セクション見出しはホーム（archive.ejs）と同じ bottom-content-header で
           上下に余白を取り、節の塊が分かれて見えるようにする %>
       <h2 class="bottom-content-header">人気のタグから記事を探す</h2>
       <%- ranking_tags() %>
-      <% if (newTags.length) { %>
-      <h2 class="bottom-content-header">今年使われ始めたタグ</h2>
+      <%# 「今年初出」ではなく件数固定の新着。トップページの「新着記事」と同じ語彙 %>
+      <h2 class="bottom-content-header">新着タグ</h2>
       <%# マークアップは「関連タグ」（archive.ejs）や _widget/tag.ejs と揃える。
           同じ見た目の要素が別の作りだとスタイルの調整が二重になる %>
       <div class="blog-tags">
         <div class="widget">
           <ul class="tag-list">
-            <% newTags.forEach(function(t){ %>
-            <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.name %> の記事 <%= t.count %>本"><%= t.name %><span class="tag-list-count"><%= t.count %></span></a></li>
+            <% recent_new_tags().forEach(function(t){ %>
+            <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.name %> の記事 <%= t.count %>本（初出 <%= t.first.format('YYYY.MM') %>）"><%= t.name %><span class="tag-list-count"><%= t.count %></span></a></li>
             <% }) %>
           </ul>
         </div>
       </div>
-      <% } %>
       <h2 class="bottom-content-header">タグクラウドから記事を探す</h2>
       <div class="tag-cloud">
       <%- custom_tagcloud({min_font:12, max_font:36}) %>


### PR DESCRIPTION
## 概要

Fixes #2052

タグ一覧（/tags/）の立ち位置を「読者がトピックから記事を探す入口」として整理しました。既存の「人気のタグ」「タグクラウド」は Issue のとおり維持しています。

## 対応内容

1. **h1「タグ一覧」を追加**: 一覧ページの中で /tags/ だけ h1 がありませんでした（/categories/ #2062 と同じ問題）
2. **統計ストリップ**: author ページの `.summary` を再利用し「タグ数 709 / 記事あたり（中央値）3」を h1 直下に表示。タグクラウドの見出しに付いていた「709件」はここへ移動
3. **「新着タグ」セクション**: 初出が新しい順に15個のタグをチップで並べます（Go1.27, ClaudeCode, コンテキストエンジニアリング など）。新しく登場したトピックの入口＝技術レーダーとして機能します
   - 当初「今年使われ始めたタグ」でしたが、年明けや更新停止時に空になるため、トップページの「新着記事」と同じ語彙・件数固定に変更しました。チップの title に初出年月（例: 初出 2026.07）を添えています
4. **人気のタグをチップ表示に統一**: `ranking_tags()` が素のテキストリンクで、ページ内のタグの見た目が割れていたため、関連タグ・新着タグと同じチップに揃えました。専用だった `popular-tag` 系 CSS は削除。href も `/tags/<タグ名>` 直書きから `url_for(tag.path)` にし、`Go1.27`（スラッグは `Go1-27`）のような名前とスラッグが異なるタグでリンク切れになる潜在バグを修正
5. **セクション見出しの余白**: 素の h2 が前のセクションに貼り付いていたため、ホームと同じ `bottom-content-header`（上48px / 下20px）に統一

## 載せないと判断したもの（Issue の検討事項）

- **記事あたりの最大・最小タグ数**: 読者の「探す」に寄与しない管理指標のため公開ページには置きません（参考: 中央値3・平均3.37・最大10・最小0）
- **一緒に使われることが多いタグ**: 各タグページの「関連タグ」が文脈付きで既に担っており、重複させません

## 動作確認

- ローカルで /tags/ の描画を確認: h1・統計2タイル・人気のタグ（チップ・30個）・新着タグ（チップ・15個・新しい順）・タグクラウド

🤖 Generated with [Claude Code](https://claude.com/claude-code)
