### PR TITLE
著者一覧を h1 + 年別タブ + 推移チャートの構成にする

### DIFF
--- a/scripts/author_generator.js
+++ b/scripts/author_generator.js
@@ -227,10 +227,6 @@ const generateSeries = (posts, author) => {
 /*
  * 著者一覧ページ
  */
-hexo.extend.helper.register('max_yearly_authors', function() {
-  return Math.max(100, ...generateAuthorsSeriesAll(this.site.posts).map(e => e.authors.unique().length)); // 最小は100
-});
-
 hexo.extend.helper.register('generate_yearly_authors_series_x', function() {
   return generateAuthorsSeriesAll(this.site.posts).map(e => e.year).join(',');
 });

--- a/scripts/author_generator.js
+++ b/scripts/author_generator.js
@@ -239,6 +239,20 @@ hexo.extend.helper.register('generate_yearly_authors_series_y', function() {
   return generateAuthorsSeriesAll(this.site.posts).map(e => e.authors.unique().length).join(',');
 });
 
+// 新規寄稿者の割合（%）。「新規」は前年に投稿が無かった寄稿者（#2073）。
+// 初出ベースではないので、数年ぶりに復帰した人も新規に数える。
+// 最初の年は前年が無く全員新規（100%）になるだけなので欠損にする
+hexo.extend.helper.register('yearly_new_author_ratio', function() {
+  const series = generateAuthorsSeriesAll(this.site.posts);
+  // 共著の旧記事は author が配列なので flat で展開する
+  const sets = series.map(e => new Set(e.authors.flat()));
+  return series.map((e, i) => {
+    if (i === 0 || sets[i].size === 0) return "'-'";
+    const newcomers = [...sets[i]].filter(a => !sets[i - 1].has(a)).length;
+    return Math.round(newcomers * 100 / sets[i].size);
+  }).join(',');
+});
+
 const generateAuthorsSeriesAll = posts => {
   const group = posts.reduce((acc, cur) => {
     const item = acc.find(p => p.year === cur.date.format("YYYY"));

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1115,6 +1115,17 @@ code {
   flex-wrap: wrap;
   gap: 4px 28px;
 }
+/* 全期間の執筆者（/authors/）。年別と重複する再掲なので details で畳む。
+   見出しの代わりになる summary はセクション見出しと同じ余白リズムにする */
+.all-authors {
+  margin-top: 48px;
+}
+.all-authors summary {
+  margin-bottom: 20px;
+  font-size: 1.2em;
+  font-weight: bold;
+  cursor: pointer;
+}
 .author-list {
   padding-inline-start: 0px;
   display: flex;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1119,7 +1119,10 @@ code {
    年ごとの ID ルールを毎年 CSS に足さずに済むよう、input+label+content を
    隣接させて flex の order で並べ替える。ラベルだけ order:1 で帯に並び、
    選択された組のコンテンツが order:2 + 全幅で下段に出る */
-.year-tabs {
+.tabs.year-tabs {
+  /* 後方の .tabs { display: flow-root } と同詳細度だと記述順で負けて
+     flex が効かず、ラベルがインライン扱いで選択コンテンツの後ろに
+     折り返してしまう。クラスを2つ重ねて順序に依存させない */
   display: flex;
   flex-wrap: wrap;
 }

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1115,16 +1115,27 @@ code {
   flex-wrap: wrap;
   gap: 4px 28px;
 }
-/* 全期間の執筆者（/authors/）。年別と重複する再掲なので details で畳む。
-   見出しの代わりになる summary はセクション見出しと同じ余白リズムにする */
-.all-authors {
-  margin-top: 48px;
+/* 著者一覧の年別タブ。ランキングと同じ radio + label 方式だが、
+   年ごとの ID ルールを毎年 CSS に足さずに済むよう、input+label+content を
+   隣接させて flex の order で並べ替える。ラベルだけ order:1 で帯に並び、
+   選択された組のコンテンツが order:2 + 全幅で下段に出る */
+.year-tabs {
+  display: flex;
+  flex-wrap: wrap;
 }
-.all-authors summary {
-  margin-bottom: 20px;
-  font-size: 1.2em;
-  font-weight: bold;
-  cursor: pointer;
+.year-tabs input {
+  display: none;
+}
+.year-tabs .tab_item {
+  float: none;
+  order: 1;
+}
+.year-tabs .tab_content {
+  order: 2;
+  width: 100%;
+}
+.year-tabs input:checked + .tab_item + .tab_content {
+  display: block;
 }
 .author-list {
   padding-inline-start: 0px;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1140,6 +1140,11 @@ code {
   order: 2;
   width: 100%;
 }
+/* 全期間は年のタブと性質が違う（集計であって1つの年ではない）ので、
+   右端に離して置く */
+.year-tabs .tab_item-all {
+  margin-left: auto;
+}
 .year-tabs input:checked + .tab_item + .tab_content {
   display: block;
 }

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1125,6 +1125,9 @@ code {
      折り返してしまう。クラスを2つ重ねて順序に依存させない */
   display: flex;
   flex-wrap: wrap;
+  /* 見出しを持たないブロックなので、上のチャートとの区切りは余白で付ける。
+     ラベルが負のマージンで 8px 帯の上に出るぶんも見込む */
+  margin-top: 40px;
 }
 .year-tabs input {
   display: none;

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -13,8 +13,9 @@
         <li><span class="summary-count"><%= count_articles() %></span><br><span class="summary-label">投稿</span></li>
       </ul>
 
-      <h2 class="bottom-content-header">年別著者数</h2>
-      <div id="chart" style="width:95%;min-height:250px"></div>
+      <%# 見出しは付けない。ページの中身は h1「著者一覧」そのもので、
+          h2 を立てても言い換えにしかならない。チャートは凡例が何のグラフかを語る %>
+      <div id="chart" class="margin-top-30" style="width:95%;min-height:250px"></div>
       <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js"></script>
       <script type="text/javascript">
         let myChart = echarts.init(document.getElementById('chart'));
@@ -65,8 +66,6 @@
         myChart.setOption(option);
       </script>
 
-      <%# 語彙は h1「著者一覧」・チャート「年別著者数」に合わせて「著者」で統一 %>
-      <h2 class="bottom-content-header">著者</h2>
       <%# 全年を縦に並べると16セクションになるが、普段見るのは今年だけなので
           タブで切り替える。既定は今年 (#2073)。ランキングと同じ radio + label 方式 %>
       <div class="nav tabs year-tabs">

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -44,7 +44,8 @@
       <%# 一覧が主役なので推移グラフは補足の読み物として最後に置く。
           /categories/ の「カテゴリ別 投稿数の推移」と同じ型 %>
       <h2 class="bottom-content-header">年別 著者数の推移</h2>
-      <div id="chart" style="width:95%;min-height:250px"></div>
+      <%# 高さは /categories/ の推移グラフ（400px）と揃える %>
+      <div id="chart" style="width:95%;min-height:400px"></div>
       <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js"></script>
       <script type="text/javascript">
         let myChart = echarts.init(document.getElementById('chart'));

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -44,8 +44,7 @@
       <%# 一覧が主役なので推移グラフは補足の読み物として最後に置く。
           /categories/ の「カテゴリ別 投稿数の推移」と同じ型 %>
       <h2 class="bottom-content-header">年別 著者数の推移</h2>
-      <%# 高さは /categories/ の推移グラフ（400px）と揃える %>
-      <div id="chart" style="width:95%;min-height:400px"></div>
+      <div id="chart" style="width:95%;min-height:350px"></div>
       <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js"></script>
       <script type="text/javascript">
         let myChart = echarts.init(document.getElementById('chart'));
@@ -66,9 +65,11 @@
           },
           yAxis: [
               {
+                  <%# 上限は 100 固定。実データ最大（2021年の106）に合わせると
+                      目盛が中途半端になる。超えた分は上にはみ出して切れて良い %>
                   type: 'value',
                   min: 0,
-                  max: <%= max_yearly_authors() %>
+                  max: 100
               },
               <%# 割合は人数と単位が違うので右軸に分ける %>
               {

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -31,7 +31,7 @@
         </div>
         <% } %>
         <input id="authors-all" type="radio" name="authors_year">
-        <label tabindex="0" class="tab_item" for="authors-all">全期間</label>
+        <label tabindex="0" class="tab_item tab_item-all" for="authors-all">全期間</label>
         <div class="tab_content">
           <ul class="summary">
             <li><span class="summary-count"><%= count_authors() %></span><br><span class="summary-label">人</span></li>

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -65,23 +65,30 @@
         myChart.setOption(option);
       </script>
 
-      <%
-        const currentYear = new Date().getFullYear();
-        for (let year = currentYear; year >= 2016; year--) {
-      %>
-        <h2 class="bottom-content-header"><%= year %>年の執筆者</h2>
-        <ul class="summary">
-          <li><span class="summary-count"><%= count_authors(year.toString()) %></span><br><span class="summary-label">人</span></li>
-          <li><span class="summary-count"><%= count_articles_year(year.toString()) %></span><br><span class="summary-label">投稿</span></li>
-        </ul>
-        <%- list_authors(year.toString()) %>
-      <% } %>
-
-      <%# 全期間の一覧は年別セクションと重複する再掲なので、既定では畳んでおく %>
-      <details class="all-authors">
-        <summary>全期間の執筆者</summary>
-        <%- list_authors() %>
-      </details>
+      <h2 class="bottom-content-header">執筆者</h2>
+      <%# 全年を縦に並べると16セクションになるが、普段見るのは今年だけなので
+          タブで切り替える。既定は今年 (#2073)。ランキングと同じ radio + label 方式 %>
+      <div class="nav tabs year-tabs">
+        <%
+          const currentYear = new Date().getFullYear();
+          for (let year = currentYear; year >= 2016; year--) {
+        %>
+        <input id="authors-<%= year %>" type="radio" name="authors_year"<%= year === currentYear ? ' checked' : '' %>>
+        <label tabindex="0" class="tab_item" for="authors-<%= year %>"><%= year %></label>
+        <div class="tab_content">
+          <ul class="summary">
+            <li><span class="summary-count"><%= count_authors(year.toString()) %></span><br><span class="summary-label">人</span></li>
+            <li><span class="summary-count"><%= count_articles_year(year.toString()) %></span><br><span class="summary-label">投稿</span></li>
+          </ul>
+          <%- list_authors(year.toString()) %>
+        </div>
+        <% } %>
+        <input id="authors-all" type="radio" name="authors_year">
+        <label tabindex="0" class="tab_item" for="authors-all">全期間</label>
+        <div class="tab_content">
+          <%- list_authors() %>
+        </div>
+      </div>
 
     </div>
   </section>

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -5,18 +5,43 @@
       ]}) %>
   <section id="main" class="margin-top-30">
     <div class="footer-gap">
+      <h1 class="list-page margin-bottom-20">著者一覧</h1>
+      <%# 全期間の統計はページの統計として h1 直下に置く。
+          カテゴリ・タグ・著者の個別ページと同じ流儀 %>
+      <ul class="summary">
+        <li><span class="summary-count"><%= count_authors() %></span><br><span class="summary-label">人</span></li>
+        <li><span class="summary-count"><%= count_articles() %></span><br><span class="summary-label">投稿</span></li>
+      </ul>
+
+      <%
+        const currentYear = new Date().getFullYear();
+        for (let year = currentYear; year >= 2016; year--) {
+      %>
+        <h2 class="bottom-content-header"><%= year %>年の執筆者</h2>
+        <ul class="summary">
+          <li><span class="summary-count"><%= count_authors(year.toString()) %></span><br><span class="summary-label">人</span></li>
+          <li><span class="summary-count"><%= count_articles_year(year.toString()) %></span><br><span class="summary-label">投稿</span></li>
+        </ul>
+        <%- list_authors(year.toString()) %>
+      <% } %>
+
+      <h2 class="bottom-content-header">全期間の執筆者</h2>
+      <%- list_authors() %>
+
+      <%# 一覧が主役なのでグラフは補足の読み物として最後に置く（/categories/ と同じ） %>
+      <h2 class="bottom-content-header">年別著者数</h2>
       <div id="chart" style="width:95%;min-height:250px"></div>
       <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js"></script>
       <script type="text/javascript">
         let myChart = echarts.init(document.getElementById('chart'));
         let option = {
-          title: {
-              text: '年別著者数'
-          },
+          <%# タイトルは直上の h2 が担うので、チャート内では重ねない %>
+          title: {},
           tooltip: {
               trigger: 'axis'
           },
-          grid: {},
+          <%# 既定の grid.left 10% で右へズレて見える。軸ラベル込みで左端に寄せる %>
+          grid: { left: 0, right: '2%', containLabel: true },
           toolbox: {},
           xAxis: {
               type: 'category',
@@ -38,25 +63,6 @@
         };
         myChart.setOption(option);
       </script>
-
-      <%
-        const currentYear = new Date().getFullYear();
-        for (let year = currentYear; year >= 2016; year--) {
-      %>
-        <h2 class="list-page"><%= year %>年の執筆者</h2>
-        <ul class="summary">
-          <li><span class="summary-count"><%= count_authors(year.toString()) %></span><br><span class="summary-label">人</span></li>
-          <li><span class="summary-count"><%= count_articles_year(year.toString()) %></span><br><span class="summary-label">投稿</span></li>
-        </ul>
-        <%- list_authors(year.toString()) %>
-      <% } %>
-
-      <h2 class="list-page margin-top-50">全期間の執筆者</h2>
-      <ul class="summary">
-        <li><span class="summary-count"><%= count_authors() %></span><br><span class="summary-label">人</span></li>
-        <li><span class="summary-count"><%= count_articles() %></span><br><span class="summary-label">投稿</span></li>
-      </ul>
-      <%- list_authors() %>
     </div>
   </section>
 </div>

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -65,7 +65,8 @@
         myChart.setOption(option);
       </script>
 
-      <h2 class="bottom-content-header">執筆者</h2>
+      <%# 語彙は h1「著者一覧」・チャート「年別著者数」に合わせて「著者」で統一 %>
+      <h2 class="bottom-content-header">著者</h2>
       <%# 全年を縦に並べると16セクションになるが、普段見るのは今年だけなので
           タブで切り替える。既定は今年 (#2073)。ランキングと同じ radio + label 方式 %>
       <div class="nav tabs year-tabs">

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -25,8 +25,11 @@
         <%- list_authors(year.toString()) %>
       <% } %>
 
-      <h2 class="bottom-content-header">全期間の執筆者</h2>
-      <%- list_authors() %>
+      <%# 全期間の一覧は年別セクションと重複する再掲なので、既定では畳んでおく %>
+      <details class="all-authors">
+        <summary>全期間の執筆者</summary>
+        <%- list_authors() %>
+      </details>
 
       <%# 一覧が主役なのでグラフは補足の読み物として最後に置く（/categories/ と同じ） %>
       <h2 class="bottom-content-header">年別著者数</h2>

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -13,6 +13,58 @@
         <li><span class="summary-count"><%= count_articles() %></span><br><span class="summary-label">投稿</span></li>
       </ul>
 
+      <h2 class="bottom-content-header">年別著者数</h2>
+      <div id="chart" style="width:95%;min-height:250px"></div>
+      <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js"></script>
+      <script type="text/javascript">
+        let myChart = echarts.init(document.getElementById('chart'));
+        let option = {
+          <%# タイトルは直上の h2 が担うので、チャート内では重ねない %>
+          title: {},
+          legend: {},
+          tooltip: {
+              trigger: 'axis'
+          },
+          <%# 既定の grid.left 10% で右へズレて見える。軸ラベル込みで左端に寄せる %>
+          grid: { left: 0, right: '2%', containLabel: true },
+          toolbox: {},
+          xAxis: {
+              type: 'category',
+              boundaryGap: false,
+              data: [<%= generate_yearly_authors_series_x() %>]
+          },
+          yAxis: [
+              {
+                  type: 'value',
+                  min: 0,
+                  max: <%= max_yearly_authors() %>
+              },
+              <%# 割合は人数と単位が違うので右軸に分ける %>
+              {
+                  type: 'value',
+                  min: 0,
+                  max: 100,
+                  axisLabel: { formatter: '{value}%' },
+                  splitLine: { show: false }
+              }
+          ],
+          series: [
+              {
+                  name: '著者数（UU）',
+                  type: 'line',
+                  data: [<%= generate_yearly_authors_series_y() %>]
+              },
+              {
+                  name: '新規寄稿者の割合（%）',
+                  type: 'line',
+                  yAxisIndex: 1,
+                  data: [<%- yearly_new_author_ratio() %>]
+              }
+          ]
+        };
+        myChart.setOption(option);
+      </script>
+
       <%
         const currentYear = new Date().getFullYear();
         for (let year = currentYear; year >= 2016; year--) {
@@ -31,41 +83,6 @@
         <%- list_authors() %>
       </details>
 
-      <%# 一覧が主役なのでグラフは補足の読み物として最後に置く（/categories/ と同じ） %>
-      <h2 class="bottom-content-header">年別著者数</h2>
-      <div id="chart" style="width:95%;min-height:250px"></div>
-      <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js"></script>
-      <script type="text/javascript">
-        let myChart = echarts.init(document.getElementById('chart'));
-        let option = {
-          <%# タイトルは直上の h2 が担うので、チャート内では重ねない %>
-          title: {},
-          tooltip: {
-              trigger: 'axis'
-          },
-          <%# 既定の grid.left 10% で右へズレて見える。軸ラベル込みで左端に寄せる %>
-          grid: { left: 0, right: '2%', containLabel: true },
-          toolbox: {},
-          xAxis: {
-              type: 'category',
-              boundaryGap: false,
-              data: [<%= generate_yearly_authors_series_x() %>]
-          },
-          yAxis: {
-              type: 'value',
-              min:0,
-              max: <%= max_yearly_authors() %>
-          },
-          series: [
-              {
-                  name: '著者数（UU）',
-                  type: 'line',
-                  data: [<%= generate_yearly_authors_series_y() %>]
-              }
-          ]
-        };
-        myChart.setOption(option);
-      </script>
     </div>
   </section>
 </div>

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -13,9 +13,38 @@
         <li><span class="summary-count"><%= count_articles() %></span><br><span class="summary-label">投稿</span></li>
       </ul>
 
-      <%# 見出しは付けない。ページの中身は h1「著者一覧」そのもので、
-          h2 を立てても言い換えにしかならない。チャートは凡例が何のグラフかを語る %>
-      <div id="chart" class="margin-top-30" style="width:95%;min-height:250px"></div>
+      <%# 全年を縦に並べると16セクションになるが、普段見るのは今年だけなので
+          タブで切り替える。既定は今年 (#2073)。ランキングと同じ radio + label 方式 %>
+      <div class="nav tabs year-tabs">
+        <%
+          const currentYear = new Date().getFullYear();
+          for (let year = currentYear; year >= 2016; year--) {
+        %>
+        <input id="authors-<%= year %>" type="radio" name="authors_year"<%= year === currentYear ? ' checked' : '' %>>
+        <label tabindex="0" class="tab_item" for="authors-<%= year %>"><%= year %></label>
+        <div class="tab_content">
+          <ul class="summary">
+            <li><span class="summary-count"><%= count_authors(year.toString()) %></span><br><span class="summary-label">人</span></li>
+            <li><span class="summary-count"><%= count_articles_year(year.toString()) %></span><br><span class="summary-label">投稿</span></li>
+          </ul>
+          <%- list_authors(year.toString()) %>
+        </div>
+        <% } %>
+        <input id="authors-all" type="radio" name="authors_year">
+        <label tabindex="0" class="tab_item" for="authors-all">全期間</label>
+        <div class="tab_content">
+          <ul class="summary">
+            <li><span class="summary-count"><%= count_authors() %></span><br><span class="summary-label">人</span></li>
+            <li><span class="summary-count"><%= count_articles() %></span><br><span class="summary-label">投稿</span></li>
+          </ul>
+          <%- list_authors() %>
+        </div>
+      </div>
+
+      <%# 一覧が主役なので推移グラフは補足の読み物として最後に置く。
+          /categories/ の「カテゴリ別 投稿数の推移」と同じ型 %>
+      <h2 class="bottom-content-header">年別 著者数の推移</h2>
+      <div id="chart" style="width:95%;min-height:250px"></div>
       <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js"></script>
       <script type="text/javascript">
         let myChart = echarts.init(document.getElementById('chart'));
@@ -65,31 +94,6 @@
         };
         myChart.setOption(option);
       </script>
-
-      <%# 全年を縦に並べると16セクションになるが、普段見るのは今年だけなので
-          タブで切り替える。既定は今年 (#2073)。ランキングと同じ radio + label 方式 %>
-      <div class="nav tabs year-tabs">
-        <%
-          const currentYear = new Date().getFullYear();
-          for (let year = currentYear; year >= 2016; year--) {
-        %>
-        <input id="authors-<%= year %>" type="radio" name="authors_year"<%= year === currentYear ? ' checked' : '' %>>
-        <label tabindex="0" class="tab_item" for="authors-<%= year %>"><%= year %></label>
-        <div class="tab_content">
-          <ul class="summary">
-            <li><span class="summary-count"><%= count_authors(year.toString()) %></span><br><span class="summary-label">人</span></li>
-            <li><span class="summary-count"><%= count_articles_year(year.toString()) %></span><br><span class="summary-label">投稿</span></li>
-          </ul>
-          <%- list_authors(year.toString()) %>
-        </div>
-        <% } %>
-        <input id="authors-all" type="radio" name="authors_year">
-        <label tabindex="0" class="tab_item" for="authors-all">全期間</label>
-        <div class="tab_content">
-          <%- list_authors() %>
-        </div>
-      </div>
-
     </div>
   </section>
 </div>


### PR DESCRIPTION
## 概要

Fixes #2073

著者一覧（/authors/）を、他の一覧ページで確立した設計言語に揃えつつ、ユースケース（普段見るのは今年だけ）に合わせて年別タブ化しました。

最終構成: **h1 著者一覧 → 全期間の統計（人・投稿）→ 年別タブ（既定は今年）→ h2 年別 著者数の推移 → チャート**

## 対応内容

1. **h1「著者一覧」を追加**（一覧ページで唯一 h1 がなかった）。全期間の統計はページの統計として h1 直下へ
2. **執筆者一覧をタブ化**: 従来は16セクションが縦に並んでいたが、普段見るのは今年だけなので radio + label の CSS タブ（ホームのランキングと同方式・JS なし）に。既定タブは今年、過去の年と全期間は別タブ。各タブに 人・投稿 の統計タイル付き
   - 既存タブの `#monthly:checked ~ #popular_monthly` のような ID 直書きだと毎年 CSS に1行足すことになるため、`input+label+content` の隣接と flex の `order` で並べ替える汎用ルールにした（2027年以降はテンプレートだけで自動追従）
   - `.year-tabs` の flex が後方の `.tabs { display: flow-root }` に記述順で負ける問題は、クラスを2つ重ねて詳細度で解決
3. **チャートの整理**: `/categories/` の「カテゴリ別 投稿数の推移」と同じ型で、一覧の下に h2「年別 著者数の推移」として配置。ライブラリ内タイトルをやめ、左寄せ（containLabel）も適用
4. **新規寄稿者の割合を第2系列に追加**: 定義は「前年に投稿が無かった寄稿者」（初出ベースではないため復帰組も含む）。単位が違うため右軸（%）。最初の年は全員新規になるだけなので欠損として描かない

## 動作確認

- /authors/ で h1 → 統計 → タブ（2026 が既定・全13タブ横並び）→ 推移チャート（2系列・凡例）の構造を確認
- タブ切り替えが CSS のみで機能すること、全期間タブにも統計タイルが出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
