### PR TITLE
アーカイブページの統計を1行に集約し、見出しと細部を揃える

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1108,36 +1108,45 @@ code {
   margin: 10px 0 20px;
 }
 /* 年ごとのカード。以前は幅100pxの素のテキストが並ぶだけで、
-   リンクなのか見分けが付かなかった */
+   リンクなのか見分けが付かなかった。
+   枠は li が持つ。hexo の list_archives は件数の span をリンクの外に
+   出すため、a に枠を付けると件数だけカードの外にはみ出して
+   「(94)」が何の数か分からなくなる (#2114) */
 .archive-list-item {
-  padding: 0;
+  position: relative;
+  padding: 8px 16px;
   margin: 0 12px 12px 0;
-}
-.archive-list-item a {
-  display: inline-block;
-  padding: 10px 16px;
   border: 1px solid #eee;
   border-radius: card-radius;
+  text-align: center;
+}
+.archive-list-item a {
   color: #424242;
   text-decoration: none;
   font-size: 1.2em;
   font-weight: bold;
 }
+/* 件数までカードに含めた分、リンクの当たりもカード全体に広げる */
+.archive-list-item a:after {
+  content: '';
+  position: absolute;
+  inset: 0;
+}
 /* 素のテキストリスト時代の margin-left: 8px がカード化後も残っていて、
    ホバーのたびにカードが右へ飛んでいた。位置は動かさず面の色だけで応える */
-.archive-list-item a:hover,
-.archive-list-item a:focus {
+.archive-list-item:hover,
+.archive-list-item:focus-within {
   background-color: #eee;
   border-color: #ddd;
 }
+/* 年の下の段に「94件」。カッコ書きだと何の数か分からない */
 .archive-list-count {
-  padding-left: 6px;
-}
-.archive-list-count:before {
-  content: "(";
+  display: block;
+  color: #6e6e6e;
+  font-size: 0.85em;
 }
 .archive-list-count:after {
-  content: ")";
+  content: "件";
 }
 .archive-list-current {
   font-weight: bold;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1123,16 +1123,12 @@ code {
   font-size: 1.2em;
   font-weight: bold;
 }
-.archive-list-item a:hover {
-  background: #f5f5f3;
-}
+/* 素のテキストリスト時代の margin-left: 8px がカード化後も残っていて、
+   ホバーのたびにカードが右へ飛んでいた。位置は動かさず面の色だけで応える */
 .archive-list-item a:hover,
 .archive-list-item a:focus {
-  margin-left:8px;
-  color: #424242;
   background-color: #eee;
   border-color: #ddd;
-  z-index: 3;
 }
 .archive-list-count {
   padding-left: 6px;

--- a/themes/future/layout/_partial/archive-all.ejs
+++ b/themes/future/layout/_partial/archive-all.ejs
@@ -1,6 +1,7 @@
 <div class="row">
   <main class="blog-posts">
-      <ul class="article-list">
+      <%# アーカイブページの最後の要素なので footer-gap でフッター前の間隔を持つ %>
+      <ul class="article-list footer-gap">
         <% page.posts.each(function(post, i){ %>
         <li>
           <span class="date"><%= date(post.date, 'YYYY.MM.DD') %></span>
@@ -9,6 +10,5 @@
         </li>
       <% }) %>
     </ul>
-  </section>
   </main>
 </div>

--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -18,22 +18,24 @@
   <%- partial('_partial/breadcrumb', {items: items}) %>
   <div id="main" class="margin-top-30">
     <% if(is_month()) { %>
-    <h1 class="list-page"><%= page.year%>年<%= page.month %>月のすべての記事 <%= count_articles_month(page.year, page.month) %>件</h1>
+    <h1 class="list-page"><%= page.year%>年<%= page.month %>月<span class="list-sub-text">のすべての記事</span></h1>
+    <ul class="summary">
+      <li><span class="summary-count"><%= count_articles_month(page.year, page.month) %></span><br><span class="summary-label">投稿</span></li>
+    </ul>
     <% } else if(is_year()) { %>
     <h1 class="list-page"><%= page.year%><span class="list-sub-text"> 年のすべての記事</span></h1>
+    <%# 統計は1行に集約。シェアの内訳を一段小さくするのは他ページと同じ (#2096) %>
     <ul class="summary">
       <% const summary = summary_yearly_term(page.year); %>
       <li><span class="summary-count"><%= count_articles_year(page.year) %></span><br><span class="summary-label">投稿</span></li>
+      <li><span class="summary-count"><%= ave_posts(page.year) %></span><br><span class="summary-label">平均投稿/月</span></li>
       <li><span class="summary-count"><%= summary.total %></span><br><span class="summary-label">総シェア数</span></li>
-      <li><span class="summary-count"><%= summary.twitter %></span><br><span class="summary-label">Twitter</span></li>
-      <li><span class="summary-count"><%= summary.facebook %></span><br><span class="summary-label">Facebook</span></li>
-      <li><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
-      <li><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.twitter %></span><br><span class="summary-label">X</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.facebook %></span><br><span class="summary-label">Facebook</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
     </ul>
-    <ul class="summary">
-      <li><span class="summary-count">平均<%= ave_posts(page.year) %></span><br><span class="summary-label">投稿/月</span></li>
-    </ul>
-    <h2 class="bottom-content-header">投稿数の推移</h2>
+    <h2 class="bottom-content-header">月別 投稿数の推移</h2>
     <div>
       <div id="chart" style="width:100%;min-height:250px"></div>
       <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
@@ -68,14 +70,16 @@
     </div>
     <% } else { %>
     <h1 class="list-page">すべての記事</h1>
+    <%# 統計は1行に集約。シェアの内訳を一段小さくするのは他ページと同じ (#2096) %>
     <ul class="summary">
       <% const summary = summary_all_term(); %>
       <li><span class="summary-count"><%= count_articles() %></span><br><span class="summary-label">投稿</span></li>
+      <li><span class="summary-count"><%= ave_posts(page.year) %></span><br><span class="summary-label">平均投稿/四半期</span></li>
       <li><span class="summary-count"><%= summary.total %></span><br><span class="summary-label">総シェア数</span></li>
-      <li><span class="summary-count"><%= summary.twitter %></span><br><span class="summary-label">Twitter</span></li>
-      <li><span class="summary-count"><%= summary.facebook %></span><br><span class="summary-label">Facebook</span></li>
-      <li><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
-      <li><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.twitter %></span><br><span class="summary-label">X</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.facebook %></span><br><span class="summary-label">Facebook</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
     </ul>
 
     <h2 class="bottom-content-header">年から探す</h2>
@@ -90,7 +94,7 @@
     %>
     <%- list_archives({format: "YYYY", type:"yearly", transform:trans}) %>
 
-    <h2 class="bottom-content-header">投稿数の推移</h2>
+    <h2 class="bottom-content-header">四半期別 投稿数の推移</h2>
     <div>
       <div id="chart" style="width:100%;min-height:250px"></div>
       <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
@@ -125,6 +129,9 @@
     </div>
 
     <% } %>
+    <%# 見出しの語彙は他の一覧ページに合わせる。ここは全記事の時系列リストなので
+        「新着記事」ではなく常に「記事一覧」 %>
+    <h2 class="bottom-content-header">記事一覧</h2>
     <%- partial('_partial/archive-all', {pagination: config.archive}) %>
   </div>
 </div>


### PR DESCRIPTION
## 概要

Fixes #2114

main に入った #2117（棒グラフ化・「年から探す」・カード型の年リンク）とコンフリクトしたため、**#2117 を土台に作り直しました**。重複していた「グラフ左詰め」「グラフをリストの前へ」「年リンクのパネル化」は #2117 の実装をそのまま採用し、この PR は残っていた不整合だけを揃えます。

構成（/articles/）: h1 → 統計（1行）→ h2 年から探す → 年カード → h2 四半期別 投稿数の推移 → 棒グラフ → h2 記事一覧 → リスト

## 対応内容

1. **統計を h1 直下の1行に集約**: 別行だった「平均投稿」をタイル化して同じ行へ。シェア内訳（X・Facebook・はてブ・Pocket）の縮小タイル化と Twitter → X 表記（#2096）をこのページにも適用
2. **グラフ見出しの粒度**: 「投稿数の推移」→「月別 投稿数の推移」（年ページ）／「四半期別 投稿数の推移」（全期間）
3. **h2「記事一覧」**: 記事リストに他ページと整合する見出しを追加（時系列の全リストなので「新着記事」とは名乗らず常に「記事一覧」）
4. **月別ページ**: h1 に埋まっていた件数を統計タイルへ
5. **年カードのホバーバグ修正**: 旧テキストリスト時代の `margin-left: 8px` が残っていて、ホバーのたびにカードが右へ飛んでいた。位置は動かさず面の色だけで応える形に
6. **archive-all の掃除**: 対応する開始タグの無い `</section>`（不正HTML）を削除し、ページ最終要素のリストに `footer-gap`（#2076 のフッター前 56px）を付与

## 動作確認

- /articles/（統計1行 → 年カード → 四半期グラフ → 記事一覧）
- /articles/2026/（統計1行 → 月別グラフ → 記事一覧）
- /articles/2026/08/（h1 + 投稿タイル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
