### PR TITLE
著者数の推移を 継続・再開・新規 の年別積み上げ + 常連の折れ線にする

### DIFF
--- a/scripts/author_generator.js
+++ b/scripts/author_generator.js
@@ -233,67 +233,46 @@ hexo.extend.helper.register('author_monthly_chart', function(name) {
 /*
  * 著者一覧ページ
  */
-hexo.extend.helper.register('generate_yearly_authors_series_x', function() {
-  return generateAuthorsSeriesAll(this.site.posts).map(e => e.year).join(',');
-});
-
-hexo.extend.helper.register('generate_yearly_authors_series_y', function() {
-  return generateAuthorsSeriesAll(this.site.posts).map(e => e.authors.unique().length).join(',');
-});
-
-// 新規寄稿者の割合（%）。「新規」は前年に投稿が無かった寄稿者（#2073）。
-// 初出ベースではないので、数年ぶりに復帰した人も新規に数える。
-// 最初の年は前年が無く全員新規（100%）になるだけなので欠損にする
-// 年ごとの新規／継続の寄稿者数。積み上げ棒にすると合計がその年の著者数になる。
-// 「新規」はその年より前に一度も出ていない人。前年比ではない
-function yearlyAuthorSplit(posts) {
-  const series = generateAuthorsSeriesAll(posts);
-  const seen = new Set();
-  return series.map(e => {
-    const authors = new Set(e.authors.flat());
-    let fresh = 0;
-    authors.forEach(a => { if (!seen.has(a)) fresh++; });
-    authors.forEach(a => seen.add(a));
-    return {year: e.year, fresh, returning: authors.size - fresh};
+// 四半期ごとの寄稿者数を 継続・新規・再開 に分けて返す (#2145)。
+// 新規 = その四半期が初投稿。
+// 再開 = 過去に投稿があるが、直前の活動四半期から1年より長くあいた。
+// 継続 = 直前の活動四半期から1年以内
+hexo.extend.helper.register('quarterly_author_types', function() {
+  const qOf = date => date.year() * 4 + Math.floor(date.month() / 3);
+  const activity = new Map(); // 著者 -> 活動した四半期の Set
+  let minQ = Infinity;
+  let maxQ = -Infinity;
+  this.site.posts.forEach(post => {
+    const q = qOf(post.date);
+    if (q < minQ) minQ = q;
+    if (q > maxQ) maxQ = q;
+    if (!activity.has(post.author)) activity.set(post.author, new Set());
+    activity.get(post.author).add(q);
   });
-}
+  if (minQ === Infinity) {
+    return JSON.stringify({quarters: [], continuing: [], newcomers: [], returning: []});
+  }
 
-hexo.extend.helper.register('yearly_new_authors', function() {
-  return yearlyAuthorSplit(this.site.posts).map(e => e.fresh).join(',');
-});
-
-hexo.extend.helper.register('yearly_returning_authors', function() {
-  return yearlyAuthorSplit(this.site.posts).map(e => e.returning).join(',');
-});
-
-hexo.extend.helper.register('yearly_new_author_ratio', function() {
-  const series = generateAuthorsSeriesAll(this.site.posts);
-  // 共著の旧記事は author が配列なので flat で展開する
-  const sets = series.map(e => new Set(e.authors.flat()));
-  return series.map((e, i) => {
-    if (i === 0 || sets[i].size === 0) return "'-'";
-    const newcomers = [...sets[i]].filter(a => !sets[i - 1].has(a)).length;
-    return Math.round(newcomers * 100 / sets[i].size);
-  }).join(',');
-});
-
-const generateAuthorsSeriesAll = posts => {
-  const group = posts.reduce((acc, cur) => {
-    const item = acc.find(p => p.year === cur.date.format("YYYY"));
-    if (item) {
-      item.authors.push(cur.author);
-    } else {
-      acc.push({
-        year: cur.date.format("YYYY"),
-        authors: [cur.author],
-      });
-    }
-    return acc;
-  }, []);
-
-  group.sort((a, b) => {
-    return a.year.localeCompare(b.year);
+  const size = maxQ - minQ + 1;
+  const continuing = new Array(size).fill(0);
+  const newcomers = new Array(size).fill(0);
+  const returning = new Array(size).fill(0);
+  activity.forEach(set => {
+    const qs = [...set].sort((a, b) => a - b);
+    qs.forEach((q, i) => {
+      if (i === 0) {
+        newcomers[q - minQ]++;
+      // 4四半期差はちょうど1年後の同じ四半期。それより長くあいたら再開
+      } else if (q - qs[i - 1] > 4) {
+        returning[q - minQ]++;
+      } else {
+        continuing[q - minQ]++;
+      }
+    });
   });
-
-  return group;
-}
+  const quarters = [];
+  for (let q = minQ; q <= maxQ; q++) {
+    quarters.push(`${Math.floor(q / 4)}-Q${(q % 4) + 1}`);
+  }
+  return JSON.stringify({quarters, continuing, newcomers, returning});
+});

--- a/scripts/author_generator.js
+++ b/scripts/author_generator.js
@@ -233,46 +233,44 @@ hexo.extend.helper.register('author_monthly_chart', function(name) {
 /*
  * 著者一覧ページ
  */
-// 四半期ごとの寄稿者数を 継続・新規・再開 に分けて返す (#2145)。
-// 新規 = その四半期が初投稿。
-// 再開 = 過去に投稿があるが、直前の活動四半期から1年より長くあいた。
-// 継続 = 直前の活動四半期から1年以内
-hexo.extend.helper.register('quarterly_author_types', function() {
-  const qOf = date => date.year() * 4 + Math.floor(date.month() / 3);
-  const activity = new Map(); // 著者 -> 活動した四半期の Set
-  let minQ = Infinity;
-  let maxQ = -Infinity;
+// 年ごとの寄稿者数を 継続・新規・再開 に分けて返す (#2145)。
+// 新規 = その年が初投稿。
+// 再開 = 過去に投稿があるが、前年には無い（2年以上あいた）。
+// 継続 = 前年にも投稿がある
+hexo.extend.helper.register('yearly_author_types', function() {
+  const activity = new Map(); // 著者 -> 活動した年の Set
+  let minY = Infinity;
+  let maxY = -Infinity;
   this.site.posts.forEach(post => {
-    const q = qOf(post.date);
-    if (q < minQ) minQ = q;
-    if (q > maxQ) maxQ = q;
+    const y = post.date.year();
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
     if (!activity.has(post.author)) activity.set(post.author, new Set());
-    activity.get(post.author).add(q);
+    activity.get(post.author).add(y);
   });
-  if (minQ === Infinity) {
-    return JSON.stringify({quarters: [], continuing: [], newcomers: [], returning: []});
+  if (minY === Infinity) {
+    return JSON.stringify({years: [], continuing: [], newcomers: [], returning: []});
   }
 
-  const size = maxQ - minQ + 1;
+  const size = maxY - minY + 1;
   const continuing = new Array(size).fill(0);
   const newcomers = new Array(size).fill(0);
   const returning = new Array(size).fill(0);
   activity.forEach(set => {
-    const qs = [...set].sort((a, b) => a - b);
-    qs.forEach((q, i) => {
+    const ys = [...set].sort((a, b) => a - b);
+    ys.forEach((y, i) => {
       if (i === 0) {
-        newcomers[q - minQ]++;
-      // 4四半期差はちょうど1年後の同じ四半期。それより長くあいたら再開
-      } else if (q - qs[i - 1] > 4) {
-        returning[q - minQ]++;
+        newcomers[y - minY]++;
+      } else if (y - ys[i - 1] > 1) {
+        returning[y - minY]++;
       } else {
-        continuing[q - minQ]++;
+        continuing[y - minY]++;
       }
     });
   });
-  const quarters = [];
-  for (let q = minQ; q <= maxQ; q++) {
-    quarters.push(`${Math.floor(q / 4)}-Q${(q % 4) + 1}`);
+  const years = [];
+  for (let y = minY; y <= maxY; y++) {
+    years.push(String(y));
   }
-  return JSON.stringify({quarters, continuing, newcomers, returning});
+  return JSON.stringify({years, continuing, newcomers, returning});
 });

--- a/scripts/author_generator.js
+++ b/scripts/author_generator.js
@@ -236,28 +236,32 @@ hexo.extend.helper.register('author_monthly_chart', function(name) {
 // 年ごとの寄稿者数を 継続・新規・再開 に分けて返す (#2145)。
 // 新規 = その年が初投稿。
 // 再開 = 過去に投稿があるが、前年には無い（2年以上あいた）。
-// 継続 = 前年にも投稿がある
+// 継続 = 前年にも投稿がある。
+// あわせて 常連 = 2年連続で年2本以上（上期・下期に1本のペースを続けている人。
+// 継続などの内訳と重なるため、積み上げには入れず別系列で返す）(#2149)
 hexo.extend.helper.register('yearly_author_types', function() {
-  const activity = new Map(); // 著者 -> 活動した年の Set
+  const activity = new Map(); // 著者 -> (年 -> 本数)
   let minY = Infinity;
   let maxY = -Infinity;
   this.site.posts.forEach(post => {
     const y = post.date.year();
     if (y < minY) minY = y;
     if (y > maxY) maxY = y;
-    if (!activity.has(post.author)) activity.set(post.author, new Set());
-    activity.get(post.author).add(y);
+    if (!activity.has(post.author)) activity.set(post.author, new Map());
+    const m = activity.get(post.author);
+    m.set(y, (m.get(y) || 0) + 1);
   });
   if (minY === Infinity) {
-    return JSON.stringify({years: [], continuing: [], newcomers: [], returning: []});
+    return JSON.stringify({years: [], continuing: [], newcomers: [], returning: [], regulars: []});
   }
 
   const size = maxY - minY + 1;
   const continuing = new Array(size).fill(0);
   const newcomers = new Array(size).fill(0);
   const returning = new Array(size).fill(0);
-  activity.forEach(set => {
-    const ys = [...set].sort((a, b) => a - b);
+  const regulars = new Array(size).fill(0);
+  activity.forEach(counts => {
+    const ys = [...counts.keys()].sort((a, b) => a - b);
     ys.forEach((y, i) => {
       if (i === 0) {
         newcomers[y - minY]++;
@@ -266,11 +270,14 @@ hexo.extend.helper.register('yearly_author_types', function() {
       } else {
         continuing[y - minY]++;
       }
+      if (counts.get(y) >= 2 && (counts.get(y - 1) || 0) >= 2) {
+        regulars[y - minY]++;
+      }
     });
   });
   const years = [];
   for (let y = minY; y <= maxY; y++) {
     years.push(String(y));
   }
-  return JSON.stringify({years, continuing, newcomers, returning});
+  return JSON.stringify({years, continuing, newcomers, returning, regulars});
 });

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -43,12 +43,12 @@
 
       <%# 一覧が主役なので推移グラフは補足の読み物として最後に置く。
           /categories/ の「カテゴリ別 投稿数の推移」と同じ型 %>
-      <h2 class="bottom-content-header">四半期別 著者数の推移</h2>
+      <h2 class="bottom-content-header">年別 著者数の推移</h2>
       <div id="chart" style="width:95%;min-height:350px"></div>
       <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js"></script>
       <script type="text/javascript">
-        <%# 継続・新規・再開の3種別 (#2145)。定義はヘルパー（quarterly_author_types）側 %>
-        const chartData = <%- quarterly_author_types() %>;
+        <%# 継続・新規・再開の3種別 (#2145)。定義はヘルパー（yearly_author_types）側 %>
+        const chartData = <%- yearly_author_types() %>;
         let myChart = echarts.init(document.getElementById('chart'));
         let option = {
           <%# タイトルは直上の h2 が担うので、チャート内では重ねない %>
@@ -63,12 +63,7 @@
           xAxis: {
               type: 'category',
               boundaryGap: true,
-              data: chartData.quarters,
-              <%# 四半期ラベルは潰れて読めないので、年の変わり目だけ出す %>
-              axisLabel: {
-                interval: 0,
-                formatter: (value, index) => (index === 0 || value.endsWith('-Q1')) ? value.slice(0, 4) + '年' : ''
-              }
+              data: chartData.years
           },
           <%# 積み上げの合計がその四半期の著者数になるので、軸は1本で足りる %>
           yAxis: { type: 'value', name: '人', min: 0 },

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -43,10 +43,12 @@
 
       <%# 一覧が主役なので推移グラフは補足の読み物として最後に置く。
           /categories/ の「カテゴリ別 投稿数の推移」と同じ型 %>
-      <h2 class="bottom-content-header">年別 著者数の推移</h2>
+      <h2 class="bottom-content-header">四半期別 著者数の推移</h2>
       <div id="chart" style="width:95%;min-height:350px"></div>
       <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js"></script>
       <script type="text/javascript">
+        <%# 継続・新規・再開の3種別 (#2145)。定義はヘルパー（quarterly_author_types）側 %>
+        const chartData = <%- quarterly_author_types() %>;
         let myChart = echarts.init(document.getElementById('chart'));
         let option = {
           <%# タイトルは直上の h2 が担うので、チャート内では重ねない %>
@@ -61,22 +63,37 @@
           xAxis: {
               type: 'category',
               boundaryGap: true,
-              data: [<%= generate_yearly_authors_series_x() %>]
+              data: chartData.quarters,
+              <%# 四半期ラベルは潰れて読めないので、年の変わり目だけ出す %>
+              axisLabel: {
+                interval: 0,
+                formatter: (value, index) => (index === 0 || value.endsWith('-Q1')) ? value.slice(0, 4) + '年' : ''
+              }
           },
-          <%# 積み上げの合計がその年の著者数になるので、軸は1本で足りる %>
+          <%# 積み上げの合計がその四半期の著者数になるので、軸は1本で足りる %>
           yAxis: { type: 'value', name: '人', min: 0 },
+          <%# 種別は同系色の濃→薄で1つのまとまりに見せる（継続=濃、新規=中、再開=薄）%>
           series: [
               {
-                  name: '継続の寄稿者',
+                  name: '継続',
                   type: 'bar',
                   stack: 'authors',
-                  data: [<%= yearly_returning_authors() %>]
+                  itemStyle: { color: '#5470c6' },
+                  data: chartData.continuing
               },
               {
-                  name: '新規の寄稿者',
+                  name: '新規',
                   type: 'bar',
                   stack: 'authors',
-                  data: [<%= yearly_new_authors() %>]
+                  itemStyle: { color: '#93a7dc' },
+                  data: chartData.newcomers
+              },
+              {
+                  name: '再開',
+                  type: 'bar',
+                  stack: 'authors',
+                  itemStyle: { color: '#c9d4ef' },
+                  data: chartData.returning
               }
           ]
         };

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -45,15 +45,30 @@
           /categories/ の「カテゴリ別 投稿数の推移」と同じ型 %>
       <h2 class="bottom-content-header">年別 著者数の推移</h2>
       <div id="chart" style="width:95%;min-height:350px"></div>
+      <%# 種別の定義。凡例のホバーでも出すが、タッチ端末はホバーが無いので
+          注記でも読めるようにする %>
+      ※継続=前年にも投稿 ／ 再開=2年以上あいての投稿 ／ 新規=初投稿 ／ 常連=2年連続で年2本以上
       <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js"></script>
       <script type="text/javascript">
         <%# 継続・新規・再開の3種別 (#2145)。定義はヘルパー（yearly_author_types）側 %>
         const chartData = <%- yearly_author_types() %>;
+        const typeNotes = {
+          '継続': '前年にも投稿がある',
+          '再開': '過去に投稿があるが前年には無い（2年以上あいての投稿）',
+          '新規': 'この年が初投稿',
+          '常連': '2年連続で年2本以上（上期・下期に1本のペース）'
+        };
         let myChart = echarts.init(document.getElementById('chart'));
         let option = {
           <%# タイトルは直上の h2 が担うので、チャート内では重ねない %>
           title: {},
-          legend: {},
+          <%# 凡例のホバーで種別の定義を出す %>
+          legend: {
+            tooltip: {
+              show: true,
+              formatter: p => typeNotes[p.name] || p.name
+            }
+          },
           tooltip: {
               trigger: 'axis'
           },

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -86,6 +86,13 @@
                   type: 'bar',
                   stack: 'authors',
                   data: chartData.newcomers
+              },
+              <%# 常連（2年連続で年2本以上）は継続などの内訳と重なるため、
+                  積み上げに混ぜず折れ線で重ねる (#2149) %>
+              {
+                  name: '常連',
+                  type: 'line',
+                  data: chartData.regulars
               }
           ]
         };

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -67,28 +67,25 @@
           },
           <%# 積み上げの合計がその四半期の著者数になるので、軸は1本で足りる %>
           yAxis: { type: 'value', name: '人', min: 0 },
-          <%# 種別は同系色の濃→薄で1つのまとまりに見せる（継続=濃、新規=中、再開=薄）%>
+          <%# 土台の継続から順に積む。色は ECharts 既定パレット（他ページのチャートと同じ）%>
           series: [
               {
                   name: '継続',
                   type: 'bar',
                   stack: 'authors',
-                  itemStyle: { color: '#5470c6' },
                   data: chartData.continuing
-              },
-              {
-                  name: '新規',
-                  type: 'bar',
-                  stack: 'authors',
-                  itemStyle: { color: '#93a7dc' },
-                  data: chartData.newcomers
               },
               {
                   name: '再開',
                   type: 'bar',
                   stack: 'authors',
-                  itemStyle: { color: '#c9d4ef' },
                   data: chartData.returning
+              },
+              {
+                  name: '新規',
+                  type: 'bar',
+                  stack: 'authors',
+                  data: chartData.newcomers
               }
           ]
         };


### PR DESCRIPTION
## 概要

Fixes #2145 / #2149 のグラフ表示部分

/authors/ の「年別 著者数の推移」を、**継続・再開・新規の3種別の積み上げ棒 + 常連の折れ線**に置き換えました。

## 種別の定義（ヘルパー `yearly_author_types`）

- **継続**: 前年にも投稿がある
- **再開**: 過去に投稿があるが、前年には無い（2年以上あいた）
- **新規**: その年が初投稿
- **常連**（折れ線）: 2年連続で年2本以上。「上期・下期に1本」のペースを続けている人（#2149 のコアメンバー定義）。継続などの内訳と重なるため積み上げには混ぜない

## 表現

- 積み上げ順は土台から 継続・再開・新規。色は ECharts 既定パレット（他ページと同じ）
- 新規の内訳が直接見えるため、右軸の「新規寄稿者の割合（%）」は廃止

## データ検証

- 新規の総和 = 328 = 全著者数と厳密一致（各著者はちょうど1回だけ新規になる）
- 常連の推移: 2020:10 / 2021:15 / 2022:15 / 2023:15 / 2024:9 / 2025:11 / 2026(8月まで):10 —— 事前のボトムアップ検証値と一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)