### PR TITLE
文脈件数の表現を整理する（著者ページはパネル、関連タグは共通本数）

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1156,14 +1156,33 @@ code {
   color: #616161;
   font-weight: bold;
 }
-/* 著者ページの「よく投稿するカテゴリ」。間隔は記事メタデータ行
-   （.blog-info）と同じ 28px */
-.author-top-categories {
-  list-style: none;
-  padding-left: 0;
+/* 著者ページの傾向パネル。タグ・カテゴリのリンクは通常の表現のまま、
+   「この著者が何本書いたか」はパネル側が名乗る。
+   リンクの右肩に著者内の件数を出すと、他ページの「タグ総数」と
+   同じ表現で違う意味になり、クリック先の件数とも食い違う (#2129) */
+.tendency-panels {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px 28px;
+  gap: 10px 12px;
+  padding-left: 0;
+  list-style: none;
+}
+.tendency-panel {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border: 1px solid #eee;
+  border-radius: card-radius;
+}
+/* チップ自身の margin はパネルの gap と二重になるので消す */
+.tendency-panel .tag-list-link {
+  margin: 0;
+}
+.tendency-panel-count {
+  color: #6e6e6e;
+  font-size: 0.85em;
+  white-space: nowrap;
 }
 /* 著者一覧の年別タブ。ランキングと同じ radio + label 方式だが、
    年ごとの ID ルールを毎年 CSS に足さずに済むよう、input+label+content を

--- a/themes/future/layout/_partial/related-tags.ejs
+++ b/themes/future/layout/_partial/related-tags.ejs
@@ -16,7 +16,10 @@
       <div class="widget">
         <ul class="tag-list" itemprop="keywords">
           <% related.forEach(function(t){ %>
-          <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.sibling ? `${t.name} の記事 ${t.posts}本（${page.tag} と同じ系列）` : `${t.name} の記事 ${t.posts}本（うち ${page.tag} と共通 ${t.co}本）` %>"><%= t.name %><span class="tag-list-count"><%= t.posts %></span></a></li>
+          <%# チップの数字はタグの総記事数ではなく、いま見ているタグの文脈での
+              件数にする (#2129)。共起タグは共通本数（title の説明とも一致）、
+              同系列タグは共起で結ばれていないので系列側の本数のまま %>
+          <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.sibling ? `${t.name} の記事 ${t.posts}本（${page.tag} と同じ系列）` : `${t.name} の記事 ${t.posts}本（うち ${page.tag} と共通 ${t.co}本）` %>"><%= t.name %><span class="tag-list-count"><%= t.sibling ? t.posts : t.co %></span></a></li>
           <% }) %>
         </ul>
       </div>

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -28,25 +28,32 @@
     <p class="summary-note">直近1年間の投稿はありません</p>
     <% } %>
     <%- get_profile(page.author) %>
+    <%# タグ・カテゴリのリンクは通常の表現のまま（チップの右肩に著者内の
+        件数を出すと、他ページの「タグ総数」と同じ表現で違う意味になり、
+        クリック先の件数とも食い違う）。この著者が何本書いたかは、
+        リンクを囲むパネル側が「n本投稿」として名乗る (#2129) %>
     <% if (as.topCategories.length) { %>
     <h2 class="bottom-content-header">よく投稿するカテゴリ</h2>
-    <%# カテゴリはタグと誤認しないようチップにせず、記事メタデータと同じ
-        テキストリンク（.article-category-link）で並べる %>
-    <ul class="author-top-categories">
+    <ul class="tendency-panels">
       <% as.topCategories.forEach(function(c){ %>
-      <li><a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= page.author %>さんの <%= c.name %> カテゴリの記事 <%= c.count %>本"><%= c.name %> (<%= c.count %>)</a></li>
+      <li class="tendency-panel">
+        <%# カテゴリはタグと誤認しないようチップにせず、記事メタデータと同じテキストリンク %>
+        <a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事へ"><%= c.name %></a>
+        <span class="tendency-panel-count"><%= c.count %>本投稿</span>
+      </li>
       <% }) %>
     </ul>
     <% } %>
     <% if (as.topTags.length) { %>
     <h2 class="bottom-content-header">よく使うタグ</h2>
-    <div class="blog-tags">
-      <ul class="tag-list">
-        <% as.topTags.forEach(function(t){ %>
-        <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= page.author %>さんの <%= t.name %> の記事 <%= t.count %>本"><%= t.name %><span class="tag-list-count"><%= t.count %></span></a></li>
-        <% }) %>
-      </ul>
-    </div>
+    <ul class="tendency-panels">
+      <% as.topTags.forEach(function(t){ %>
+      <li class="tendency-panel">
+        <a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.name %> タグの記事へ"><%= t.name %></a>
+        <span class="tendency-panel-count"><%= t.count %>本投稿</span>
+      </li>
+      <% }) %>
+    </ul>
     <% } %>
     <h2 class="bottom-content-header">月別投稿数</h2>
     <div id="chart" style="width:95%;min-height:250px"></div>


### PR DESCRIPTION
## 概要

Fixes #2129

「文脈でスコープした件数」をどう表現するかの整理です。原則: **チップ右肩の数字という表現は「クリック先で見える件数」と一致させ、文脈件数は別の表現で示す**。

## 対応内容

1. **著者ページ（よく投稿するカテゴリ／よく使うタグ）をパネル表現に**
   - 従来はチップ右肩に著者内の件数（Go 59）を出しており、他ページの「タグ総数」と同じ表現で違う意味・クリック先（262件）ともズレてサプライズだった
   - タグ・カテゴリのリンクは通常の表現（チップ／テキストリンク・件数なし）に戻し、**リンクを囲むパネルが「59本投稿」と名乗る**形に変更。年カード（2026 / 94件）と同じ「入れ物が説明する」パターン

```
┌───────────────┐ ┌───────────────┐
│ [Go]  59本投稿 │ │ [AWS] 14本投稿 │
└───────────────┘ └───────────────┘
```

2. **関連タグ（タグページ）**: チップの数字をタグ総数 → いま見ているタグとの共通本数に変更（AWS 126 → 26。title の説明と一致）

## 動作確認

- /authors/真野隼記/ でパネル13個（カテゴリ3 + タグ10）の描画・リンク先・「n本投稿」表記を確認
- /tags/Go/ の関連タグで共通本数表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
