### PR TITLE
without ページから戻る導線を足し、文言を具体的にする

### DIFF
--- a/themes/future/layout/category-without.ejs
+++ b/themes/future/layout/category-without.ejs
@@ -40,9 +40,14 @@
     <%- popular %>
     <% } %>
     <% } %>
-    <%# カテゴリページの「◯◯ 以外の記事を見る」と対になる位置。
-        見出しの直下、一覧に入る前に置く %>
-    <% const backLink = `<p class="list-page-note">${page.excludedTag} の記事は <a href="${url_for('tags/' + page.excludedTag)}">${page.excludedTag} タグ</a>にまとまっています</p>`; %>
+    <%# カテゴリページの「◯◯以外の記事を見る」と対になる位置。
+        見出しの直下、一覧に入る前に置く。
+        絞り込みを解く導線（カテゴリへ戻る）と、除いた側を見る導線（タグ）を並べる。
+        今はパンくずからしか戻れなかった %>
+    <% const backLink = `<p class="list-page-note">`
+         + `<a href="${url_for('categories/' + page.category + '/')}">${page.excludedTag}の記事を含む${page.category}カテゴリを見る</a><br>`
+         + `${page.excludedTag}の記事は<a href="${url_for('tags/' + page.excludedTag + '/')}">${page.excludedTag}タグ</a>にまとまっています`
+         + `</p>`; %>
     <%- partial('_partial/archive', {pagination: config.category, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧', list_note: backLink}) %>
   </section>
 </div>

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -67,7 +67,7 @@
         「新着記事」の見出しの直下、一覧に入る前に置く %>
     <% const without = category_without_tag(page.category); %>
     <% const withoutLink = without
-         ? `<p class="category-without-link"><a href="${url_for(without.path)}">${without.name} 以外の記事を見る（${without.count}本）</a></p>`
+         ? `<p class="category-without-link"><a href="${url_for(without.path)}">${page.category}カテゴリの${without.name}以外の記事を見る（${without.count}本）</a></p>`
          : ''; %>
     <%- partial('_partial/archive', {pagination: config.category, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧', list_note: withoutLink}) %>
 


### PR DESCRIPTION
#2107 のフォローアップ。

## カテゴリページ側

```diff
- Go 以外の記事を見る（136本）
+ ProgrammingカテゴリのGo以外の記事を見る（136本）
```

カテゴリ名が無いと、どのカテゴリの絞り込みなのかが文だけでは分かりませんでした。

## without ページ側

**パンくずからしか戻れなかった**ので、リンクを2本にしました。

```
新着記事
Goの記事を含むProgrammingカテゴリを見る     ← 追加（絞り込みを解く）
Goの記事はGoタグにまとまっています           ← 既存（除いた側を見る）
  記事1
  …
```

これで往復の導線が揃います。

| ページ | 新着記事の直後 |
| --- | --- |
| `/categories/Programming/` | ProgrammingカテゴリのGo以外の記事を見る（136本） |
| `/categories/Programming/without-go/` | Goの記事を含むProgrammingカテゴリを見る<br>Goの記事はGoタグにまとまっています |

あわせてリンク先に末尾スラッシュを付けました（`/categories/Programming` → `/categories/Programming/`）。サイト内の他のリンクと同じ形になります。

## 確認

差分ビルド（`_config.fast.yml`）で、両ページの文言とリンク先を確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)