### PR TITLE
タグクラウドの文字色をタグチップに揃える

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1288,6 +1288,13 @@ code {
   /* 間隔は右と下に取る。左に取ると折り返した行頭にも効いて字下げに見える。
      クラウドは密度が持ち味なので、チップの一覧より狭めにする */
   margin: 0 8px 4px 0;
+  /* タグチップ（.tag-list-link）と同じ色。リンク既定の青のままだと
+     同じページのタグ表示の中で色が割れる (#2126) */
+  color: #616161;
+}
+.tag-cloud a:hover,
+.tag-cloud a:focus {
+  color: #424242;
 }
 /* metronic の `.featured-post, .related-post { padding: 20px 0 0 10px }` により
    関連記事のカードだけ上と左に余白が付き、参照記事のカードとずれていた。


### PR DESCRIPTION
## 概要

Fixes #2126

/tags/ のタグクラウドがリンク既定の青のままで、同じページのタグチップ（`.tag-list-link` の `#616161`）と色が割れていました。

## 対応

- `.tag-cloud a` にチップと同じ `#616161` を指定
- ホバー・フォーカス時は一段濃い `#424242` で応答

サイズの大小（記事数のエンコーディング）は従来どおりです。

## 動作確認

- 生成された site.css で `.tag-cloud a { color: #616161 }` の出力を確認
- /tags/ のクラウドがチップと同系色になることをブラウザで確認してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)