### PR TITLE
連載の本数に索引記事も数える

### DIFF
--- a/scripts/series.js
+++ b/scripts/series.js
@@ -22,8 +22,10 @@
  * 不統一だった。機械が一方の流儀で番号を振ると、他方の114記事で
  * 本文の「4本目です」と食い違う。番号が無いより害が大きい。
  *
- * 全何本かはこの流儀に依存しないので出せる。索引は連載の目次であって
- * 本編ではないため、本数には数えない。
+ * 全何本かはこの流儀に依存しないので出せる。索引記事も1本に数える。
+ * 索引は目次であると同時に読み物でもあり、そこだけ本編と分ける根拠がない。
+ * 本文が「1本目です」と名乗る記事が日付順では2番目に来ることになるが、
+ * 番号は出さないので食い違いは表に出ない。
  *
  * ナビに出す題名からは、連載名を名乗り直している部分を落とす。
  * 連載名は見出しに出ているので、前 / 次 の両方で繰り返すと本題が埋もれる。
@@ -97,8 +99,6 @@ function build(site) {
   const series = new Map(); // 記事のパス -> その記事から見た連載
   for (const [name, posts] of groups) {
     const index = posts.find(p => p.tags && p.tags.some(t => t.name === 'インデックス'));
-    // 索引は本編に数えない。索引記事自身から見た本数も同じ値になる
-    const total = posts.length - (index ? 1 : 0);
 
     // 落とすのはナビの表示だけ。記事の title そのものは触らない
     const nav = posts.map(p => ({path: p.path, title: navTitle(p.title, name)}));
@@ -106,7 +106,7 @@ function build(site) {
     posts.forEach((post, i) => {
       series.set(post.path, {
         name,
-        total,
+        total: posts.length,
         index: index && index !== post ? index : null,
         prev: i > 0 ? nav[i - 1] : null,
         next: i < posts.length - 1 ? nav[i + 1] : null


### PR DESCRIPTION
Closes #2043

#2042 で入れた「全 N 本」が、索引を一律で本数から引いていました。索引が本編を兼ねる連載で1本少なく出ていました。

**索引記事も1本に数えます。** 索引は目次であると同時に読み物でもあり、そこだけ本編と分ける根拠がありません。

```diff
- const total = posts.length - (index ? 1 : 0);
+ total: posts.length,
```

| 連載 | before | after |
| --- | --- | --- |
| Go1.27リリース | 全 8 本 | **全 9 本** |
| CI/CD | 全 6 本 | **全 7 本** |

## 番号との食い違いについて

索引を数えると、本文が「1本目です」と名乗る記事が日付順では2番目に来ます。ただし**ナビは番号を出さない**ので、この食い違いは表に出ません。読者から見ると「索引を含めて全9本、これはそのうちの1本」という素直な数え方になります。

## 確認

`hexo clean && hexo generate`。連載ナビを持つ**全620記事**について、表示された本数がフロントマター `series` の実件数と一致することを機械的に照合しました（一致 620 / 不一致 0）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
