### PR TITLE
ヘッダーのサイト名を Web フォント無しの範囲でモダンにする

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -247,27 +247,38 @@ body.page-header-fixed .header {
   height: 3px;
   background-color: rgba(0,0,0,0.6);
 }
+/* サイト名の見た目は Web フォント無しの範囲で作る (#2131)。
+   Avenir Next（macOS/iOS の幾何学グロテスク）と Segoe UI Variable Display
+   （Win11 の見出し用）を優先し、無い環境は従来のシステムスタックに落ちる。
+   サイト名は固定の英字なので絵文字フォントは要らない */
 .header-title {
   margin: 1px 0 0;
   font-size: 80px;
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
-  font-weight: 700;
-  color: #ddd;
+  font-family: "Avenir Next", "Segoe UI Variable Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+  font-weight: 800;
+  /* 大型の見出しは字間を詰めると締まる */
+  letter-spacing: -0.02em;
+  color: #fff;
   text-align: center;
-  text-shadow: 0px 4px 3px rgba(0,0,0,0.4), 0px 8px 13px rgba(0,0,0,0.1), 0px 18px 23px rgba(0,0,0,0.1);
+  /* 三重の影は古びて見える。画像上の可読性に必要な最小限だけ残す */
+  text-shadow: 0 2px 12px rgba(0,0,0,0.45);
 }
 .header-title a {
-  color: #ddd;
+  color: #fff;
   text-decoration: none;
 }
+/* 大きく締めた英字に対して、和文サブタイトルは小さく字間を開けて対比させる */
 .header-title-sub {
   padding-bottom: 15px;
   font-size: 20px;
   font-family: 'Segoe UI', 'Helvetica Neue', 'Hiragino Kaku Gothic ProN', 'メイリオ', 'meiryo', 'sans-serif';
   font-weight: 400;
+  letter-spacing: 0.35em;
+  /* 字間は各字の右に付くため、中央揃えが右へズレて見える。先頭を同量で戻す */
+  text-indent: 0.35em;
   color: #ddd;
   text-align: center;
-  text-shadow: 0px 4px 3px rgba(0,0,0,0.4), 0px 8px 13px rgba(0,0,0,0.1), 0px 18px 23px rgba(0,0,0,0.1);
+  text-shadow: 0 2px 12px rgba(0,0,0,0.45);
 }
 .site-logo {
   padding: 0px;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -277,15 +277,16 @@ body.page-header-fixed .header {
   padding-bottom: 15px;
   font-size: 20px;
   font-family: 'Segoe UI', 'Helvetica Neue', 'Hiragino Kaku Gothic ProN', 'メイリオ', 'meiryo', 'sans-serif';
-  /* 写真の上では 400 の和文が細く沈む。字間を開けたぶんも視認性を落とすので
-     太さと白で補う */
-  font-weight: 600;
+  /* 和文システムフォントのウェイトは実質 400/600 の二値（ヒラギノは W3/W6）で、
+     600 は太すぎ 400 は写真に沈む。400 のまま、タイトな影で輪郭を立てて
+     視認性を補う */
+  font-weight: 400;
   letter-spacing: 0.35em;
   /* 字間は各字の右に付くため、中央揃えが右へズレて見える。先頭を同量で戻す */
   text-indent: 0.35em;
   color: #fff;
   text-align: center;
-  text-shadow: 0 2px 12px rgba(0,0,0,0.45);
+  text-shadow: 0 1px 2px rgba(0,0,0,0.8), 0 2px 12px rgba(0,0,0,0.45);
 }
 .site-logo {
   padding: 0px;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -267,16 +267,23 @@ body.page-header-fixed .header {
   color: #fff;
   text-decoration: none;
 }
+/* 見出しホバーで「#」を出す仕掛け（metronic の h1:hover ::before）は
+   本文見出しのアンカー用。ホームでは h1 になるサイト名には出さない */
+.header-title:hover ::before {
+  content: none;
+}
 /* 大きく締めた英字に対して、和文サブタイトルは小さく字間を開けて対比させる */
 .header-title-sub {
   padding-bottom: 15px;
   font-size: 20px;
   font-family: 'Segoe UI', 'Helvetica Neue', 'Hiragino Kaku Gothic ProN', 'メイリオ', 'meiryo', 'sans-serif';
-  font-weight: 400;
+  /* 写真の上では 400 の和文が細く沈む。字間を開けたぶんも視認性を落とすので
+     太さと白で補う */
+  font-weight: 600;
   letter-spacing: 0.35em;
   /* 字間は各字の右に付くため、中央揃えが右へズレて見える。先頭を同量で戻す */
   text-indent: 0.35em;
-  color: #ddd;
+  color: #fff;
   text-align: center;
   text-shadow: 0 2px 12px rgba(0,0,0,0.45);
 }


### PR DESCRIPTION
## 概要

Fixes #2131

Web フォントを入れない制約のまま、ヘッダーのサイト名のタイポグラフィを更新しました。流星の演出は #2158 に分離しています。

## 対応内容

| 項目 | 変更 |
| --- | --- |
| フォントスタック | 先頭に `Avenir Next`（macOS/iOS）と `Segoe UI Variable Display`（Win11）。無い環境は従来へフォールバック。固定英字なので絵文字フォントは除去 |
| ウェイト・字間 | 700 → **800**、`letter-spacing: -0.02em` |
| 色・影 | `#ddd` → `#fff`、三重の text-shadow → 単層 `0 2px 12px` |
| サブタイトル | 字間 **0.35em** で英字と対比。和文ウェイトは実質 400/600 の二値で 600 は太すぎたため、**400 + タイトな影のフチ取り**で視認性を確保。中央ズレは `text-indent` で補正 |
| ホバーの「#」修正 | ホームでは h1 になるため、本文見出し用のアンカー記号（metronic の `h1:hover ::before`）が出ていたのを打ち消し |

## 動作確認

- 生成 CSS の出力確認済み。見た目は主観なのでブラウザで確認してください（Mac=Avenir Next、Win11=Segoe UI Variable、他=従来フォントの強化版）

🤖 Generated with [Claude Code](https://claude.com/claude-code)