### PR TITLE
フッター前の間隔を全ページ 56px に統一する

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -50,6 +50,11 @@
      左の 5px も含めて1行で書く */
   margin: 48px 0 56px 5px !important;
 }
+/* フッター直前に来る最後のブロックに付ける共通クラス。
+   間隔はページ送りの下（#page-nav）に揃える */
+.footer-gap {
+  margin-bottom: 56px;
+}
 
 /* Extra info topbar tweaks */
 @media (max-width: 480px) {
@@ -1105,10 +1110,6 @@ code {
      見出しの上 48px）に比べて狭かった。フッターとの間隔を上側と揃える。
      ページャの下が 56px なので、それに合わせる */
   margin-bottom: 56px;
-}
-.tag-cloud {
-  /* 以前は左に 15px の字下げがあり、他のセクションより右にズレて始まっていた */
-  margin-bottom: 40px;
 }
 .tag-cloud a {
   display: inline-block;

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -82,7 +82,9 @@
           <section class="social-area" data-nosnippet>
           <%- partial('social-button', {feed:false}) %>
           </section>
-          <aside>
+          <%# 最後の section ではなく aside に付ける。中の margin-bottom-40 は
+              相殺で吸収され、skip_career で最後の節が変わっても間隔が保たれる %>
+          <aside class="footer-gap">
             <%# 自動生成のブロックであることが分かるよう、「この記事を参照している記事」と同じ card で囲う %>
             <section class="related-post margin-bottom-40 nav" data-nosnippet>
               <div class="card">

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -4,7 +4,7 @@
         {label: '著者'}
       ]}) %>
   <section id="main" class="margin-top-30">
-    <div>
+    <div class="footer-gap">
       <div id="chart" style="width:95%;min-height:250px"></div>
       <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js"></script>
       <script type="text/javascript">

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -33,7 +33,7 @@
     <div class="widget">
       <h2>カテゴリから記事を探す</h2>
       <div class="widget">
-        <ul class="nav sidebar-categories margin-bottom-40">
+        <ul class="nav sidebar-categories footer-gap">
         <%
           const compareFunc = (a, b) => b.posts.length - a.posts.length;
           const categoryRanks = site.categories.data.sort(compareFunc)

--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -31,7 +31,7 @@
         </div>
       </div>
       <h2 class="bottom-content-header">タグクラウド</h2>
-      <div class="tag-cloud">
+      <div class="tag-cloud footer-gap">
       <%- custom_tagcloud({min_font:12, max_font:36}) %>
       </div>
     </section>


### PR DESCRIPTION
## 概要

/tags/ の h2 上余白を広げた際（#2075）に「最後のコンテンツとフッターの間が狭い」ことに気づき、調査したところ**サイト共通の問題**でした。

## 調査結果

「最後のコンテンツの下はページ送りと同じ 56px」という基準が `#page-nav` と `.popular-articles` の CSS コメントで既に2回宣言されていますが、ページ送り以外で終わるページには適用されていませんでした。

| ページ | 最後の要素 | 従来の間隔 |
| --- | --- | --- |
| ページ送りで終わる一覧・ホーム1頁目 | `#page-nav` / タグから記事を探す | 56px（基準） |
| /tags/ | タグクラウド | 40px |
| /categories/ | カテゴリ一覧 | 40px |
| /authors/ | 著者一覧 | 約16px（最も狭い） |
| 記事ページ | We're hiring カード | 40px |

## 対応

共通クラス `.footer-gap { margin-bottom: 56px }` を1つ定義し、各ページの最後のブロックに付けました。

- /tags/: タグクラウドの div（`.tag-cloud` 自身の `margin-bottom: 40px` は撤去）
- /categories/: カテゴリ一覧の ul（`margin-bottom-40` ユーティリティを置き換え）
- /authors/: ページ全体を包む div（最後がどの年のリストでも一定になる）
- 記事ページ: 関連記事〜We're hiring を包む `<aside>`（内側の `margin-bottom-40` はマージン相殺で吸収され、`skip_career` の記事でも間隔が保たれる）

## 依存

`improve-tags-page`（#2075）の上に積んでいます。**#2075 を先にマージしてください**（マージ後にこの PR の diff は自動的にこの変更分だけになります）。

## 動作確認

- 4ページすべてで `.footer-gap` が描画に乗ることを確認
- 生成された site.css にルールが1箇所だけ出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
