### PR TITLE
一覧ページの見出しを直し、統計の折り返しを揃える

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1400,16 +1400,15 @@ a.series-nav-item:hover .series-nav-item-title {
   padding-inline-start: 0px;
   display: flex;
   flex-wrap: wrap;
+  /* 項目の間隔は gap で持つ。padding-left で空けると、折り返した行の
+     先頭にも余白が残って左端が揃わない */
+  gap: 8px 25px;
   padding: 0 0 4px 0;
 }
 .summary li {
   list-style: none;
-  margin-bottom: 8px;
   padding-inline-start: 0px;
-  padding: 0 5px 0px 25px;
-}
-.summary li:first-child {
-  padding: 0 5px 0px 0px;
+  padding: 0;
 }
 /* 記事数やシェア数の統計。以前は .summary の 1.2em に 1.6em を掛けた
    25px で、ページ見出し（26px）とほぼ同じ大きさだった。一覧ページの

--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -59,7 +59,7 @@
       </div>
       <% if (page.posts.length){ %>
       <div id="page-nav" class="pagination">
-        <%- paginator({prev_text:'Prev', next_text:'Next', mid_size:3, end_size:2, show_all:false}) %>
+        <%- paginator({prev_text:'前へ', next_text:'次へ', mid_size:3, end_size:2, show_all:false}) %>
       </div>
       <% } %>
     </section>

--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -59,7 +59,7 @@
       </div>
       <% if (page.posts.length){ %>
       <div id="page-nav" class="pagination">
-        <%- paginator({prev_text:'前へ', next_text:'次へ', mid_size:3, end_size:2, show_all:false}) %>
+        <%- paginator({prev_text:'Prev', next_text:'Next', mid_size:3, end_size:2, show_all:false}) %>
       </div>
       <% } %>
     </section>

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -8,7 +8,7 @@
         {label: page.category, url: page.current === 1 ? null : (page.base || '/categories/' + page.category)}
       ].concat(page.current === 1 ? [] : [{label: page.current + 'ページ目'}])}) %>
   <section id="main" class="margin-top-30">
-    <h1 class="list-page"><%- page.category %> <span class="list-sub-text">カテゴリの記事</span></h1>
+    <h1 class="list-page"><%- page.category %> <span class="list-sub-text">カテゴリ</span></h1>
     <% if (page.current === 1) { %>
     <% const cs = category_stats(page.category); %>
     <ul class="summary">

--- a/themes/future/layout/tag.ejs
+++ b/themes/future/layout/tag.ejs
@@ -5,7 +5,7 @@
         {label: page.tag, url: page.current === 1 ? null : (page.base || '/tags/' + page.tag)}
       ].concat(page.current === 1 ? [] : [{label: page.current + 'ページ目'}])}) %>
   <section id="main" class="margin-top-30">
-    <h1 class="list-page"><%- page.tag %> <span class="list-sub-text">タグの記事</span></h1>
+    <h1 class="list-page"><%- page.tag %> <span class="list-sub-text">タグ</span></h1>
     <% if (page.current === 1) { %>
     <% const summary = summary_tag(page.tag); %>
     <ul class="summary">


### PR DESCRIPTION
Closes #2089
Closes #2086

## #2089 見出し

見出しの下に統計も並ぶので「記事」だけを指していませんでした。

```diff
- <h1>Go <span>タグの記事</span></h1>
+ <h1>Go <span>タグ</span></h1>
- <h1>Programming <span>カテゴリの記事</span></h1>
+ <h1>Programming <span>カテゴリ</span></h1>
```

## #2086 統計の折り返し

原因は `.summary li` の `padding: 0 5px 0px 25px` でした。項目の間隔を左パディングで作っていたため、**折り返した行の先頭にも 25px が残り左端が揃いません**でした（`:first-child` だけ例外にしていたので、2行目以降には効きません）。

```diff
  .summary {
    display: flex;
    flex-wrap: wrap;
+   gap: 8px 25px;
  }
  .summary li {
-   margin-bottom: 8px;
-   padding: 0 5px 0px 25px;
+   padding: 0;
  }
- .summary li:first-child {
-   padding: 0 5px 0px 0px;
- }
```

間隔の定義が3箇所から `gap` の1行になります。

## 確認

差分ビルド（`_config.fast.yml`、17秒）で生成物を確認しました。

なお #2095（ページャの Prev / Next）は別で作業中とのことなので、この PR からは外しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)