### PR TITLE
著者ページに執筆傾向（カテゴリ・タグ・直近1年）を出す

### DIFF
--- a/scripts/author_generator.js
+++ b/scripts/author_generator.js
@@ -125,6 +125,36 @@ hexo.extend.helper.register('count_authors', function(year='all') {
   return posts.map(post => post.author).unique().length;
 });
 
+// 著者ページの傾向表示用 (#2082)。よく投稿するカテゴリ（上位3）と
+// よく使うタグ（上位10）、直近1年の投稿数を返す
+hexo.extend.helper.register('author_stats', function(name) {
+  const oneYearAgo = Date.now() - 365 * 24 * 60 * 60 * 1000;
+  const posts = this.site.posts.filter(post => [].concat(post.author || []).includes(name));
+  const catCount = new Map();
+  const tagCount = new Map();
+  let recent = 0;
+  posts.forEach(post => {
+    if (post.date.valueOf() >= oneYearAgo) recent++;
+    (post.categories ? post.categories.toArray() : []).forEach(c => {
+      const e = catCount.get(c.name) || {name: c.name, path: c.path, count: 0};
+      e.count++;
+      catCount.set(c.name, e);
+    });
+    (post.tags ? post.tags.toArray() : []).forEach(t => {
+      const e = tagCount.get(t.name) || {name: t.name, path: t.path, count: 0};
+      e.count++;
+      tagCount.set(t.name, e);
+    });
+  });
+  const byCount = (a, b) => b.count - a.count;
+  return {
+    recent,
+    topCategories: [...catCount.values()].sort(byCount).slice(0, 3),
+    // インデックスは連載索引の構造タグで、執筆傾向を表さない
+    topTags: [...tagCount.values()].filter(t => t.name !== 'インデックス').sort(byCount).slice(0, 10),
+  };
+});
+
 hexo.extend.helper.register('post_author_link', function(post) {
   const author = post.author || 'Anonymous';
   // li の直下に li を入れるとパーサが外側の li を閉じてしまい、

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1064,6 +1064,15 @@ code {
   color: #616161;
   font-weight: bold;
 }
+/* 著者ページの「よく投稿するカテゴリ」。間隔は記事メタデータ行
+   （.blog-info）と同じ 28px */
+.author-top-categories {
+  list-style: none;
+  padding-left: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 28px;
+}
 .author-list {
   padding-inline-start: 0px;
   display: flex;

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -15,15 +15,41 @@
       <li><span class="summary-count"><%= page.hatebu %></span><br><span class="summary-label">はてブ</span></li>
       <li><span class="summary-count"><%= page.pocket %></span><br><span class="summary-label">Pocket</span></li>
     </ul>
+    <% const as = author_stats(page.author); %>
+    <%# 直近1年（#2082）は全期間の統計と時間軸が違うので、混ぜずに行を分ける。
+        カテゴリ・タグページ (#2084 / #2088) と同じ構成 %>
+    <ul class="summary">
+      <li><span class="summary-count"><%= as.recent %></span><br><span class="summary-label">直近1年の投稿</span></li>
+    </ul>
     <%- get_profile(page.author) %>
+    <% if (as.topCategories.length) { %>
+    <h2 class="bottom-content-header">よく投稿するカテゴリ</h2>
+    <%# カテゴリはタグと誤認しないようチップにせず、記事メタデータと同じ
+        テキストリンク（.article-category-link）で並べる %>
+    <ul class="author-top-categories">
+      <% as.topCategories.forEach(function(c){ %>
+      <li><a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= page.author %>さんの <%= c.name %> カテゴリの記事 <%= c.count %>本"><%= c.name %> (<%= c.count %>)</a></li>
+      <% }) %>
+    </ul>
+    <% } %>
+    <% if (as.topTags.length) { %>
+    <h2 class="bottom-content-header">よく使うタグ</h2>
+    <div class="blog-tags">
+      <ul class="tag-list">
+        <% as.topTags.forEach(function(t){ %>
+        <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= page.author %>さんの <%= t.name %> の記事 <%= t.count %>本"><%= t.name %><span class="tag-list-count"><%= t.count %></span></a></li>
+        <% }) %>
+      </ul>
+    </div>
+    <% } %>
+    <h2 class="bottom-content-header">月別投稿数</h2>
     <div id="chart" style="width:95%;min-height:250px"></div>
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
     <script type="text/javascript">
       let myChart = echarts.init(document.getElementById('chart'));
       let option = {
-        title: {
-            text: '月別投稿数'
-        },
+        <%# タイトルは直上の h2 が担うので、チャート内では重ねない %>
+        title: {},
         tooltip: {
             trigger: 'axis'
         },
@@ -60,6 +86,7 @@
     %>
     <%= count_author(page.author) %>記事中の <%= start_post %> ～ <%= end_post %> を表示
     <% } %>
-    <%- partial('_partial/archive', {pagination: config.author, index: true}) %>
+    <%# 見出しの語彙はホーム・カテゴリ・タグページに合わせる %>
+    <%- partial('_partial/archive', {pagination: config.author, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧'}) %>
   </section>
 </div>

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -53,7 +53,8 @@
         tooltip: {
             trigger: 'axis'
         },
-        grid: {},
+        <%# 既定の grid.left 10% で右へズレて見える。軸ラベル込みで左端に寄せる %>
+        grid: { left: 0, right: '2%', containLabel: true },
         toolbox: {},
         xAxis: {
             type: 'category',


### PR DESCRIPTION
## 概要

Fixes #2082

著者個人ページに執筆傾向を追加しました。カテゴリ・タグ個別ページ（#2087 / #2090）で確立した構成に合わせています。

構成: h1 → 統計（全期間）→ 統計（直近1年）→ プロフィール → よく投稿するカテゴリ → よく使うタグ → 月別投稿数チャート → h2 新着記事 → 記事一覧

## 対応内容

1. **統計に「直近1年の投稿」の行を追加**（`author_stats` ヘルパーを新設）。全期間の統計と時間軸が違うため行を分けるのは他ページと同じ
2. **よく投稿するカテゴリ（上位3）**: 「カテゴリをチップにするとタグと誤認する」という既存の設計判断に従い、記事メタデータと同じテキストリンク（`.article-category-link`）で表示。間隔も記事メタデータ行と同じ 28px
3. **よく使うタグ（上位10、`インデックス` 除外）**: 他ページと同じチップ。title に「◯◯さんの Go の記事 59本」の形で件数を補足
4. **チャートに h2「月別投稿数」**を立て、ECharts 内部のタイトルは重複するため外しました
5. **記事一覧に h2**（1ページ目「新着記事」・以降「記事一覧」。`list_heading` を再利用）

例（真野隼記さん）: よく投稿するカテゴリ = Programming (62)・Culture (26)・DevOps (16)、よく使うタグ = Go 59 / AWS 14 / TechBlog 10 / 登壇レポート 10 …と、執筆者の人となりが見える情報になります。

## 動作確認

- /authors/真野隼記/ で新セクションの描画と順序、共著記事の集計（author 配列対応）を確認
- 2ページ目が「記事一覧」見出し + 件数レンジのままであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
