### PR TITLE
著者の月別投稿数をカテゴリ積み上げにし、軸ラベルと期間を整える

### DIFF
--- a/scripts/author_generator.js
+++ b/scripts/author_generator.js
@@ -206,27 +206,16 @@ hexo.extend.helper.register('author_monthly_chart', function(name) {
   });
   if (!min) return JSON.stringify({months: [], series: []});
 
-  // 期間が12ヶ月未満だと軸が数ヶ月分しかなく見栄えが悪い (#2140)。
-  // 同一年に収まるなら 1〜12月へ、年をまたぐ短い期間は末尾から12ヶ月に広げる
-  let startY = +min.slice(0, 4);
-  let startM = +min.slice(5);
+  // 軸は暦年に揃える。開始は初投稿年の1月、終了は最終投稿年の12月 (#2140)。
+  // 投稿月そのままだと数ヶ月分しか無い著者の軸が中途半端な月で
+  // 始まり・止まりして見栄えが悪い。全著者を同じ規則にする
+  const startY = +min.slice(0, 4);
   const endY = +max.slice(0, 4);
-  const endM = +max.slice(5);
-  const span = (endY - startY) * 12 + (endM - startM) + 1;
-  if (span < 12) {
-    if (startY === endY) {
-      startM = 1;
-    } else {
-      const s = endY * 12 + (endM - 1) - 11;
-      startY = Math.floor(s / 12);
-      startM = (s % 12) + 1;
-    }
-  }
-  const endTotal = startY === endY && span < 12 ? 12 : endM;
-
   const months = [];
