### PR TITLE
ページャーの Prev / Next を 前のページ / 次のページ にする

### DIFF
--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -59,7 +59,8 @@
       </div>
       <% if (page.posts.length){ %>
       <div id="page-nav" class="pagination">
-        <%- paginator({prev_text:'Prev', next_text:'Next', mid_size:3, end_size:2, show_all:false}) %>
+        <%# 連載ナビの「前の記事／次の記事」と同じ対象明示型の日本語にする (#2095) %>
+        <%- paginator({prev_text:'前のページ', next_text:'次のページ', mid_size:3, end_size:2, show_all:false}) %>
       </div>
       <% } %>
     </section>


### PR DESCRIPTION
## 概要

Fixes #2095

ページャーの「Prev / Next」を「**前のページ / 次のページ**」にしました。

## 検討の経緯

- **サイト内の前例**: 連載ナビが既に「前の記事／次の記事」と日本語・対象明示型。404 の日本語化（#2077）など日本語へ寄せる流れの中で、ページャーだけ英語が残っていました
- **他サービス（実測）**: はてなブログは「次のページ」（対象明示型）、Qiita は記号のみ（‹ › アイコン）。英語表記の類似サービスは見当たりません
- 文言は簡潔型（前へ・次へ）ではなく、連載ナビと同じ**対象明示型**を採用しました

変更は `paginator()` の `prev_text` / `next_text` の1箇所です。

## レビュー時の確認ポイント

`.pagination > a:first-child / :last-child` に `padding: 4px 12px 8px` という上下非対称の指定があり、英語表記（Prev/Next）の見た目に合わせた調整の可能性があります。日本語にして文字が上寄りに見える場合は言ってください（数字と同じ `6px 12px` に揃えます）。

## 動作確認

- /page/2/ のページャーで「前のページ」「次のページ」の描画を確認（`rel="prev"` / `rel="next"` は従来どおり）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
