### PR TITLE
トップページの人気のタグを10件に絞る

### DIFF
--- a/themes/future/_config.yml
+++ b/themes/future/_config.yml
@@ -8,9 +8,10 @@ featured_count: 10
 
 # 一覧画面のタグ表示
 # min: 表示対象とするタグの最低記事数
-# max: SNSリアクション合計の多い順に絞り込む表示上限（スクロール量を抑えるため3行程度に収める）
+# max: SNSリアクション合計の多い順に絞り込む表示上限。
+#      同じページの「よく読まれている記事」（10件）と数を揃える (#2127)
 tag_display_min_count: 15
-tag_display_max_count: 25
+tag_display_max_count: 10
 
 # Integrations(GA4 プロパティ)
 google_analytics: G-X1C28R8H0M


### PR DESCRIPTION
## 概要

Fixes #2127

ホームの「人気のタグから記事を探す」の表示上限を 25 → 10 件にし、同じページの「よく読まれている記事」（10件）と数を揃えました。

変更は `themes/future/_config.yml` の `tag_display_max_count` の1箇所です（コメントに理由を追記）。/tags/ の「人気のタグ」（30件・`ranking_tags`）は別の仕組みのため影響ありません。

## 動作確認

- ホームの該当セクションのチップが10個になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)