### PR TITLE
よく読まれている記事に経過年数のペナルティをかける

### DIFF
--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -22,11 +22,18 @@ hexo.extend.helper.register("get_ga4_pv", url => {
 // 指定した記事の中から PV の多い順に取り出す。カテゴリ・タグの一覧ページで
 // 「よく読まれている記事」を出すのに使う（#2033 / #2034）
 hexo.extend.helper.register('popular_posts_in', function(posts, limit = 4) {
+  // PV は累積なので、古い記事ほど有利になる。経過年数で割って、
+  // 何年もかけて積んだ数字と最近読まれている数字を並べられるようにする。
+  // 分母を 1+年数 にしているのは、公開直後の記事で 0 除算にしないため
+  const YEAR = 365 * 24 * 60 * 60 * 1000;
+  const now = Date.now();
+  const score = post => getGA4PV('/' + post.path) / (1 + (now - post.date.valueOf()) / YEAR);
+
   const ranked = posts
-    .map(post => ({post, pv: getGA4PV('/' + post.path)}))
+    .map(post => ({post, pv: getGA4PV('/' + post.path), score: score(post)}))
     .filter(x => x.pv > 0)
     // 同点の決着が無いとビルドごとに並びが変わる
-    .sort((a, b) => b.pv - a.pv || (a.post.path < b.post.path ? -1 : 1))
+    .sort((a, b) => b.score - a.score || (a.post.path < b.post.path ? -1 : 1))
     .slice(0, limit);
 
   if (ranked.length === 0) return '';


### PR DESCRIPTION
GA4 の PV は**累積**なので、何年も前のバズった記事が並び続けていました。

```js
score = PV / (1 + 経過年数)
```

分母を `1 + 年数` にしているのは、公開直後の記事で 0 除算にしないためです。

## 効果（Programming カテゴリ）

| | before | after |
| --- | --- | --- |
| 1 | AWS利用時に read: connection reset by（4.8年・65,300PV） | 龍が如く7のすごいテスト（2.4年） |
| 2 | OpenAPIにおけるundefinedとnullの設計（4.8年） | なぜアーキチームは設計や実装のパターンを絞りたいか（0.7年） |
| 3 | 龍が如く7のすごいテスト（2.4年） | 署名付きURLを利用した…（2.0年） |
| 4 | プログラマーのためのCPU入門（3.4年） | 非同期設計ガイドラインを公開しました（0.5年） |

累積が本当に突出した記事は残りつつ、直近1〜2年の記事が入るようになります。

減衰の強さは `pv / (1+年数)^0.7` も試しましたが、効きが弱く4.8年の記事が2枠を占めたままでした。`^1.0` を採っています。

## 適用範囲

カテゴリ・タグ・`without-go` の「よく読まれている記事」です。ホームのランキング（`popular_posts`）は元から新しい記事に係数をかけているので、こちらは変更していません。

## 確認

差分ビルド（`_config.fast.yml`）で、カテゴリとタグの並びが入れ替わることを確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)