### PR TITLE
ページャーの青塗りを選択中のページだけにする

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -30,12 +30,18 @@
 .pagination > a:last-child {
   padding: 4px 12px 8px;
 }
-.pagination span {
+/* 青く塗るのは選択中のページだけ。span 全体に掛けると省略の「…」
+   （span.space）まで塗られ、クリックできそうに見えて迷わせる (#2091)。
+   「…」は base の .pagination > span（グレー文字・白地）のままにする */
+.pagination span.current {
   z-index: 2;
   color: #fff;
   cursor: default;
   background-color: #337ab7;
   border-color: #337ab7;
+}
+.pagination .space {
+  cursor: default;
 }
 
 /* ページャ。以前は下にランキングとタグ一覧が続いていて間隔が埋まって


### PR DESCRIPTION
## 概要

Fixes #2091

ページャーで、省略の「…」が選択中のページ番号と同じ青ハイライトになっており、どちらがクリックできるのか迷わせていました。

## 原因と対応

`.pagination span { background-color: #337ab7 }` が **span 全体**に掛かっており、選択中ページ（`span.page-number.current`）と省略記号（`span.space`）の両方が青塗りされていました。

- 青塗りを `.pagination span.current` に限定
- 「…」は base ルール（グレー文字 `#868c93`・白地）のままになり、Issue の「無地 or 薄いグレー」を満たします。`cursor: default` も明示しました

## 動作確認

- ローカルのトップページ下部のページャーで、「1」だけが青、「…」がグレー文字・白地になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
