### PR TITLE
404ページを日本語化し、記事用の付属ブロックを外す

### DIFF
--- a/source/404.ejs
+++ b/source/404.ejs
@@ -1,5 +1,5 @@
 ---
-title: 
+title: ページが見つかりません
 layout: page
 ---
 <div class="row margin-bottom-40">
@@ -11,10 +11,10 @@ layout: page
       404
     </div>
     <div class="details">
-      <h3>Oops!  You're lost.</h3>
+      <h3>ページが見つかりませんでした</h3>
       <p>
-      We can not find the page you're looking for.<br>
-      <a href="/index.html" class="link">Return home</a> or try the search bar below.
+      お探しのページは、移動または削除された可能性があります。<br>
+      <a href="/" class="link">ホームへ戻る</a>か、検索をお試しください。
       </p>
     </div>
   </div>

--- a/themes/future/layout/page.ejs
+++ b/themes/future/layout/page.ejs
@@ -1,0 +1,18 @@
+<%# 素のページ（404 など）用の最小レイアウト。
+    このファイルが無いと Hexo が post 用レイアウトへフォールバックし、
+    関連記事・SNSボタン・We're hiring まで付いてしまう (#2077)。
+    サイドバーは残す。404 の本文が検索ボックスへ誘導している %>
+<div class="row">
+  <main class="col-md-9 blog-posts">
+    <article class="article blog-item">
+      <div class="article-inner">
+        <div class="article-entry">
+          <%- page.content %>
+        </div>
+      </div>
+    </article>
+  </main>
+  <aside class="col-md-3 blog-sidebar">
+    <%- partial('_partial/sidebar') %>
+  </aside>
+</div>


### PR DESCRIPTION
## 概要

Fixes #2077

404 ページを日本語化し、記事用の付属ブロック（関連記事・SNSボタン・We're hiring）を外しました。

## 原因と対応

`source/404.ejs` は `layout: page` を指定していますが、テーマに `page.ejs` が存在せず、Hexo が **post 用レイアウトへフォールバック**していました。そのため 404 に関連記事（No related post）・SNS シェアボタン・We're hiring カードまで付いていました。

1. **`themes/future/layout/page.ejs` を新規追加**: 本文とサイドバーだけの素のページ用最小レイアウト。`layout: page` を使うのは現状 404 のみです
   - サイドバーを残すのは、404 の本文が検索ボックスへ誘導しているため（モバイル・タブレットでは #2067 のとおり本文の下に落ちます）
2. **日本語化**: 「ページが見つかりませんでした／お探しのページは、移動または削除された可能性があります。ホームへ戻るか、検索をお試しください。」。`title` も設定し、タブに「ページが見つかりません | フューチャー技術ブログ」が出ます
3. **ホームへのリンク**: `/index.html` → `/`

## 動作確認

- ローカルの /404.html で、関連記事・SNSボタン・We're hiring が消えていること、日本語の見出し・本文・タイトル、`href="/"` のリンク、検索ボックスの表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