-  for (let y = startY, m = startM; y < endY || (y === endY && m <= endTotal); m === 12 ? (y++, m = 1) : m++) {
-    months.push(`${y}/${String(m).padStart(2, '0')}`);
+  for (let y = startY; y <= endY; y++) {
+    for (let m = 1; m <= 12; m++) {
+      months.push(`${y}/${String(m).padStart(2, '0')}`);
+    }
   }
 
   // 積み上げの並びは合計の多いカテゴリから。凡例の順もこれに従う

--- a/scripts/author_generator.js
+++ b/scripts/author_generator.js
@@ -2,7 +2,6 @@
 
 const pagination = require('hexo-pagination');
 const {getSNSCnt, getTwitterCnt, getFacebookCnt, getHatebuCnt, getPocketCnt} = require('./lib/sns');
-const moment = require('moment');
 
 hexo.extend.generator.register("author", function(locals) {
     // author は1記事1名。配列だと著者ページの記事一覧に入らず、集計からも
@@ -184,65 +183,62 @@ hexo.extend.helper.register('post_author_link', function(post) {
   return `<li class="blog-info-item">${link}</li>`
 });
 
-// チャート表示用のデータを生成
-hexo.extend.helper.register('generate_post_series', function(author) {
-  return generateSeries(this.site.posts, author).map(e => e.count).join(',');
-});
+// 著者ページの月別投稿数チャート用データ (#2135 / #2138 / #2140)。
+// カテゴリごとの積み上げにするため {months, series} を JSON で返す
+hexo.extend.helper.register('author_monthly_chart', function(name) {
+  const posts = this.site.posts.filter(post => [].concat(post.author || []).includes(name));
+  // month(YYYY/MM) -> category -> count
+  const byMonth = new Map();
+  const catTotal = new Map();
+  let min = null;
+  let max = null;
+  posts.forEach(post => {
+    const ym = post.date.format('YYYY/MM');
+    if (!min || ym < min) min = ym;
+    if (!max || ym > max) max = ym;
+    // カテゴリは第1のものだけ数える。複数カテゴリを全部積むと
+    // 合計が投稿数と合わなくなる
+    const cat = post.categories && post.categories.length ? post.categories.first().name : '未分類';
+    catTotal.set(cat, (catTotal.get(cat) || 0) + 1);
+    if (!byMonth.has(ym)) byMonth.set(ym, new Map());
+    const m = byMonth.get(ym);
+    m.set(cat, (m.get(cat) || 0) + 1);
+  });
+  if (!min) return JSON.stringify({months: [], series: []});
 
-hexo.extend.helper.register('generate_post_month', function(author) {
-  return generateSeries(this.site.posts, author).map(e => e.yyyyMM).join(',');
-});
-
-hexo.extend.helper.register('max_post_month', function(author) {
-  return Math.max(5, ...generateSeries(this.site.posts, author).map(e => e.count)); // 最小は5
-});
-
-const generateSeries = (posts, author) => {
-  const target = posts.filter(post => post.author === author);
-  const start = moment.min(...target.map(item => item.date)).clone(); // Add操作で副作用があるのでclone
-  const end = moment.max(...target.map(item => item.date));
-
-  let fillingItems = [];
-  for (;;) {
-    const date = start.add(1, 'M')
-    fillingItems.push({
-      yyyyMM: date.format("YYYYMM"),
-      count:0
-    })
-    if (date.format("YYYYMM") === end.format("YYYYMM") || date >= end) {
-      break;
+  // 期間が12ヶ月未満だと軸が数ヶ月分しかなく見栄えが悪い (#2140)。
+  // 同一年に収まるなら 1〜12月へ、年をまたぐ短い期間は末尾から12ヶ月に広げる
+  let startY = +min.slice(0, 4);
+  let startM = +min.slice(5);
+  const endY = +max.slice(0, 4);
+  const endM = +max.slice(5);
+  const span = (endY - startY) * 12 + (endM - startM) + 1;
+  if (span < 12) {
+    if (startY === endY) {
+      startM = 1;
+    } else {
+      const s = endY * 12 + (endM - 1) - 11;
+      startY = Math.floor(s / 12);
+      startM = (s % 12) + 1;
     }
   }
+  const endTotal = startY === endY && span < 12 ? 12 : endM;
 
-  const group = target.reduce((acc, cur) => {
-    const item = acc.find(p => p.yyyyMM === cur.date.format("YYYYMM"));
-    if (item) {
-      item.count++;
-    } else {
-      acc.push({
-        yyyyMM: cur.date.format("YYYYMM"),
-        count: 1
-      });
-    }
-    return acc;
-  }, []);
+  const months = [];
+  for (let y = startY, m = startM; y < endY || (y === endY && m <= endTotal); m === 12 ? (y++, m = 1) : m++) {
+    months.push(`${y}/${String(m).padStart(2, '0')}`);
+  }
 
-  const merge = group.concat(fillingItems).reduce((acc, cur) => {
-    const item = acc.find(p => p.yyyyMM === cur.yyyyMM);
-    if (item) {
-      item.count += cur.count;
-    } else {
-      acc.push(cur);
-    }
-    return acc;
-  }, []);
-
-  merge.sort((a, b) => {
-    return a.yyyyMM.localeCompare(b.yyyyMM);
-  });
-
-  return merge;
-}
+  // 積み上げの並びは合計の多いカテゴリから。凡例の順もこれに従う
+  const cats = [...catTotal.entries()].sort((a, b) => b[1] - a[1]).map(([c]) => c);
+  const series = cats.map(cat => ({
+    name: cat,
+    type: 'bar',
+    stack: 'total',
+    data: months.map(ym => (byMonth.get(ym) && byMonth.get(ym).get(cat)) || 0),
+  }));
+  return JSON.stringify({months, series});
+});
 
 
 /*

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -59,10 +59,14 @@
     <div id="chart" style="width:95%;min-height:250px"></div>
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
     <script type="text/javascript">
+      <%# カテゴリごとの積み上げ棒 (#2138)。期間の穴埋めと軸の下限12ヶ月は
+          ヘルパー側（author_monthly_chart）が持つ (#2140) %>
+      const chartData = <%- author_monthly_chart(page.author) %>;
       let myChart = echarts.init(document.getElementById('chart'));
       let option = {
         <%# タイトルは直上の h2 が担うので、チャート内では重ねない %>
         title: {},
+        legend: {},
         tooltip: {
             trigger: 'axis'
         },
@@ -72,23 +76,20 @@
         xAxis: {
             type: 'category',
             boundaryGap: true,
-            // data: ['2021/01', '2021/02', '2021/03', '2021/04', '2021/05', '2021/06', '2021/07']
-            data: [<%= generate_post_month(page.author) %>]
+            data: chartData.months,
+            <%# 毎月のラベルは潰れて読めない (#2135)。年の変わり目と先頭だけ
+                「2026年」と出し、月の詳細はツールチップに任せる %>
+            axisLabel: {
+              interval: 0,
+              formatter: (value, index) => (index === 0 || value.endsWith('/01')) ? value.slice(0, 4) + '年' : ''
+            }
         },
         yAxis: {
             type: 'value',
-            min:0,
-            max:<%= max_post_month(page.author) %>
-
+            <%# 投稿数は整数。自動目盛だと 0.5 刻みが出ることがある %>
+            minInterval: 1
         },
-        series: [
-            {
-                name: '投稿数',
-                type: 'bar',
-                // data: [2, 2, 1, 3, 2, 1, 0]
-                data: [<%= generate_post_series(page.author) %>]
-            }
-        ]
+        series: chartData.series
       };
       myChart.setOption(option);
     </script>

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -62,6 +62,9 @@
       <%# カテゴリごとの積み上げ棒 (#2138)。期間の穴埋めと軸の下限12ヶ月は
           ヘルパー側（author_monthly_chart）が持つ (#2140) %>
       const chartData = <%- author_monthly_chart(page.author) %>;
+      <%# 軸が12ヶ月以下（投稿の少ない著者）なら月ラベルが全部読めるので毎月出す。
+          長期の著者は潰れるため年の変わり目だけにする (#2135) %>
+      const monthlyLabels = chartData.months.length <= 12;
       let myChart = echarts.init(document.getElementById('chart'));
       let option = {
         <%# タイトルは直上の h2 が担うので、チャート内では重ねない %>
@@ -77,17 +80,19 @@
             type: 'category',
             boundaryGap: true,
             data: chartData.months,
-            <%# 毎月のラベルは潰れて読めない (#2135)。年の変わり目と先頭だけ
-                「2026年」と出し、月の詳細はツールチップに任せる %>
             axisLabel: {
               interval: 0,
-              formatter: (value, index) => (index === 0 || value.endsWith('/01')) ? value.slice(0, 4) + '年' : ''
+              formatter: (value, index) => monthlyLabels
+                ? value
+                : ((index === 0 || value.endsWith('/01')) ? value.slice(0, 4) + '年' : '')
             }
         },
         yAxis: {
             type: 'value',
             <%# 投稿数は整数。自動目盛だと 0.5 刻みが出ることがある %>
-            minInterval: 1
+            minInterval: 1,
+            <%# 上限は最低3。月1本の著者が天井に張り付いて見えるのを避ける %>
+            max: value => Math.max(3, value.max)
         },
         series: chartData.series
       };


### PR DESCRIPTION
## 概要

Fixes #2135, Fixes #2138, Fixes #2140

著者ページの「月別投稿数」チャートの3件をまとめて対応しました。データ生成を新ヘルパー `author_monthly_chart`（{months, series} を JSON で返す）に置き換えています。

## 対応内容

1. **カテゴリごとの積み上げ棒グラフに（#2138）**: 投稿の第1カテゴリで積み上げ、凡例付き。凡例に出るのは**その著者が使っているカテゴリだけ**（著者内の本数降順）。複数カテゴリを全部積むと合計が投稿数と合わなくなるため、第1カテゴリだけを数えます
2. **X軸ラベル（#2135）**: 軸が12ヶ月以下の著者は全月ラベル（`2016/01`〜）、13ヶ月以上は年の変わり目だけ「2026年」。月の詳細はツールチップで見えます
3. **軸は暦年に揃える（#2140）**: 開始＝初投稿年の1月、終了＝最終投稿年の12月。「12ヶ月未満だけ広げる」場合分けだと、2026/02 が最終投稿の著者は軸が2月で止まる一方、1記事の著者だけ12月まで伸びて不揃いになるため、全著者を同じ規則にしました
4. **Y軸**: 整数目盛（minInterval: 1）+ 上限に下限3（月1本の著者が天井に張り付いて見えない）

旧ヘルパー3つ（`generate_post_series` / `generate_post_month` / `max_post_month`）と `moment` 依存は使い手が無くなったため削除しました。

## 動作確認

- 真野隼記（2016〜）: 2016/01〜2026/12・カテゴリ13色の積み上げ・年ラベル
- 亀井隆徳（2020 と 2026/02 の2本）: 2020/01〜2026/12 に暦年整列
- 小川達（2016年に1本）: 2016/01〜2016/12・全月ラベル・Y軸上限3

🤖 Generated with [Claude Code](https://claude.com/claude-code)