### PR TITLE
カテゴリの過半数を占めるタグを除いた一覧を出す

### DIFF
--- a/scripts/category_chart_helpers.js
+++ b/scripts/category_chart_helpers.js
@@ -120,6 +120,11 @@ hexo.extend.helper.register('category_index', function() {
     .map(category => buildCategoryStats.call(this, category));
 });
 
+// 絞り込んだ一覧用。カテゴリと同じ統計を、記事の部分集合に対して出す (#2038)
+hexo.extend.helper.register('stats_of_posts', function(name, path, posts) {
+  return buildCategoryStats.call(this, {name, path, length: posts.length, posts});
+});
+
 // カテゴリ個別ページ用。一覧と同じ統計を個別ページにも出す (#2084)
 hexo.extend.helper.register('category_stats', function(name) {
   const category = this.site.categories.findOne({name});

--- a/scripts/category_without_tag.js
+++ b/scripts/category_without_tag.js
@@ -1,0 +1,39 @@
+'use strict';
+
+/**
+ * カテゴリの過半数を1つのタグが占めると、それ以外の記事に辿り着けない。
+ * Programming は 337本中 201本（60%）が Go で、「Go 以外の Programming」を
+ * 探す手段が無かった。そのタグを除いた一覧を1本だけ生成する。
+ *
+ * 「そのタグで絞り込む」側は作らない。/tags/Go/ と同義になるため。
+ */
+
+const pagination = require('hexo-pagination');
+const {dominantTag} = require('./lib/dominant_tag');
+
+hexo.extend.generator.register('category_without_tag', function(locals) {
+  const perPage = (this.config.category_generator || {}).per_page || this.config.per_page || 10;
+  const pages = [];
+
+  locals.categories.forEach(category => {
+    const dominant = dominantTag(category);
+    if (!dominant) return;
+
+    pages.push(...pagination(category.path + dominant.slug, dominant.rest.sort('-date'), {
+      layout: ['category-without', 'archive', 'index'],
+      perPage,
+      data: {category: category.name, excludedTag: dominant.name}
+    }));
+  });
+
+  return pages;
+});
+
+// カテゴリページから「◯◯ 以外の記事」への導線を出すのに使う
+hexo.extend.helper.register('category_without_tag', function(name) {
+  const category = this.site.categories.findOne({name});
+  if (!category) return null;
+  const dominant = dominantTag(category);
+  if (!dominant) return null;
+  return {name: dominant.name, count: dominant.rest.length, path: category.path + dominant.slug + '/'};
+});

--- a/scripts/category_without_tag.js
+++ b/scripts/category_without_tag.js
@@ -19,10 +19,11 @@ hexo.extend.generator.register('category_without_tag', function(locals) {
     const dominant = dominantTag(category);
     if (!dominant) return;
 
-    pages.push(...pagination(category.path + dominant.slug, dominant.rest.sort('-date'), {
+    const rest = dominant.rest.sort('-date');
+    pages.push(...pagination(category.path + dominant.slug, rest, {
       layout: ['category-without', 'archive', 'index'],
       perPage,
-      data: {category: category.name, excludedTag: dominant.name}
+      data: {category: category.name, excludedTag: dominant.name, withoutPosts: rest, withoutPath: category.path + dominant.slug + '/'}
     }));
   });
 

--- a/scripts/count_post.js
+++ b/scripts/count_post.js
@@ -80,9 +80,8 @@ hexo.extend.helper.register('summary_yearly_term', function(year) {
 /*
  * カテゴリ個別ページ
  */
-hexo.extend.helper.register('summary_category', function(category) {
-  const posts = this.site.posts.filter(post => post.categories.map(c => c.name).includes(category));
-
+// 記事の集合に対する反響の合計。カテゴリ・タグ・絞り込み後の一覧で共用する
+function summaryOf(posts) {
   const total = posts.map(post => getSNSCnt(post.permalink)).reduce((acc, cur) => acc + cur);
   const authors = posts.map(post => post.author).flat().unique().length;
   const tw = posts.map(post => getTwitterCnt(post.permalink)).reduce((acc, cur) => acc + cur);
@@ -98,7 +97,13 @@ hexo.extend.helper.register('summary_category', function(category) {
     hatebu: hatebu,
     pocket: pocket
   };
+}
+
+hexo.extend.helper.register('summary_category', function(category) {
+  return summaryOf(this.site.posts.filter(post => post.categories.map(c => c.name).includes(category)));
 });
+
+hexo.extend.helper.register('summary_posts', summaryOf);
 
 /*
  * タグ個別ページ

--- a/scripts/lib/dominant_tag.js
+++ b/scripts/lib/dominant_tag.js
@@ -1,0 +1,40 @@
+'use strict';
+
+// 連載の索引につけるタグ。トピックではないので支配タグの候補から外す
+const OPS_TAGS = new Set(['インデックス']);
+// 1ページに収まるカテゴリでは、スクロールすれば全部見えるので絞る意味がない
+const MIN_POSTS = 25;
+// 過半数。ここを下げると Frontend や DataScience まで広がるが、
+// 3割程度のタグは「支配している」とは言えず、絞り込みはタグページで足りる
+const DOMINANT_RATIO = 0.5;
+
+/**
+ * カテゴリの過半数を1つのタグが占めていれば、そのタグと残りの記事を返す。
+ * 該当しなければ null。
+ */
+function dominantTag(category) {
+  if (category.length < MIN_POSTS) return null;
+
+  const counts = new Map();
+  category.posts.forEach(post => {
+    if (!post.tags) return;
+    post.tags.forEach(tag => {
+      if (OPS_TAGS.has(tag.name)) return;
+      counts.set(tag.name, (counts.get(tag.name) || 0) + 1);
+    });
+  });
+
+  let top = null;
+  for (const [name, count] of counts) {
+    // 同数は名前で決める（決着が無いとビルドごとに変わる）
+    if (!top || count > top.count || (count === top.count && name < top.name)) {
+      top = {name, count};
+    }
+  }
+  if (!top || top.count / category.length <= DOMINANT_RATIO) return null;
+
+  const rest = category.posts.filter(post => !post.tags.some(t => t.name === top.name));
+  return {name: top.name, count: top.count, rest, slug: `without-${top.name.toLowerCase()}`};
+}
+
+module.exports = {dominantTag};

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -329,6 +329,16 @@ body.page-header-fixed .header {
   font-weight: bold;
   margin-bottom: 4px;
 }
+/* カテゴリの支配的なタグを除いた一覧への導線 */
+.category-without-link {
+  margin: 12px 0 0;
+  font-size: 1.2em;
+}
+.list-page-note {
+  margin: 8px 0 0;
+  color: #777;
+}
+
 /* ホームの「連載から探す」。We're hiring のカードと同じ横並びの作り */
 .series-panels .article-card {
   display: flex;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -330,8 +330,10 @@ body.page-header-fixed .header {
   margin-bottom: 4px;
 }
 /* カテゴリの支配的なタグを除いた一覧への導線 */
+/* 見出しと一覧の間に入るので、上下とも .bottom-content-header の
+   下マージン（20px）に揃える。下が 0 だと一覧に貼り付く */
 .category-without-link {
-  margin: 12px 0 0;
+  margin: 0 0 20px;
   font-size: 1.2em;
 }
 .list-page-note {

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -336,10 +336,12 @@ body.page-header-fixed .header {
   margin: 0 0 20px;
   font-size: 1.2em;
 }
-/* h1 と統計タイルの間に入る補足。下を空けないと統計に貼り付く */
+/* 対になる .category-without-link と同じ位置・同じ大きさで出す。
+   1.2em は .article-entry 配下にしか効かないのでここで明示する */
 .list-page-note {
-  margin: 8px 0 20px;
+  margin: 0 0 20px;
   color: #777;
+  font-size: 1.2em;
 }
 
 /* ホームの「連載から探す」。We're hiring のカードと同じ横並びの作り */

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -336,8 +336,9 @@ body.page-header-fixed .header {
   margin: 0 0 20px;
   font-size: 1.2em;
 }
+/* h1 と統計タイルの間に入る補足。下を空けないと統計に貼り付く */
 .list-page-note {
-  margin: 8px 0 0;
+  margin: 8px 0 20px;
   color: #777;
 }
 

--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -85,6 +85,10 @@
       <% if (listHeading) { %>
       <h2 id="posts" class="bottom-content-header"><a href="#posts" class="headerlink" title="記事一覧"></a><%= listHeading %></h2>
       <% } %>
+      <%# 見出しとリストの間に置きたい補足を呼び出し側から差し込む %>
+      <% if (typeof list_note !== 'undefined' && list_note) { %>
+      <%- list_note %>
+      <% } %>
       <div class="archives">
         <% page.posts.each(function(post, i){ %>
         <%- partial('archive-post', {post: post, even: i % 2 == 0, index: true}) %>

--- a/themes/future/layout/category-without.ejs
+++ b/themes/future/layout/category-without.ejs
@@ -9,7 +9,6 @@
     <h1 class="list-page"><%- page.category %> <span class="list-sub-text">カテゴリの <%- page.excludedTag %> 以外の記事</span></h1>
     <%# 構成はカテゴリページと同じ。統計・タグ・ランキングは絞り込んだ後の集合で数える %>
     <% if (page.current === 1) { %>
-    <p class="list-page-note"><%- page.excludedTag %> の記事は <a href="<%- url_for('tags/' + page.excludedTag) %>"><%- page.excludedTag %> タグ</a>にまとまっています</p>
     <% const summary = summary_posts(page.withoutPosts); %>
     <% const stats = stats_of_posts(page.category, page.withoutPath, page.withoutPosts); %>
     <ul class="summary">
@@ -41,6 +40,9 @@
     <%- popular %>
     <% } %>
     <% } %>
-    <%- partial('_partial/archive', {pagination: config.category, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧'}) %>
+    <%# カテゴリページの「◯◯ 以外の記事を見る」と対になる位置。
+        見出しの直下、一覧に入る前に置く %>
+    <% const backLink = `<p class="list-page-note">${page.excludedTag} の記事は <a href="${url_for('tags/' + page.excludedTag)}">${page.excludedTag} タグ</a>にまとまっています</p>`; %>
+    <%- partial('_partial/archive', {pagination: config.category, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧', list_note: backLink}) %>
   </section>
 </div>

--- a/themes/future/layout/category-without.ejs
+++ b/themes/future/layout/category-without.ejs
@@ -1,0 +1,13 @@
+<div class="container">
+  <%- partial('_partial/breadcrumb', {items: [
+        {label: 'ホーム', url: '/'},
+        {label: 'カテゴリ', url: '/categories/'},
+        {label: page.category, url: '/categories/' + page.category + '/'},
+        {label: page.excludedTag + ' 以外', url: page.current === 1 ? null : page.base}
+      ].concat(page.current === 1 ? [] : [{label: page.current + 'ページ目'}])}) %>
+  <section id="main" class="margin-top-30">
+    <h1 class="list-page"><%- page.category %> <span class="list-sub-text">カテゴリの <%- page.excludedTag %> 以外の記事</span></h1>
+    <p class="list-page-note"><%- page.excludedTag %> の記事は <a href="<%- url_for('tags/' + page.excludedTag) %>"><%- page.excludedTag %> タグ</a>にまとまっています</p>
+    <%- partial('_partial/archive', {pagination: config.category, index: true, list_heading: '記事一覧'}) %>
+  </section>
+</div>

--- a/themes/future/layout/category-without.ejs
+++ b/themes/future/layout/category-without.ejs
@@ -3,11 +3,44 @@
         {label: 'ホーム', url: '/'},
         {label: 'カテゴリ', url: '/categories/'},
         {label: page.category, url: '/categories/' + page.category + '/'},
-        {label: page.excludedTag + ' 以外', url: page.current === 1 ? null : page.base}
+        {label: page.excludedTag + ' 以外', url: page.current === 1 ? null : page.withoutPath}
       ].concat(page.current === 1 ? [] : [{label: page.current + 'ページ目'}])}) %>
   <section id="main" class="margin-top-30">
     <h1 class="list-page"><%- page.category %> <span class="list-sub-text">カテゴリの <%- page.excludedTag %> 以外の記事</span></h1>
+    <%# 構成はカテゴリページと同じ。統計・タグ・ランキングは絞り込んだ後の集合で数える %>
+    <% if (page.current === 1) { %>
     <p class="list-page-note"><%- page.excludedTag %> の記事は <a href="<%- url_for('tags/' + page.excludedTag) %>"><%- page.excludedTag %> タグ</a>にまとまっています</p>
-    <%- partial('_partial/archive', {pagination: config.category, index: true, list_heading: '記事一覧'}) %>
+    <% const summary = summary_posts(page.withoutPosts); %>
+    <% const stats = stats_of_posts(page.category, page.withoutPath, page.withoutPosts); %>
+    <ul class="summary">
+      <li><span class="summary-count"><%= page.withoutPosts.length %></span><br><span class="summary-label">投稿</span></li>
+      <li><span class="summary-count"><%= summary.authors %></span><br><span class="summary-label">著者数</span></li>
+      <li><span class="summary-count"><%= summary.total %></span><br><span class="summary-label">総シェア数</span></li>
+      <li><span class="summary-count"><%= summary.twitter %></span><br><span class="summary-label">Twitter</span></li>
+      <li><span class="summary-count"><%= summary.facebook %></span><br><span class="summary-label">Facebook</span></li>
+      <li><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
+      <li><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
+    </ul>
+    <ul class="summary">
+      <li><span class="summary-count"><%= stats.recent %></span><br><span class="summary-label">直近1年の投稿</span></li>
+      <li><span class="summary-count"><%= stats.recentAuthorCount %></span><br><span class="summary-label">直近1年の著者数</span></li>
+    </ul>
+    <% if (stats.topTags.length) { %>
+    <h2 class="bottom-content-header">よく使われるタグ</h2>
+    <div class="blog-tags">
+      <ul class="tag-list">
+        <% stats.topTags.forEach(function(t){ %>
+        <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= page.category %> カテゴリの <%= t.name %> の記事 <%= t.count %>本"><%= t.name %><span class="tag-list-count"><%= t.count %></span></a></li>
+        <% }) %>
+      </ul>
+    </div>
+    <% } %>
+    <% const popular = popular_posts_in(page.withoutPosts.toArray()); %>
+    <% if (popular) { %>
+    <h2 class="bottom-content-header">よく読まれている記事</h2>
+    <%- popular %>
+    <% } %>
+    <% } %>
+    <%- partial('_partial/archive', {pagination: config.category, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧'}) %>
   </section>
 </div>

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -42,6 +42,12 @@
       </ul>
     </div>
     <% } %>
+    <%# 1つのタグがカテゴリの過半数を占めると、それ以外の記事に辿り着けない。
+        絞り込む側はタグページが担うので、除いた側だけ導線を出す（#2038） %>
+    <% const without = category_without_tag(page.category); %>
+    <% if (without) { %>
+    <p class="category-without-link"><a href="<%- url_for(without.path) %>"><%= without.name %> 以外の記事を見る（<%= without.count %>本）</a></p>
+    <% } %>
     <%# そのカテゴリの中でよく読まれている記事。新着より前に置く。
         絞り込んだ直後の読者がまず知りたいのは「定番はどれか」であって、
         新しさは新着一覧が担う %>

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -42,12 +42,6 @@
       </ul>
     </div>
     <% } %>
-    <%# 1つのタグがカテゴリの過半数を占めると、それ以外の記事に辿り着けない。
-        絞り込む側はタグページが担うので、除いた側だけ導線を出す（#2038） %>
-    <% const without = category_without_tag(page.category); %>
-    <% if (without) { %>
-    <p class="category-without-link"><a href="<%- url_for(without.path) %>"><%= without.name %> 以外の記事を見る（<%= without.count %>本）</a></p>
-    <% } %>
     <%# そのカテゴリの中でよく読まれている記事。新着より前に置く。
         絞り込んだ直後の読者がまず知りたいのは「定番はどれか」であって、
         新しさは新着一覧が担う %>
@@ -69,5 +63,12 @@
     <%# 見出しの語彙はホームに合わせる。一覧は日付降順なので
         1ページ目だけが「新着」を名乗れる %>
     <%- partial('_partial/archive', {pagination: config.category, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧'}) %>
+    <%# 一覧を読み終えた読者への次の導線。1つのタグがカテゴリの過半数をがカテゴリの過半数を占めると、それ以外の記事に辿り着けない。
+        絞り込む側はタグページが担うので、除いた側だけ導線を出す（#2038） %>
+    <% const without = category_without_tag(page.category); %>
+    <% if (without) { %>
+    <p class="category-without-link"><a href="<%- url_for(without.path) %>"><%= without.name %> 以外の記事を見る（<%= without.count %>本）</a></p>
+    <% } %>
+
   </section>
 </div>

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -62,13 +62,14 @@
     <% } %>
     <%# 見出しの語彙はホームに合わせる。一覧は日付降順なので
         1ページ目だけが「新着」を名乗れる %>
-    <%- partial('_partial/archive', {pagination: config.category, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧'}) %>
-    <%# 一覧を読み終えた読者への次の導線。1つのタグがカテゴリの過半数をがカテゴリの過半数を占めると、それ以外の記事に辿り着けない。
-        絞り込む側はタグページが担うので、除いた側だけ導線を出す（#2038） %>
+    <%# 1つのタグがカテゴリの過半数を占めると、それ以外の記事に辿り着けない。
+        絞り込む側はタグページが担うので、除いた側だけ導線を出す（#2038）。
+        「新着記事」の見出しの直下、一覧に入る前に置く %>
     <% const without = category_without_tag(page.category); %>
-    <% if (without) { %>
-    <p class="category-without-link"><a href="<%- url_for(without.path) %>"><%= without.name %> 以外の記事を見る（<%= without.count %>本）</a></p>
-    <% } %>
+    <% const withoutLink = without
+         ? `<p class="category-without-link"><a href="${url_for(without.path)}">${without.name} 以外の記事を見る（${without.count}本）</a></p>`
+         : ''; %>
+    <%- partial('_partial/archive', {pagination: config.category, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧', list_note: withoutLink}) %>
 
   </section>
 </div>


### PR DESCRIPTION
Closes #2038

## 測った結果

カテゴリごとの「最大タグの占有率」です（`インデックス` は連載の索引でトピックではないので候補から除外）。

| カテゴリ | 記事 | 最大タグ | 占有 | 除くと残る |
| --- | --- | --- | --- | --- |
| **Programming** | 337 | **Go** | **60%** | **136本** |
| Mobile | 57 | Flutter | 49% | 29本 |
| DataScience | 113 | 機械学習 | 34% | 75本 |
| Frontend | 131 | Vue.js | 31% | 91本 |
| Infrastructure | 155 | AWS | 25% | 117本 |
| DevOps | 184 | Terraform | 24% | 140本 |

**過半数を超えるのは Programming だけ**でした。3割程度のタグは「支配している」とは言えず、絞り込みはタグページで足ります。

## 作るもの

`/categories/Programming/without-go/` を1本だけ生成します。

```
Programming カテゴリ
[統計]
Go 以外の記事を見る（136本）→        ← 追加
よく使われるタグ  Go(201) Java(31) …
よく読まれている記事
新着記事
```

遷移先:

```
ホーム › カテゴリ › Programming › Go 以外
Programming カテゴリの Go 以外の記事
Go の記事は Go タグにまとまっています
[記事一覧・ページャ]
```

**「そのタグで絞り込む」側は作りません。** `/tags/Go/` と同義になるためです。カテゴリ→タグの導線は既にあります。

## 条件

- 記事 **25本以上**（1ページに収まるカテゴリでは絞る意味がない）
- 最大タグの占有が **過半数**
- `インデックス` は候補から外す

閾値は `scripts/lib/dominant_tag.js` の定数1箇所です。

## URL

`/categories/Programming/without-go/` です。`/categories/Programming/without/Go/` だと `/without/` という中身の無い階層が生まれてしまうので採りませんでした。

## 確認

**全ビルド**で確認しました（新しい URL が増えるため）。生成されたのは `Programming/without-go` のみで、他のカテゴリには出ていません。

なお Infrastructure に AWS / Google Cloud とネットワークが混在している件は、カテゴリの切り分けそのものの話なので #2057 の議題として残しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)