### PR TITLE
統計タイルのシェア内訳を一段小さくし、直近1年ゼロは文で言う

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1400,6 +1400,9 @@ a.series-nav-item:hover .series-nav-item-title {
   padding-inline-start: 0px;
   display: flex;
   flex-wrap: wrap;
+  /* 一段小さいシェア内訳（.summary-sub）が主要タイルと上端で揃うと
+     浮いて見えるため、ラベル行を基準に下端で揃える (#2096) */
+  align-items: flex-end;
   /* 項目の間隔は gap で持つ。padding-left で空けると、折り返した行の
      先頭にも余白が残って左端が揃わない */
   gap: 8px 25px;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1426,6 +1426,17 @@ a.series-nav-item:hover .series-nav-item-title {
   /* 親の bold に対する lighter は結局 normal になる。意図を明示する */
   font-weight: normal;
 }
+/* シェアの内訳（X・Facebook・はてブ・Pocket）。読者の行動を変える数字では
+   ないので、投稿数・著者数と同格に並べず一段小さくする (#2096) */
+.summary-sub .summary-count {
+  font-size: 14px;
+}
+/* 直近1年の投稿が無いときの表記。0 のタイルを並べるより文で言う方が伝わる */
+.summary-note {
+  margin: 0 0 8px;
+  color: #777;
+  font-size: 0.9em;
+}
 .bottom-content-header {
   font-weight: bold;
   /* 見出しと直後のコンテンツが近すぎて窮屈に見えていた。

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -10,17 +10,21 @@
     <ul class="summary">
       <li><span class="summary-count"><%= count_author(page.author) %></span><br><span class="summary-label">投稿</span></li>
       <li><span class="summary-count"><%= page.authorSNSCnt %></span><br><span class="summary-label">総シェア数</span></li>
-      <li><span class="summary-count"><%= page.twitterShare %></span><br><span class="summary-label">Twitter</span></li>
-      <li><span class="summary-count"><%= page.facebookShare %></span><br><span class="summary-label">Facebook</span></li>
-      <li><span class="summary-count"><%= page.hatebu %></span><br><span class="summary-label">はてブ</span></li>
-      <li><span class="summary-count"><%= page.pocket %></span><br><span class="summary-label">Pocket</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= page.twitterShare %></span><br><span class="summary-label">X</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= page.facebookShare %></span><br><span class="summary-label">Facebook</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= page.hatebu %></span><br><span class="summary-label">はてブ</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= page.pocket %></span><br><span class="summary-label">Pocket</span></li>
     </ul>
     <% const as = author_stats(page.author); %>
     <%# 直近1年（#2082）は全期間の統計と時間軸が違うので、混ぜずに行を分ける。
         カテゴリ・タグページ (#2084 / #2088) と同じ構成 %>
+    <% if (as.recent > 0) { %>
     <ul class="summary">
       <li><span class="summary-count"><%= as.recent %></span><br><span class="summary-label">直近1年の投稿</span></li>
     </ul>
+    <% } else { %>
+    <p class="summary-note">直近1年間の投稿はありません</p>
+    <% } %>
     <%- get_profile(page.author) %>
     <% if (as.topCategories.length) { %>
     <h2 class="bottom-content-header">よく投稿するカテゴリ</h2>

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -16,17 +16,19 @@
       <li><span class="summary-count"><%= count_category(page.category) %></span><br><span class="summary-label">投稿</span></li>
       <li><span class="summary-count"><%= summary.authors %></span><br><span class="summary-label">著者数</span></li>
       <li><span class="summary-count"><%= summary.total %></span><br><span class="summary-label">総シェア数</span></li>
-      <li><span class="summary-count"><%= summary.twitter %></span><br><span class="summary-label">Twitter</span></li>
-      <li><span class="summary-count"><%= summary.facebook %></span><br><span class="summary-label">Facebook</span></li>
-      <li><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
-      <li><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.twitter %></span><br><span class="summary-label">X</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.facebook %></span><br><span class="summary-label">Facebook</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
     </ul>
     <%# 直近1年（#2084）は全期間の統計と時間軸が違うので、混ぜずに行を分ける %>
-    <% if (cs) { %>
+    <% if (cs && cs.recent > 0) { %>
     <ul class="summary">
       <li><span class="summary-count"><%= cs.recent %></span><br><span class="summary-label">直近1年の投稿</span></li>
       <li><span class="summary-count"><%= cs.recentAuthorCount %></span><br><span class="summary-label">直近1年の著者数</span></li>
     </ul>
+    <% } else if (cs) { %>
+    <p class="summary-note">直近1年間の投稿はありません</p>
     <% } %>
     <% if (cs && cs.topTags.length) { %>
     <%# 一覧と同じ代表タグ。マークアップも /categories/ と揃える。

--- a/themes/future/layout/tag.ejs
+++ b/themes/future/layout/tag.ejs
@@ -12,19 +12,21 @@
       <li><span class="summary-count"><%= count_tag(page.tag) %></span><br><span class="summary-label">投稿</span></li>
       <li><span class="summary-count"><%= summary.authors %></span><br><span class="summary-label">著者数</span></li>
       <li><span class="summary-count"><%= summary.total %></span><br><span class="summary-label">総シェア数</span></li>
-      <li><span class="summary-count"><%= summary.twitter %></span><br><span class="summary-label">Twitter</span></li>
-      <li><span class="summary-count"><%= summary.facebook %></span><br><span class="summary-label">Facebook</span></li>
-      <li><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
-      <li><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.twitter %></span><br><span class="summary-label">X</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.facebook %></span><br><span class="summary-label">Facebook</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
     </ul>
     <%# 直近1年（#2088）は全期間の統計と時間軸が違うので、混ぜずに行を分ける。
         カテゴリページ (#2084) と同じ構成 %>
     <% const ts = tag_stats(page.tag); %>
-    <% if (ts) { %>
+    <% if (ts && ts.recent > 0) { %>
     <ul class="summary">
       <li><span class="summary-count"><%= ts.recent %></span><br><span class="summary-label">直近1年の投稿</span></li>
       <li><span class="summary-count"><%= ts.recentAuthorCount %></span><br><span class="summary-label">直近1年の著者数</span></li>
     </ul>
+    <% } else if (ts) { %>
+    <p class="summary-note">直近1年間の投稿はありません</p>
     <% } %>
     <% } else { %>
     <%


### PR DESCRIPTION
## 概要

Fixes #2096

タグ個別ページの1stビューが統計で占められスカスカに見える問題への対応です。統計タイルは同じ部品なので、タグ・カテゴリ・著者の3ページに揃えて適用しています。

## 対応内容

1. **シェア内訳（X・Facebook・はてブ・Pocket）のタイルを一段小さく**: 数字を `clamp(17-20px)` → 14px に落とし、投稿数・著者数・総シェア数（主要統計）との主従を付けました
2. **Twitter → X に表記変更**
3. **直近1年の投稿が 0 のとき**はタイルを出さず「直近1年間の投稿はありません」の一文に（例: /tags/HoloLens/）。0 のタイルを2枚並べるより端的に伝わります

## 動作確認

- /tags/Go/（内訳が小さいタイル・X 表記）
- /tags/HoloLens/（直近1年間の投稿はありません）
- /categories/Programming/・/authors/ の各ページで同じ見た目になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
