### PR TITLE
折り返し時の左端を揃え、トップの人気タグを10件にする

### DIFF
--- a/themes/future/_config.yml
+++ b/themes/future/_config.yml
@@ -10,7 +10,7 @@ featured_count: 10
 # min: 表示対象とするタグの最低記事数
 # max: SNSリアクション合計の多い順に絞り込む表示上限（スクロール量を抑えるため3行程度に収める）
 tag_display_min_count: 15
-tag_display_max_count: 25
+tag_display_max_count: 10
 
 # Integrations(GA4 プロパティ)
 google_analytics: G-X1C28R8H0M

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -198,13 +198,6 @@ a:focus .img_wrap img {
 .social-area {
 	padding: 1.5em 0;
 }
-/* ul.social-button の padding-left: 16px のぶん、親が左余白を持たない場所では
-   本文やコンテナの左端からずれて見える。該当する2箇所で打ち消す。
-   記事一覧の各記事に付くボタン（.archive-social-button）は親カラムの
-   余白があるため対象外 */
-.social-area ul.social-button {
-  padding-left: 0;
-}
 
 .img-frame-line {
   border: 1px solid #ddd;
@@ -449,17 +442,20 @@ h2 {
 /******************************
  ソーシャルボタン
 ******************************/
+/* 間隔は gap で持つ。padding-left と li の margin で作ると、
+   折り返した行の先頭に余白が残って左端が揃わない */
 ul.social-button {
   border: none;
   display: flex;
   flex-wrap: wrap;
+  gap: 8px 16px;
   list-style-type: none;
-  padding: 8px 0px 4px 16px;
+  padding: 8px 0 4px;
   width: auto;
 }
 ul.social-button li {
   height: 21px;
-  margin: 0.5em 1em 0 0em;
+  margin: 0;
 }
 ul.social-button li a {
 	width: 100%;
@@ -923,6 +919,22 @@ code {
 }
 .blog-tags li {
   display: inline-block;
+}
+/* 記事メタ行のタグ。間隔は親の gap で持つ */
+.blog-info-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 6px;
+}
+.blog-info-tags .tag-list-link {
+  margin: 0;
+}
+/* 狭い画面ではタグが折り返しやすい。日付や著者の後ろから続けると
+   2行目がその位置から始まって左端が揃わないので、行ごと分ける */
+@media (max-width: 767px) {
+  .blog-info-tags {
+    flex-basis: 100%;
+  }
 }
 .tag-list-link {
   color: #616161;

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -10,7 +10,7 @@
           <ul class="blog-info">
             <li class="blog-info-item"><%- partial('post/date', {class_name: 'archive-article-date', date_format: 'YYYY.MM.DD'}) %></li>
             <%- post_author_link(post) %>
-            <li class="blog-info-item"><%- partial('post/tag') %></li>
+            <li class="blog-info-item blog-info-tags"><%- partial('post/tag') %></li>
             <%# 更新タイミングを title で補足する。集計値が無い記事（公開直後など）は項目ごと出さない %>
             <% const pv = get_ga4_pv(post.path); %>
             <% if (pv) { %>


### PR DESCRIPTION
Closes #2125
Closes #2127

## #2125 折り返し時の左詰め

どちらも **間隔を `padding-left` と `margin` で作っていた**のが原因でした。#2086 の統計タイルと同じ性質です。

### ソーシャルボタン

```diff
  ul.social-button {
-   padding: 8px 0px 4px 16px;
+   gap: 8px 16px;
+   padding: 8px 0 4px;
  }
  ul.social-button li {
-   margin: 0.5em 1em 0 0em;
+   margin: 0;
  }
```

`padding-left: 16px` を消したので、記事ページ側でそれを打ち消していた指定も不要になりました（1ルール削除）。

### 記事メタ行のタグ

タグは `日付 → 著者 → タグ → PV → 文字数` の途中から始まるので、折り返すと**2行目がタグの開始位置から始まって**いました。

```
2026.08.04   武田大輝   Go言語  Go1.27
                        UUID  Terraform   ← ここが揃わない
```

狭い画面（767px 以下）ではタグを**行ごと分け**て、コンテナの左端から始まるようにしました。チップの間隔も `margin` から `gap` に移しています。

## #2127 トップの人気タグ

`tag_display_max_count` を 25 → **10** に。同じページの「よく読まれている記事」と数を揃えました。

## 確認

差分ビルド（`_config.fast.yml`）で、生成 CSS の `gap` 指定・タグ li のクラス付与・トップページのタグが10件になることを確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)