### PR TITLE
TLS 証明書検証を無効化する環境変数の設定をやめる

### DIFF
--- a/scripts/techcast_latest.js
+++ b/scripts/techcast_latest.js
@@ -6,9 +6,6 @@ const RssParser = require("rss-parser");
 
 let feedItems = [];
 
-// プロキシ対応
-process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
-
 (async () => {
   const rssParser = new RssParser();
 


### PR DESCRIPTION
## 概要

Fixes #2102

Hexo 起動時の `NODE_TLS_REJECT_UNAUTHORIZED` 警告を解消しました。

## 原因と対応

`scripts/techcast_latest.js` が「プロキシ対応」として `process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0` を設定しており、**hexo プロセス全体**の TLS 証明書検証が無効になっていました。警告は Node の正当な指摘です。

この設定を削除しました（Issue コメントの案1）。

- CI（GitHub Actions）のビルドにプロキシは無く、通常の証明書検証で TechCast RSS（anchor.fm）の取得が成功することを確認済み
- 万一取得に失敗しても `catch` でエラーログを出すだけでビルドは壊れません（Tech Cast セクションが出ないだけ）
- 社内プロキシ配下のローカルビルドで RSS 取得が失敗するようになった場合は、`HttpsProxyAgent` 側に `rejectUnauthorized: false` を渡すスコープ限定の形で復活させてください（プロセス全体には効かせない）

## 動作確認

- `hexo s` の起動ログから警告が消えたこと
- ホーム1ページ目の Tech Cast セクションが描画されること（RSS 取得成功）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
