### PR TITLE
タグ個別ページのレイアウトをカテゴリページに揃える

### DIFF
--- a/scripts/tags.js
+++ b/scripts/tags.js
@@ -28,6 +28,22 @@ hexo.extend.helper.register('recent_new_tags', function(limit = 15) {
     .slice(0, limit);
 });
 
+// タグ個別ページの統計。カテゴリページ (#2084) と同じ「直近1年」を出す (#2088)
+hexo.extend.helper.register('tag_stats', function(name) {
+  const tag = this.site.tags.findOne({name});
+  if (!tag) return null;
+  const oneYearAgo = Date.now() - 365 * 24 * 60 * 60 * 1000;
+  const recentAuthors = new Set();
+  let recent = 0;
+  tag.posts.forEach(post => {
+    if (post.date.valueOf() < oneYearAgo) return;
+    recent++;
+    // 共著の旧記事は author が配列
+    [].concat(post.author || []).forEach(a => recentAuthors.add(a));
+  });
+  return {recent, recentAuthorCount: recentAuthors.size};
+});
+
 hexo.extend.helper.register('median_tags_per_post', function() {
   const counts = this.site.posts.map(p => (p.tags ? p.tags.length : 0)).sort((a, b) => a - b);
   return counts[Math.floor(counts.length / 2)] || 0;

--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -27,35 +27,13 @@
         </div>
     </section>
   <% } %>
-  <%# 関連タグは一覧の前に出す。カテゴリページの「よく使われるタグ」と同じ位置で、
-      絞り込み直しの導線は一覧を読み始める前にある方が働く (#2088)。
-      2ページ目以降はページを繰っている最中なので出さない。
+  <%# 関連タグは1ページ目だけ一覧の前に出す。カテゴリページの
+      「よく使われるタグ」と同じ位置で、絞り込み直しの導線は一覧を
+      読み始める前にある方が働く (#2088)。2ページ目以降は下（ページャーの後）。
       ホームの全タグ一覧と両方を置くと読者がどちらを見ればよいか迷うため、
       タグページはこちらだけ（文脈あり・数個 ＞ 文脈なし・714件） %>
   <% if (is_tag() && page.current === 1) { %>
-  <% const related = related_tags(page.tag); %>
-  <% if (related.length) { %>
-  <aside>
-    <section class="popular-articles">
-      <div class="blog-tags margin-bottom-20">
-        <%# 見出しは記事ページの「関連記事」に合わせる。あちらも内部ではスコアで
-            並べているが強度は名乗っていない。「関連が強いタグ」とすると根拠を
-            問われるうえ、実際には絞り込み系と発見系が混在していて言い切れない %>
-        <h2 id="relatedtags" class="bottom-content-header"><a href="#relatedtags" class="headerlink" title="関連タグ"></a>関連タグ</h2>
-        <%# マークアップは「人気のタグから記事を探す」（_widget/tag.ejs の
-            list_toppagetags）と揃える。同じ見た目の要素が別の作りだと
-            スタイルの調整が二重になる %>
-        <div class="widget">
-          <ul class="tag-list" itemprop="keywords">
-            <% related.forEach(function(t){ %>
-            <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.sibling ? `${t.name} の記事 ${t.posts}本（${page.tag} と同じ系列）` : `${t.name} の記事 ${t.posts}本（うち ${page.tag} と共通 ${t.co}本）` %>"><%= t.name %><span class="tag-list-count"><%= t.posts %></span></a></li>
-            <% }) %>
-          </ul>
-        </div>
-      </div>
-    </section>
-  </aside>
-  <% } %>
+  <%- partial('related-tags') %>
   <% } %>
   <% if (pagination == 2){ %>
     <% page.posts.each(function(post){ %>
@@ -88,6 +66,11 @@
   <% } %>
 
 
+    <%# 2ページ目以降は、ページを繰って読み尽くしかけた読者への
+        次の導線としてページャーの下に関連タグを出す %>
+    <% if (is_tag() && page.current !== 1) { %>
+    <%- partial('related-tags') %>
+    <% } %>
     <%# 「人気のタグから記事を探す」はホームの1ページ目だけに出す。
         タグ・カテゴリ・著者のページを見ている読者は、すでに絞り込んだ
         状態で記事を探しているので、そこから全タグの一覧へ戻す導線は

--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -27,6 +27,36 @@
         </div>
     </section>
   <% } %>
+  <%# 関連タグは一覧の前に出す。カテゴリページの「よく使われるタグ」と同じ位置で、
+      絞り込み直しの導線は一覧を読み始める前にある方が働く (#2088)。
+      2ページ目以降はページを繰っている最中なので出さない。
+      ホームの全タグ一覧と両方を置くと読者がどちらを見ればよいか迷うため、
+      タグページはこちらだけ（文脈あり・数個 ＞ 文脈なし・714件） %>
+  <% if (is_tag() && page.current === 1) { %>
+  <% const related = related_tags(page.tag); %>
+  <% if (related.length) { %>
+  <aside>
+    <section class="popular-articles">
+      <div class="blog-tags margin-bottom-20">
+        <%# 見出しは記事ページの「関連記事」に合わせる。あちらも内部ではスコアで
+            並べているが強度は名乗っていない。「関連が強いタグ」とすると根拠を
+            問われるうえ、実際には絞り込み系と発見系が混在していて言い切れない %>
+        <h2 id="relatedtags" class="bottom-content-header"><a href="#relatedtags" class="headerlink" title="関連タグ"></a>関連タグ</h2>
+        <%# マークアップは「人気のタグから記事を探す」（_widget/tag.ejs の
+            list_toppagetags）と揃える。同じ見た目の要素が別の作りだと
+            スタイルの調整が二重になる %>
+        <div class="widget">
+          <ul class="tag-list" itemprop="keywords">
+            <% related.forEach(function(t){ %>
+            <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.sibling ? `${t.name} の記事 ${t.posts}本（${page.tag} と同じ系列）` : `${t.name} の記事 ${t.posts}本（うち ${page.tag} と共通 ${t.co}本）` %>"><%= t.name %><span class="tag-list-count"><%= t.posts %></span></a></li>
+            <% }) %>
+          </ul>
+        </div>
+      </div>
+    </section>
+  </aside>
+  <% } %>
+  <% } %>
   <% if (pagination == 2){ %>
     <% page.posts.each(function(post){ %>
       <%- partial('article', {post: post, index: true}) %>
@@ -58,17 +88,12 @@
   <% } %>
 
 
-    <%# 「タグから記事を探す」はホームの1ページ目だけに出す。
+    <%# 「人気のタグから記事を探す」はホームの1ページ目だけに出す。
         タグ・カテゴリ・著者のページを見ている読者は、すでに絞り込んだ
         状態で記事を探しているので、そこから全タグの一覧へ戻す導線は
         読者の意図とズレる。ホームの2ページ目以降も、ページを繰っている
         最中なので探し直す段階に無い。
         ランキングは上（isHomeFirst の分岐）に出しているのでここには無い %>
-    <%# ホームでは全タグ一覧、タグページでは関連するタグを出す。
-
-        タグページに両方を置くと、読者がどちらを見ればよいか迷う。
-        いま見ているタグからの導線（文脈あり・数個）の方が、
-        サイト全体の入口（文脈なし・714件）より役に立つ %>
     <% if (isHomeFirst) { %>
     <aside>
       <section class="popular-articles">
@@ -80,30 +105,6 @@
         </div>
       </section>
     </aside>
-    <% } else if (is_tag()) { %>
-    <% const related = related_tags(page.tag); %>
-    <% if (related.length) { %>
-    <aside>
-      <section class="popular-articles">
-        <div class="blog-tags margin-bottom-20">
-          <%# 見出しは記事ページの「関連記事」に合わせる。あちらも内部ではスコアで
-              並べているが強度は名乗っていない。「関連が強いタグ」とすると根拠を
-              問われるうえ、実際には絞り込み系と発見系が混在していて言い切れない %>
-          <h2 id="relatedtags" class="bottom-content-header"><a href="#relatedtags" class="headerlink" title="関連タグ"></a>関連タグ</h2>
-          <%# マークアップは「タグから記事を探す」（_widget/tag.ejs の
-              list_toppagetags）と揃える。同じ見た目の要素が別の作りだと
-              スタイルの調整が二重になる %>
-          <div class="widget">
-            <ul class="tag-list" itemprop="keywords">
-              <% related.forEach(function(t){ %>
-              <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.sibling ? `${t.name} の記事 ${t.posts}本（${page.tag} と同じ系列）` : `${t.name} の記事 ${t.posts}本（うち ${page.tag} と共通 ${t.co}本）` %>"><%= t.name %><span class="tag-list-count"><%= t.posts %></span></a></li>
-              <% }) %>
-            </ul>
-          </div>
-        </div>
-      </section>
-    </aside>
-    <% } %>
     <% } %>
   </main>
   <aside class="col-xs-12 col-sm-12 col-md-2 blog-sidebar">

--- a/themes/future/layout/_partial/related-tags.ejs
+++ b/themes/future/layout/_partial/related-tags.ejs
@@ -1,0 +1,26 @@
+<%# タグページの関連タグ。archive.ejs が読者の状態に合わせて位置を変えて使う。
+    1ページ目 = 一覧の前（このタグで合っているかの絞り込み直し）、
+    2ページ目以降 = ページャーの下（読み尽くしかけた読者への次の導線）(#2088) %>
+<% const related = related_tags(page.tag); %>
+<% if (related.length) { %>
+<aside>
+  <section class="popular-articles">
+    <div class="blog-tags margin-bottom-20">
+      <%# 見出しは記事ページの「関連記事」に合わせる。あちらも内部ではスコアで
+          並べているが強度は名乗っていない。「関連が強いタグ」とすると根拠を
+          問われるうえ、実際には絞り込み系と発見系が混在していて言い切れない %>
+      <h2 id="relatedtags" class="bottom-content-header"><a href="#relatedtags" class="headerlink" title="関連タグ"></a>関連タグ</h2>
+      <%# マークアップは「人気のタグから記事を探す」（_widget/tag.ejs の
+          list_toppagetags）と揃える。同じ見た目の要素が別の作りだと
+          スタイルの調整が二重になる %>
+      <div class="widget">
+        <ul class="tag-list" itemprop="keywords">
+          <% related.forEach(function(t){ %>
+          <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.sibling ? `${t.name} の記事 ${t.posts}本（${page.tag} と同じ系列）` : `${t.name} の記事 ${t.posts}本（うち ${page.tag} と共通 ${t.co}本）` %>"><%= t.name %><span class="tag-list-count"><%= t.posts %></span></a></li>
+          <% }) %>
+        </ul>
+      </div>
+    </div>
+  </section>
+</aside>
+<% } %>

--- a/themes/future/layout/tag.ejs
+++ b/themes/future/layout/tag.ejs
@@ -17,6 +17,15 @@
       <li><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
       <li><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
     </ul>
+    <%# 直近1年（#2088）は全期間の統計と時間軸が違うので、混ぜずに行を分ける。
+        カテゴリページ (#2084) と同じ構成 %>
+    <% const ts = tag_stats(page.tag); %>
+    <% if (ts) { %>
+    <ul class="summary">
+      <li><span class="summary-count"><%= ts.recent %></span><br><span class="summary-label">直近1年の投稿</span></li>
+      <li><span class="summary-count"><%= ts.recentAuthorCount %></span><br><span class="summary-label">直近1年の著者数</span></li>
+    </ul>
+    <% } %>
     <% } else { %>
     <%
         const perPage = 25;
@@ -25,7 +34,8 @@
     %>
     <%= count_tag(page.tag) %> 記事中の <%= start_post %> ～ <%= end_post %> を表示
     <% } %>
-    <%- partial('_partial/archive', {pagination: config.tag, index: true}) %>
+    <%# 見出しの語彙はホーム・カテゴリページに合わせる %>
+    <%- partial('_partial/archive', {pagination: config.tag, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧'}) %>
   </section>
 </div>
 


### PR DESCRIPTION
## 概要

Fixes #2088

タグ個別ページ（/tags/Go/ など）のレイアウトを、#2087 で整えたカテゴリ個別ページと同じ構成に揃えました。

- 1ページ目: h1 → 統計（全期間）→ 統計（直近1年）→ **関連タグ** → h2 新着記事 → 記事一覧 → ページャー
- 2ページ目以降: h1 → 件数レンジ → h2 記事一覧 → 記事一覧 → ページャー → **関連タグ**

## 対応内容

1. **統計に「直近1年の投稿」「直近1年の著者数」の行を追加**（`tag_stats` ヘルパーを新設）。全期間の統計と時間軸が違うため行を分けるのもカテゴリページと同じ
2. **記事一覧に h2 を追加**: 1ページ目「新着記事」・2ページ目以降「記事一覧」（`archive` partial の `list_heading` を利用）
3. **関連タグの位置を読者の状態で出し分け**: 1ページ目は「このタグで合っているか」の絞り込み直しなので一覧の前（カテゴリの「よく使われるタグ」と同じ位置）、2ページ目以降はページを繰って読み尽くしかけた読者への次の導線としてページャーの下。出し分けのため `_partial/related-tags.ejs` に切り出しました

## 動作確認

- /tags/Go/: 直近1年の統計行、関連タグ→新着記事→一覧→ページャーの順序
- /tags/Go/page/2/: 記事一覧見出し→一覧→ページャー→関連タグの順序
- ホーム・カテゴリページに影響が無いこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)