### PR TITLE
よく読まれている記事をパネルにし、タグより前に出す

### DIFF
--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const fs = require("fs");
-const {postListItem} = require("./lib/post_list");
+const {snsLabel} = require("./lib/post_list");
 
 const load = JSON.parse(fs.readFileSync("ga4_pv.json", 'utf-8'));
 const map = new Map();
@@ -21,7 +21,7 @@ hexo.extend.helper.register("get_ga4_pv", url => {
 
 // 指定した記事の中から PV の多い順に取り出す。カテゴリ・タグの一覧ページで
 // 「よく読まれている記事」を出すのに使う（#2033 / #2034）
-hexo.extend.helper.register('popular_posts_in', function(posts, limit = 5) {
+hexo.extend.helper.register('popular_posts_in', function(posts, limit = 4) {
   const ranked = posts
     .map(post => ({post, pv: getGA4PV('/' + post.path)}))
     .filter(x => x.pv > 0)
@@ -31,6 +31,16 @@ hexo.extend.helper.register('popular_posts_in', function(posts, limit = 5) {
 
   if (ranked.length === 0) return '';
 
-  const links = ranked.map(x => postListItem(x.post, 'featured-posts-item')).join('\n');
-  return `<div class="widget"><ul class="nav featured-post-link">${links}</ul></div>`;
+  // マークアップはホームの「連載から探す」と同じカード。2列で並べる
+  const cards = ranked.map(({post}) => {
+    const thumb = post.thumbnail
+      ? `<a href="/${post.path}" title="${post.title}" class="img_wrap panel-thumb"><img src="${post.thumbnail}" alt="" width="200" height="135" loading="lazy"></a>`
+      : '';
+    return `<div class="col-12 col-md-6"><div class="article-card post-panel h-100">${thumb}`
+      + `<div class="panel-body"><a href="/${post.path}" class="panel-title">${post.title}</a>`
+      + `<div class="panel-meta">${post.date.format('YYYY.MM.DD')}${snsLabel(post.permalink)}</div>`
+      + `</div></div></div>`;
+  }).join('');
+
+  return `<div class="row g-4">${cards}</div>`;
 });

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -344,8 +344,10 @@ body.page-header-fixed .header {
   font-size: 1.2em;
 }
 
-/* ホームの「連載から探す」。We're hiring のカードと同じ横並びの作り */
-.series-panels .article-card {
+/* ホームの「連載から探す」と、カテゴリ・タグの「よく読まれている記事」で共用する
+   カード。We're hiring と同じ横並びの作り */
+.series-panels .article-card,
+.post-panel {
   display: flex;
   gap: 12px;
   align-items: flex-start;
@@ -353,32 +355,36 @@ body.page-header-fixed .header {
   margin: 0;
   border: 1px solid #eee;
 }
-.series-panel-thumb {
+.panel-thumb {
   flex: 0 0 88px;
   line-height: 0;
 }
-.series-panel-thumb img {
+.panel-thumb img {
   width: 88px;
   height: auto;
   border-radius: 4px;
 }
-.series-panel-body {
+.panel-body {
   min-width: 0;
 }
-.series-panel-name {
+.panel-title {
   display: block;
   margin-bottom: 4px;
   color: #424242;
   font-size: 1.2em;
   font-weight: bold;
 }
-.series-panel-name:hover {
+.panel-title:hover {
   color: #424242;
   text-decoration: underline;
 }
-.series-panel-meta {
+.panel-meta {
   color: #777;
   font-size: 0.9em;
+}
+/* 反響のハートは日付の右に少し離して置く */
+.panel-meta .snscount {
+  margin-left: 8px;
 }
 
 /* ホーム冒頭のブログ説明 */

--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -38,12 +38,12 @@
         <% panels.forEach(function(s){ %>
         <div class="col-12 col-md-6">
           <div class="article-card series-panel h-100">
-            <a href="<%- url_for(s.index.path) %>" title="<%= s.name %>" class="img_wrap series-panel-thumb">
+            <a href="<%- url_for(s.index.path) %>" title="<%= s.name %>" class="img_wrap panel-thumb">
               <img src="<%= s.index.thumbnail %>" alt="" width="200" height="135" loading="lazy">
             </a>
-            <div class="series-panel-body">
-              <a href="<%- url_for(s.index.path) %>" class="series-panel-name"><%= s.name %></a>
-              <div class="series-panel-meta">全 <%= s.total %> 本・<%= date(s.latest, 'YYYY.MM.DD') %> 更新</div>
+            <div class="panel-body">
+              <a href="<%- url_for(s.index.path) %>" class="panel-title"><%= s.name %></a>
+              <div class="panel-meta">全 <%= s.total %> 本・<%= date(s.latest, 'YYYY.MM.DD') %> 更新</div>
             </div>
           </div>
         </div>

--- a/themes/future/layout/category-without.ejs
+++ b/themes/future/layout/category-without.ejs
@@ -24,6 +24,11 @@
       <li><span class="summary-count"><%= stats.recent %></span><br><span class="summary-label">直近1年の投稿</span></li>
       <li><span class="summary-count"><%= stats.recentAuthorCount %></span><br><span class="summary-label">直近1年の著者数</span></li>
     </ul>
+    <% const popular = popular_posts_in(page.withoutPosts.toArray()); %>
+    <% if (popular) { %>
+    <h2 class="bottom-content-header">よく読まれている記事</h2>
+    <%- popular %>
+    <% } %>
     <% if (stats.topTags.length) { %>
     <h2 class="bottom-content-header">よく使われるタグ</h2>
     <div class="blog-tags">
@@ -33,11 +38,6 @@
         <% }) %>
       </ul>
     </div>
-    <% } %>
-    <% const popular = popular_posts_in(page.withoutPosts.toArray()); %>
-    <% if (popular) { %>
-    <h2 class="bottom-content-header">よく読まれている記事</h2>
-    <%- popular %>
     <% } %>
     <% } %>
     <%# カテゴリページの「◯◯以外の記事を見る」と対になる位置。

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -30,6 +30,15 @@
     <% } else if (cs) { %>
     <p class="summary-note">直近1年間の投稿はありません</p>
     <% } %>
+    <%# そのカテゴリの中でよく読まれている記事。新着より前に置く。
+        絞り込んだ直後の読者がまず知りたいのは「定番はどれか」であって、
+        新しさは新着一覧が担う %>
+    <% const catAll = site.categories.findOne({name: page.category}); %>
+    <% const popular = catAll ? popular_posts_in(catAll.posts.toArray()) : ''; %>
+    <% if (popular) { %>
+    <h2 class="bottom-content-header">よく読まれている記事</h2>
+    <%- popular %>
+    <% } %>
     <% if (cs && cs.topTags.length) { %>
     <%# 一覧と同じ代表タグ。マークアップも /categories/ と揃える。
         カテゴリ名は h1 が名乗っているので見出しでは繰り返さない %>
@@ -41,15 +50,6 @@
         <% }) %>
       </ul>
     </div>
-    <% } %>
-    <%# そのカテゴリの中でよく読まれている記事。新着より前に置く。
-        絞り込んだ直後の読者がまず知りたいのは「定番はどれか」であって、
-        新しさは新着一覧が担う %>
-    <% const catAll = site.categories.findOne({name: page.category}); %>
-    <% const popular = catAll ? popular_posts_in(catAll.posts.toArray()) : ''; %>
-    <% if (popular) { %>
-    <h2 class="bottom-content-header">よく読まれている記事</h2>
-    <%- popular %>
     <% } %>
     <% } %>
     <% if (page.current !== 1) { %>


### PR DESCRIPTION
Closes #2105
Closes #2106

## #2105 順序

カテゴリページを **よく読まれている記事 → よく使われるタグ → 新着記事** の順にしました。タグページが既にこの順で、揃っていませんでした。

`/categories/Programming/without-go/` も同じ順に直しています。

## #2106 パネル化

```
よく読まれている記事
┌────────────────────────┐ ┌────────────────────────┐
│ 🖼 龍が如く7のすごいテストを… │ │ 🖼 署名付きURLを利用した…    │
│    2024.02.15 ♡430         │ │    2024.07.05 ♡215        │
└────────────────────────┘ └────────────────────────┘
┌────────────────────────┐ ┌────────────────────────┐
│ 🖼 なぜアーキチームは設計や…  │ │ 🖼 Goのテストをはじめて…     │
│    2025.11.07 ♡88          │ │    2025.05.09 ♡172        │
└────────────────────────┘ └────────────────────────┘
```

- **2列・4件**（テキスト時は5件でしたが、2列なので偶数に）
- 内容は **サムネイル・タイトル・日付・反響**
- マークアップはホームの「連載から探す」と**共通**

共通化にあたってクラス名を `series-panel-*` から `panel-*` に寄せました。連載カードと記事カードで同じ見た目を2箇所に書かずに済みます。

```diff
- .series-panel-thumb / .series-panel-name / .series-panel-meta
+ .panel-thumb / .panel-title / .panel-meta
```

## 適用範囲

カテゴリページ・タグページ・`without-go` ページの3種すべてで同じカードになります。

## 確認

差分ビルド（`_config.fast.yml`、17秒）で、3種のページのカードとホームの連載パネルが崩れていないことを確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)