### PR TITLE
サイドバーをパンくずの下から始める

### DIFF
--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -1,116 +1,109 @@
-<div class="row">
-  <main class="col-xs-12 col-sm-12 col-md-10 blog-posts">
-  <%# ホームの1ページ目だけ、ランキングを記事リストより前に出す。
-      ホームに来る読者は「どんな記事があるか」をざっと掴みたいのであって、
-      公開順の先頭から読みたいわけではない %>
-  <% const isHome = is_home(); %>
-  <% const isHomeFirst = isHome && page.current === 1; %>
-  <% if (isHomeFirst) { %>
-    <section class="popular-articles home-ranking">
-        <h2 id="popular" class="bottom-content-header"><a href="#popular" class="headerlink" title="よく読まれている記事"></a>よく読まれている記事</h2>
-        <div class="margin-bottom-20 nav tabs">
-          <input id="monthly" type="radio" name="tab_item" checked>
-          <label tabindex="0" class="tab_item" for="monthly">トレンド</label>
-          <input id="yearly" type="radio" name="tab_item">
-          <label tabindex="0" class="tab_item" for="yearly">年間人気</label>
-          <input id="sns" type="radio" name="tab_item">
-          <label tabindex="0" class="tab_item" for="sns">SNS人気</label>
-          <div class="tab_content" id="popular_monthly">
-            <%- popular_posts('monthly') %>
-          </div>
-          <div class="tab_content" id="popular_yearly">
-            <%- popular_posts('yearly') %>
-          </div>
-          <div class="tab_content" id="popular_sns">
-            <%- sns_popular_posts() %>
+<%# ホームの1ページ目だけ、ランキングを記事リストより前に出す。
+    ホームに来る読者は「どんな記事があるか」をざっと掴みたいのであって、
+    公開順の先頭から読みたいわけではない %>
+<% const isHome = is_home(); %>
+<% const isHomeFirst = isHome && page.current === 1; %>
+<% if (isHomeFirst) { %>
+  <section class="popular-articles home-ranking">
+      <h2 id="popular" class="bottom-content-header"><a href="#popular" class="headerlink" title="よく読まれている記事"></a>よく読まれている記事</h2>
+      <div class="margin-bottom-20 nav tabs">
+        <input id="monthly" type="radio" name="tab_item" checked>
+        <label tabindex="0" class="tab_item" for="monthly">トレンド</label>
+        <input id="yearly" type="radio" name="tab_item">
+        <label tabindex="0" class="tab_item" for="yearly">年間人気</label>
+        <input id="sns" type="radio" name="tab_item">
+        <label tabindex="0" class="tab_item" for="sns">SNS人気</label>
+        <div class="tab_content" id="popular_monthly">
+          <%- popular_posts('monthly') %>
+        </div>
+        <div class="tab_content" id="popular_yearly">
+          <%- popular_posts('yearly') %>
+        </div>
+        <div class="tab_content" id="popular_sns">
+          <%- sns_popular_posts() %>
+        </div>
+      </div>
+  </section>
+<% } %>
+<%# はじめて来た読者は記事の探し方が分からない。ランキングと新着の間に
+    「連載」と「タグ」という2つの入口を置く (#2039) %>
+<% if (isHomeFirst) { %>
+<% const panels = recent_series(4); %>
+<% if (panels.length) { %>
+  <section class="series-panels">
+    <h2 id="series" class="bottom-content-header"><a href="#series" class="headerlink" title="連載から探す"></a>連載から探す</h2>
+    <div class="row g-4">
+      <% panels.forEach(function(s){ %>
+      <div class="col-12 col-md-6">
+        <div class="article-card series-panel h-100">
+          <a href="<%- url_for(s.index.path) %>" title="<%= s.name %>" class="img_wrap panel-thumb">
+            <img src="<%= s.index.thumbnail %>" alt="" width="200" height="135" loading="lazy">
+          </a>
+          <div class="panel-body">
+            <a href="<%- url_for(s.index.path) %>" class="panel-title"><%= s.name %></a>
+            <div class="panel-meta">全 <%= s.total %> 本・<%= date(s.latest, 'YYYY.MM.DD') %> 更新</div>
           </div>
         </div>
-    </section>
-  <% } %>
-  <%# はじめて来た読者は記事の探し方が分からない。ランキングと新着の間に
-      「連載」と「タグ」という2つの入口を置く (#2039) %>
-  <% if (isHomeFirst) { %>
-  <% const panels = recent_series(4); %>
-  <% if (panels.length) { %>
-    <section class="series-panels">
-      <h2 id="series" class="bottom-content-header"><a href="#series" class="headerlink" title="連載から探す"></a>連載から探す</h2>
-      <div class="row g-4">
-        <% panels.forEach(function(s){ %>
-        <div class="col-12 col-md-6">
-          <div class="article-card series-panel h-100">
-            <a href="<%- url_for(s.index.path) %>" title="<%= s.name %>" class="img_wrap panel-thumb">
-              <img src="<%= s.index.thumbnail %>" alt="" width="200" height="135" loading="lazy">
-            </a>
-            <div class="panel-body">
-              <a href="<%- url_for(s.index.path) %>" class="panel-title"><%= s.name %></a>
-              <div class="panel-meta">全 <%= s.total %> 本・<%= date(s.latest, 'YYYY.MM.DD') %> 更新</div>
-            </div>
-          </div>
-        </div>
-        <% }) %>
       </div>
-    </section>
-  <% } %>
-    <section class="popular-articles">
-      <div class="blog-tags margin-bottom-20">
-        <%# 実体は list_toppagetags のシェア数順・件数上限ありのリストなので
-            「人気のタグ」。/tags/ の同名セクションと表記を揃える (#2052) %>
-        <h2 id="searchbytag" class="bottom-content-header"><a href="#searchbytag" class="headerlink" title="人気のタグから記事を探す"></a>人気のタグから記事を探す</h2>
-        <%- partial('../_widget/tag.ejs') %>
-      </div>
-    </section>
-  <% } %>
-  <%# 関連タグは1ページ目だけ一覧の前に出す。カテゴリページの
-      「よく使われるタグ」と同じ位置で、絞り込み直しの導線は一覧を
-      読み始める前にある方が働く (#2088)。2ページ目以降は下（ページャーの後）。
-      ホームの全タグ一覧と両方を置くと読者がどちらを見ればよいか迷うため、
-      タグページはこちらだけ（文脈あり・数個 ＞ 文脈なし・714件） %>
-  <% if (is_tag() && page.current === 1) { %>
+      <% }) %>
+    </div>
+  </section>
+<% } %>
+  <section class="popular-articles">
+    <div class="blog-tags margin-bottom-20">
+      <%# 実体は list_toppagetags のシェア数順・件数上限ありのリストなので
+          「人気のタグ」。/tags/ の同名セクションと表記を揃える (#2052) %>
+      <h2 id="searchbytag" class="bottom-content-header"><a href="#searchbytag" class="headerlink" title="人気のタグから記事を探す"></a>人気のタグから記事を探す</h2>
+      <%- partial('../_widget/tag.ejs') %>
+    </div>
+  </section>
+<% } %>
+<%# 関連タグは1ページ目だけ一覧の前に出す。カテゴリページの
+    「よく使われるタグ」と同じ位置で、絞り込み直しの導線は一覧を
+    読み始める前にある方が働く (#2088)。2ページ目以降は下（ページャーの後）。
+    ホームの全タグ一覧と両方を置くと読者がどちらを見ればよいか迷うため、
+    タグページはこちらだけ（文脈あり・数個 ＞ 文脈なし・714件） %>
+<% if (is_tag() && page.current === 1) { %>
+<%- partial('related-tags') %>
+<% } %>
+<% if (pagination == 2){ %>
+  <% page.posts.each(function(post){ %>
+    <%- partial('article', {post: post, index: true}) %>
+  <% }) %>
+<% } else { %>
+  <section class="archives-wrap">
+    <%# ホームだけ見出しを出す。タグ／カテゴリ／著者ページは
+        パンくずと h1 が既に「何の一覧か」を示しているため不要。
+        1ページ目は新着そのものだが、2ページ目以降は全記事を繰っている
+        途中なので「新着記事」だと実態とずれる %>
+    <%# 呼び出し側は list_heading で見出しを渡せる（カテゴリページ等）。
+        archives-wrap の margin-top の内側に置かないと、呼び出し側の h2 と
+        間隔を二重取りして見出しとリストが離れる %>
+    <% const listHeading = (typeof list_heading !== 'undefined' && list_heading) ? list_heading : (isHome ? (page.current === 1 ? '新着記事' : '記事一覧') : null); %>
+    <% if (listHeading) { %>
+    <h2 id="posts" class="bottom-content-header"><a href="#posts" class="headerlink" title="記事一覧"></a><%= listHeading %></h2>
+    <% } %>
+    <%# 見出しとリストの間に置きたい補足を呼び出し側から差し込む %>
+    <% if (typeof list_note !== 'undefined' && list_note) { %>
+    <%- list_note %>
+    <% } %>
+    <div class="archives">
+      <% page.posts.each(function(post, i){ %>
+      <%- partial('archive-post', {post: post, even: i % 2 == 0, index: true}) %>
+      <% }) %>
+    </div>
+    <% if (page.posts.length){ %>
+    <div id="page-nav" class="pagination">
+      <%# 連載ナビの「前の記事／次の記事」と同じ対象明示型の日本語にする (#2095) %>
+      <%- paginator({prev_text:'前のページ', next_text:'次のページ', mid_size:3, end_size:2, show_all:false}) %>
+    </div>
+    <% } %>
+  </section>
+<% } %>
+
+
+  <%# 2ページ目以降は、ページを繰って読み尽くしかけた読者への
+      次の導線としてページャーの下に関連タグを出す %>
+  <% if (is_tag() && page.current !== 1) { %>
   <%- partial('related-tags') %>
   <% } %>
-  <% if (pagination == 2){ %>
-    <% page.posts.each(function(post){ %>
-      <%- partial('article', {post: post, index: true}) %>
-    <% }) %>
-  <% } else { %>
-    <section class="archives-wrap">
-      <%# ホームだけ見出しを出す。タグ／カテゴリ／著者ページは
-          パンくずと h1 が既に「何の一覧か」を示しているため不要。
-          1ページ目は新着そのものだが、2ページ目以降は全記事を繰っている
-          途中なので「新着記事」だと実態とずれる %>
-      <%# 呼び出し側は list_heading で見出しを渡せる（カテゴリページ等）。
-          archives-wrap の margin-top の内側に置かないと、呼び出し側の h2 と
-          間隔を二重取りして見出しとリストが離れる %>
-      <% const listHeading = (typeof list_heading !== 'undefined' && list_heading) ? list_heading : (isHome ? (page.current === 1 ? '新着記事' : '記事一覧') : null); %>
-      <% if (listHeading) { %>
-      <h2 id="posts" class="bottom-content-header"><a href="#posts" class="headerlink" title="記事一覧"></a><%= listHeading %></h2>
-      <% } %>
-      <%# 見出しとリストの間に置きたい補足を呼び出し側から差し込む %>
-      <% if (typeof list_note !== 'undefined' && list_note) { %>
-      <%- list_note %>
-      <% } %>
-      <div class="archives">
-        <% page.posts.each(function(post, i){ %>
-        <%- partial('archive-post', {post: post, even: i % 2 == 0, index: true}) %>
-        <% }) %>
-      </div>
-      <% if (page.posts.length){ %>
-      <div id="page-nav" class="pagination">
-        <%# 連載ナビの「前の記事／次の記事」と同じ対象明示型の日本語にする (#2095) %>
-        <%- paginator({prev_text:'前のページ', next_text:'次のページ', mid_size:3, end_size:2, show_all:false}) %>
-      </div>
-      <% } %>
-    </section>
-  <% } %>
-
-
-    <%# 2ページ目以降は、ページを繰って読み尽くしかけた読者への
-        次の導線としてページャーの下に関連タグを出す %>
-    <% if (is_tag() && page.current !== 1) { %>
-    <%- partial('related-tags') %>
-    <% } %>
-  </main>
-  <aside class="col-xs-12 col-sm-12 col-md-2 blog-sidebar">
-    <%- partial('sidebar') %>
-  </aside>
-</div>

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -4,6 +4,8 @@
         {label: '著者', url: '/authors/'},
         {label: page.author, url: page.current === 1 ? null : (page.base || '/authors/' + page.author)}
       ].concat(page.current === 1 ? [] : [{label: page.current + 'ページ目'}])}) %>
+  <div class="row">
+    <main class="col-xs-12 col-sm-12 col-md-10 blog-posts">
   <section id="main" class="margin-top-30">
     <h1 class="list-page"><%- page.author %><span class="list-sub-text">さんのページ</span></h1>
     <% if (page.current === 1) { %>
@@ -94,4 +96,9 @@
     <%# 見出しの語彙はホーム・カテゴリ・タグページに合わせる %>
     <%- partial('_partial/archive', {pagination: config.author, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧'}) %>
   </section>
+    </main>
+    <aside class="col-xs-12 col-sm-12 col-md-2 blog-sidebar">
+      <%- partial('_partial/sidebar') %>
+    </aside>
+  </div>
 </div>

--- a/themes/future/layout/category-without.ejs
+++ b/themes/future/layout/category-without.ejs
@@ -5,6 +5,8 @@
         {label: page.category, url: '/categories/' + page.category + '/'},
         {label: page.excludedTag + ' 以外', url: page.current === 1 ? null : page.withoutPath}
       ].concat(page.current === 1 ? [] : [{label: page.current + 'ページ目'}])}) %>
+  <div class="row">
+    <main class="col-xs-12 col-sm-12 col-md-10 blog-posts">
   <section id="main" class="margin-top-30">
     <h1 class="list-page"><%- page.category %> <span class="list-sub-text">カテゴリの <%- page.excludedTag %> 以外の記事</span></h1>
     <%# 構成はカテゴリページと同じ。統計・タグ・ランキングは絞り込んだ後の集合で数える %>
@@ -50,4 +52,9 @@
          + `</p>`; %>
     <%- partial('_partial/archive', {pagination: config.category, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧', list_note: backLink}) %>
   </section>
+    </main>
+    <aside class="col-xs-12 col-sm-12 col-md-2 blog-sidebar">
+      <%- partial('_partial/sidebar') %>
+    </aside>
+  </div>
 </div>

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -7,6 +7,8 @@
         {label: 'カテゴリ', url: '/categories/'},
         {label: page.category, url: page.current === 1 ? null : (page.base || '/categories/' + page.category)}
       ].concat(page.current === 1 ? [] : [{label: page.current + 'ページ目'}])}) %>
+  <div class="row">
+    <main class="col-xs-12 col-sm-12 col-md-10 blog-posts">
   <section id="main" class="margin-top-30">
     <h1 class="list-page"><%- page.category %> <span class="list-sub-text">カテゴリ</span></h1>
     <% if (page.current === 1) { %>
@@ -72,4 +74,9 @@
     <%- partial('_partial/archive', {pagination: config.category, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧', list_note: withoutLink}) %>
 
   </section>
+    </main>
+    <aside class="col-xs-12 col-sm-12 col-md-2 blog-sidebar">
+      <%- partial('_partial/sidebar') %>
+    </aside>
+  </div>
 </div>

--- a/themes/future/layout/index.ejs
+++ b/themes/future/layout/index.ejs
@@ -6,6 +6,8 @@
     <%- partial('_partial/breadcrumb', {items: [
           {label: 'ホーム', url: page.current === 1 ? null : '/'}
         ].concat(page.current === 1 ? [] : [{label: page.current + 'ページ目'}])}) %>
+    <div class="row">
+      <main class="col-xs-12 col-sm-12 col-md-10 blog-posts">
     <%# ホームにブログの説明が無く、初めて来た読者に何のサイトか伝わらなかった。
         文面はフッターの About Us と同じ theme.about を使い、二重に持たない %>
     <% if (page.current === 1) { %>
@@ -30,6 +32,11 @@
         数字として破綻している（カウントAPI廃止前後の値が固定されたまま）。
         購読導線として意味のある Feedly だけ、性質の近いフッターの Links へ移した %>
     <%- partial('_partial/archive', {pagination: config.archive}) %>
+      </main>
+      <aside class="col-xs-12 col-sm-12 col-md-2 blog-sidebar">
+        <%- partial('_partial/sidebar') %>
+      </aside>
+    </div>
   </div>
 <% } %>
 

--- a/themes/future/layout/tag.ejs
+++ b/themes/future/layout/tag.ejs
@@ -4,6 +4,8 @@
         {label: 'タグ', url: '/tags/'},
         {label: page.tag, url: page.current === 1 ? null : (page.base || '/tags/' + page.tag)}
       ].concat(page.current === 1 ? [] : [{label: page.current + 'ページ目'}])}) %>
+  <div class="row">
+    <main class="col-xs-12 col-sm-12 col-md-10 blog-posts">
   <section id="main" class="margin-top-30">
     <h1 class="list-page"><%- page.tag %> <span class="list-sub-text">タグ</span></h1>
     <% if (page.current === 1) { %>
@@ -50,5 +52,10 @@
     <%# 見出しの語彙はホーム・カテゴリページに合わせる %>
     <%- partial('_partial/archive', {pagination: config.tag, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧'}) %>
   </section>
+    </main>
+    <aside class="col-xs-12 col-sm-12 col-md-2 blog-sidebar">
+      <%- partial('_partial/sidebar') %>
+    </aside>
+  </div>
 </div>
 


### PR DESCRIPTION
意図的ではなく、構造の副作用でした。

`_partial/archive.ejs` が2カラムの `row` と `aside` を持っていたため、**それより前にある h1・統計・パネルが2カラムの外**に出ていました。結果としてサイドバーが「新着記事」の高さから始まっていました。

```
before                          after
─────────────────               ─────────────────
パンくず                          パンくず
h1                              ┌──────────┬───┐
統計タイル                        │ h1        │ サ │
よく読まれている記事               │ 統計タイル  │ イ │
よく使われるタグ                   │ よく読まれ… │ ド │
┌──────────┬───┐              │ よく使われ… │ バ │
│ 新着記事    │ サ │              │ 新着記事    │ ー │
│ 記事一覧    │ イ │              │ 記事一覧    │   │
└──────────┴───┘              └──────────┴───┘
```

## 直し方

`row` / `main` / `aside` を `_partial/archive.ejs` から呼び出し側へ移しました。対象は5レイアウトです。

| レイアウト | |
| --- | --- |
| `index.ejs` | ホーム |
| `category.ejs` | カテゴリ |
| `tag.ejs` | タグ |
| `author.ejs` | 著者 |
| `category-without.ejs` | `without-go` |

年・月アーカイブは `_partial/archive-all` を使っていて元からサイドバーが無いので、対象外です。

## 確認

差分ビルド（`_config.fast.yml`）で、

- **全1139ページのサイドバーの有無が変化なし**（before / after を機械的に照合）。増えても減ってもいません
- 4種のページで `パンくず → row → 新着記事 → sidebar` の順になり、h1 が `row` の内側に入ったこと

を確認しました。サイドバーを持たない40ページ（各索引ページと年・月アーカイブ）も、元から持っていなかったものです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)