### PR TITLE
著者の傾向から使用1本だけのタグ・カテゴリを省く

### DIFF
--- a/scripts/author_generator.js
+++ b/scripts/author_generator.js
@@ -160,11 +160,19 @@ hexo.extend.helper.register('author_stats', function(name) {
     });
   });
   const byCount = (a, b) => b.count - a.count;
+  // 使用が1本だけの項目は「よく使う」傾向とは言えないので省く (#2139)。
+  // ただし省いた結果が空になる著者（投稿1本や、投稿ごとにタグが全部違う著者）は
+  // 何も出せなくなるので、その場合だけ省かずに全部見せる
+  const pickTop = (entries, limit) => {
+    const sorted = entries.sort(byCount);
+    const repeated = sorted.filter(e => e.count >= 2);
+    return (repeated.length > 0 ? repeated : sorted).slice(0, limit);
+  };
   return {
     recent,
-    topCategories: [...catCount.values()].sort(byCount).slice(0, 3),
+    topCategories: pickTop([...catCount.values()], 3),
     // インデックスは連載索引の構造タグで、執筆傾向を表さない
-    topTags: [...tagCount.values()].filter(t => t.name !== 'インデックス').sort(byCount).slice(0, 10),
+    topTags: pickTop([...tagCount.values()].filter(t => t.name !== 'インデックス'), 10),
   };
 });
 


### PR DESCRIPTION
## 概要

Fixes #2139

著者ページの「よく使うタグ」「よく投稿するカテゴリ」から、使用が1本だけの項目を省きます（1回の使用は傾向ではない）。

## ルール

**省いた結果が空になる著者は、省かずに全部見せる**フォールバック方式です。

- 使用2本以上の項目があれば、1本だけの項目は省く
- 省くと空になる著者（投稿1本、または投稿ごとにタグが全部違う著者）は全項目を表示——「1本の著者は全部出るのに、2本の著者は何も出ない」という矛盾を作らない
- カテゴリにも同じ規則を適用（「1回は傾向ではない」という根拠が共通のため）

## 動作確認（3ケース）

- 真野隼記（153本）: 変化なし（上位10タグは最小でも7本）
- 亀井隆徳（2本・タグがすべて1本）: フォールバックで全項目表示（1本投稿のパネルが並ぶ）
- 小川達（1本）: 全項目表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)