### PR TITLE
ホームにブログの説明を出す

### DIFF
--- a/themes/future/_config.yml
+++ b/themes/future/_config.yml
@@ -27,5 +27,6 @@ favicon: /favicon.ico # path from root of hexo site
 twitter_widget_id: "twsrc%5Etfw" # as a string, from https://publish.twitter.com/?buttonType=MentionButton&dnt=1&lang=ja&query=https%3A%2F%2Ftwitter.com%2Ffuture_techblog&widget=Timeline
 twitter_username: future_techblog # twitter username without the @
 
-about: 経営とITをデザインする、フューチャーの技術ブログです。業務で利用している幅広い技術について紹介します。<br /><br /><a href="http://www.future.co.jp/">http://www.future.co.jp/</a>
+about: 経営とITをデザインする、フューチャーの技術ブログです。業務で利用している幅広い技術について紹介します。
+corporate_url: http://www.future.co.jp/
 email: techblog@future.co.jp

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -376,12 +376,7 @@ body.page-header-fixed .header {
   font-weight: bold;
 }
 .site-lede-text {
-  margin: 0 0 4px;
-}
-.site-lede-meta {
   margin: 0;
-  color: #777;
-  font-size: 0.9em;
 }
 
 /* 記事の概要文。一覧（トップ・タグ・カテゴリ・著者）と We're hiring カードで共用。

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -373,8 +373,10 @@ body.page-header-fixed .header {
   margin-top: 30px;
   margin-bottom: 28px;
 }
+/* 1.2em は .article-entry 配下にしか効かないので、ここで明示する */
 .site-lede-text {
   margin: 0;
+  font-size: 1.2em;
 }
 
 /* 記事の概要文。一覧（トップ・タグ・カテゴリ・著者）と We're hiring カードで共用。

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -366,6 +366,24 @@ body.page-header-fixed .header {
   font-size: 0.9em;
 }
 
+/* ホーム冒頭のブログ説明 */
+.site-lede {
+  margin-bottom: 28px;
+}
+.site-lede-title {
+  margin: 0 0 6px;
+  font-size: 2em;
+  font-weight: bold;
+}
+.site-lede-text {
+  margin: 0 0 4px;
+}
+.site-lede-meta {
+  margin: 0;
+  color: #777;
+  font-size: 0.9em;
+}
+
 /* 記事の概要文。一覧（トップ・タグ・カテゴリ・著者）と We're hiring カードで共用。
    line-height は normal だとフォント依存で環境により 1.4〜1.7 程度に揺れるため明示する */
 .lede {

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -255,7 +255,7 @@ body.page-header-fixed .header {
   background-color: rgba(0,0,0,0.6);
 }
 .header-title {
-  margin-top: 1px;
+  margin: 1px 0 0;
   font-size: 80px;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
   font-weight: 700;
@@ -369,11 +369,6 @@ body.page-header-fixed .header {
 /* ホーム冒頭のブログ説明 */
 .site-lede {
   margin-bottom: 28px;
-}
-.site-lede-title {
-  margin: 0 0 6px;
-  font-size: 2em;
-  font-weight: bold;
 }
 .site-lede-text {
   margin: 0;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -367,7 +367,10 @@ body.page-header-fixed .header {
 }
 
 /* ホーム冒頭のブログ説明 */
+/* パンくずとの間隔は他のページの .margin-top-30 に合わせる
+   （隣接マージンが相殺されるので、そのまま 30px になる） */
 .site-lede {
+  margin-top: 30px;
   margin-bottom: 28px;
 }
 .site-lede-text {

--- a/themes/future/layout/_partial/footer.ejs
+++ b/themes/future/layout/_partial/footer.ejs
@@ -6,6 +6,7 @@
         <div class="col-lg-4 col-md-4 col-sm-6 col-6 pre-footer-col">
           <h2>About Us</h2>
           <p><%- theme.about %></p>
+          <p><a href="<%= theme.corporate_url %>"><%= theme.corporate_url %></a></p>
           <div class="social-btn x-btn-follow x-btn-follow">
             <a
               href="https://x.com/intent/follow?screen_name=future_techblog"

--- a/themes/future/layout/_partial/header.ejs
+++ b/themes/future/layout/_partial/header.ejs
@@ -2,7 +2,13 @@
 <header class="header">
 	<div class="header-overlay">
 		<div class="header-menu"></div>
+		<%# ホームではここがページの見出しそのものなので h1 にする。記事ページは
+		    記事タイトルが h1 なので div のまま。見た目は同じ %>
+		<% if (is_home()) { %>
+		<h1 class="header-title"><a href="/">Future Tech Blog</a></h1>
+		<% } else { %>
 		<div class="header-title"><a href="/">Future Tech Blog</a></div>
+		<% } %>
 		<div class="header-title-sub">フューチャー技術ブログ</div>
 	</div>
 </header>

--- a/themes/future/layout/index.ejs
+++ b/themes/future/layout/index.ejs
@@ -10,7 +10,6 @@
         文面はフッターの About Us と同じ theme.about を使い、二重に持たない %>
     <% if (page.current === 1) { %>
     <section class="site-lede">
-      <h1 class="site-lede-title">フューチャー技術ブログ</h1>
       <p class="site-lede-text"><%- theme.about %></p>
     </section>
     <% } %>

--- a/themes/future/layout/index.ejs
+++ b/themes/future/layout/index.ejs
@@ -6,6 +6,15 @@
     <%- partial('_partial/breadcrumb', {items: [
           {label: 'ホーム', url: page.current === 1 ? null : '/'}
         ].concat(page.current === 1 ? [] : [{label: page.current + 'ページ目'}])}) %>
+    <%# ホームにブログの説明が無く、初めて来た読者に何のサイトか伝わらなかった。
+        文面はフッターの About Us と同じ theme.about を使い、二重に持たない %>
+    <% if (page.current === 1) { %>
+    <section class="site-lede">
+      <h1 class="site-lede-title">フューチャー技術ブログ</h1>
+      <p class="site-lede-text"><%- theme.about %></p>
+      <p class="site-lede-meta"><%= site.posts.length %> 記事・<%= count_authors() %> 人の執筆者・<%= count_tags() %> タグ</p>
+    </section>
+    <% } %>
     <% if (page.current > 1) { %>
     <%
         const perPage = 25;

--- a/themes/future/layout/index.ejs
+++ b/themes/future/layout/index.ejs
@@ -12,7 +12,6 @@
     <section class="site-lede">
       <h1 class="site-lede-title">フューチャー技術ブログ</h1>
       <p class="site-lede-text"><%- theme.about %></p>
-      <p class="site-lede-meta"><%= site.posts.length %> 記事・<%= count_authors() %> 人の執筆者・<%= count_tags() %> タグ</p>
     </section>
     <% } %>
     <% if (page.current > 1) { %>


### PR DESCRIPTION
Closes #2035

ホームに「何のサイトか」の説明がありませんでした。

```
┌────────────────────────┐
│   Future Tech Blog       │  ← ホームではここが h1 になる
│   フューチャー技術ブログ   │
└────────────────────────┘
ホーム

経営とITをデザインする、フューチャーの技術ブログです。   ← 追加
業務で利用している幅広い技術について紹介します。

よく読まれている記事
連載から探す
人気のタグから記事を探す
新着記事
```

## 文言は二重に持たない

説明はフッターの About Us にしかありませんでした。**同じ `theme.about` を使い回します**。

そのままだと企業サイトへのリンクが本文に混ざるので、`about` は説明文だけにして URL を別キーに切り出しました。

```diff
- about: 経営とITを…紹介します。<br /><br /><a href="http://www.future.co.jp/">http://www.future.co.jp/</a>
+ about: 経営とITを…紹介します。
+ corporate_url: http://www.future.co.jp/
```

リンクはフッターのテンプレート側で組みます。フッターの見た目は変わりません。

## h1 の置き場所

ホームには h1 が1つもありませんでした（ヘッダーのサイト名は `div`）。当初ヒーローに h1 を置きましたが、ヘッダーに大きく同じ文字列が出ているので重複します。

**ホームではヘッダーのサイト名を h1 にしました。** ホームにとってはそこがページの見出しそのものです。記事ページは記事タイトルが h1 のままで、**見た目はどちらも変わりません**（h1 の既定マージンが効かないよう `margin` を明示）。

| ページ | h1 |
| --- | --- |
| ホーム | Future Tech Blog |
| 記事 | 記事タイトル |
| タグ / カテゴリ / 著者 | タグ名など（従来どおり） |

## 確認

差分ビルド（`_config.fast.yml`、9秒）で、各ページ種別の h1 が1つずつになり、フッターの About Us も従来どおり出ることを確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)