### PR TITLE
カテゴリ・タグの一覧によく読まれている記事を出す

### DIFF
--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require("fs");
+const {postListItem} = require("./lib/post_list");
 
 const load = JSON.parse(fs.readFileSync("ga4_pv.json", 'utf-8'));
 const map = new Map();
@@ -16,4 +17,20 @@ const getGA4PV = url => map.get(url)?.pv || 0;
 hexo.extend.helper.register("get_ga4_pv", url => {
   const pv = getGA4PV("/" + url);
   return pv > 0 ? pv.toLocaleString() : '';
+});
+
+// 指定した記事の中から PV の多い順に取り出す。カテゴリ・タグの一覧ページで
+// 「よく読まれている記事」を出すのに使う（#2033 / #2034）
+hexo.extend.helper.register('popular_posts_in', function(posts, limit = 5) {
+  const ranked = posts
+    .map(post => ({post, pv: getGA4PV('/' + post.path)}))
+    .filter(x => x.pv > 0)
+    // 同点の決着が無いとビルドごとに並びが変わる
+    .sort((a, b) => b.pv - a.pv || (a.post.path < b.post.path ? -1 : 1))
+    .slice(0, limit);
+
+  if (ranked.length === 0) return '';
+
+  const links = ranked.map(x => postListItem(x.post, 'featured-posts-item')).join('\n');
+  return `<div class="widget"><ul class="nav featured-post-link">${links}</ul></div>`;
 });

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -40,6 +40,15 @@
       </ul>
     </div>
     <% } %>
+    <%# そのカテゴリの中でよく読まれている記事。新着より前に置く。
+        絞り込んだ直後の読者がまず知りたいのは「定番はどれか」であって、
+        新しさは新着一覧が担う %>
+    <% const catAll = site.categories.findOne({name: page.category}); %>
+    <% const popular = catAll ? popular_posts_in(catAll.posts.toArray()) : ''; %>
+    <% if (popular) { %>
+    <h2 class="bottom-content-header">よく読まれている記事</h2>
+    <%- popular %>
+    <% } %>
     <% } %>
     <% if (page.current !== 1) { %>
     <%

--- a/themes/future/layout/tag.ejs
+++ b/themes/future/layout/tag.ejs
@@ -34,6 +34,17 @@
     %>
     <%= count_tag(page.tag) %> 記事中の <%= start_post %> ～ <%= end_post %> を表示
     <% } %>
+    <% if (page.current === 1) { %>
+    <%# そのタグの中でよく読まれている記事。新着より前に置く。
+        絞り込んだ直後の読者がまず知りたいのは「定番はどれか」であって、
+        新しさは新着一覧が担う %>
+    <% const tagAll = site.tags.findOne({name: page.tag}); %>
+    <% const popular = tagAll ? popular_posts_in(tagAll.posts.toArray()) : ''; %>
+    <% if (popular) { %>
+    <h2 class="bottom-content-header">よく読まれている記事</h2>
+    <%- popular %>
+    <% } %>
+    <% } %>
     <%# 見出しの語彙はホーム・カテゴリページに合わせる %>
     <%- partial('_partial/archive', {pagination: config.tag, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧'}) %>
   </section>


### PR DESCRIPTION
Closes #2033
Closes #2034

同じ仕組みの適用先違いなので1つにまとめました。

## 出すもの

カテゴリ・タグの一覧ページ（1ページ目のみ）に「よく読まれている記事」を**上位5件**出します。**新着記事より前**に置きました。絞り込んだ直後の読者がまず知りたいのは「このカテゴリ／タグの定番はどれか」で、新しさは新着一覧が担うためです。

```
Go タグ
[統計]
よく読まれている記事      ← 追加
  2024年版のDockerfileの考え方＆書き方
  PostgreSQLの全文検索機能を試してみる
  Goのテストをはじめてみよう（2025年版）
  Go1.22 リリース連載 HTTPルーティングの強化
  Go 1.26で go fix が面白くなった
新着記事
  …
```

## 順位の基準

**GA4 の PV** です。ホームの「よく読まれている記事」と同じ基準に揃えました。既存の `ga4_pv.json`（`get_ga4_pv` が使っているもの）をそのまま使うので、新しいデータ取得は増えません。

PV の実測が無い記事は出しません（`get_ga4_pv` が架空の値を出さない方針と同じ）。5件に満たなければその数だけ、0件ならセクションごと出しません。

マークアップは `lib/post_list.js` の共通実装で、ホームのランキングと同じ `featured-posts-item` です。

## 確認

差分ビルド（`_config.fast.yml`、10秒）で、タグ440ページ・カテゴリ16ページに表示されることを確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)