### PR TITLE
運営向けのメンテナンス画面 /doctor/ を新設する

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -22,6 +22,11 @@ function matchableTag(name) {
   return name.length >= 4;
 }
 
+// 数が多い受け皿カテゴリ。カテゴリ運用のルールとして、ここへ寄せる提案はしない
+// （何でも Programming / DevOps に見えてしまうため、具体的なカテゴリへ
+// 移す方向だけを提案する）
+const SUGGEST_IGNORE = new Set(['Programming', 'DevOps']);
+
 hexo.extend.helper.register('doctor_checks', function() {
   const posts = this.site.posts.sort('-date');
 
@@ -29,9 +34,11 @@ hexo.extend.helper.register('doctor_checks', function() {
   // 自分の票が入ると、小さいタグでは現状カテゴリが常に勝って検出できない
   const tagCat = new Map(); // タグ -> (カテゴリ -> 記事数)
   const tagN = new Map();
+  const catSize = new Map(); // カテゴリ -> 記事数
   posts.forEach(post => {
     const cat = post.categories.first();
     if (!cat) return;
+    catSize.set(cat.name, (catSize.get(cat.name) || 0) + 1);
     post.tags.forEach(tag => {
       if (tag.name === 'インデックス') return;
       if (!tagCat.has(tag.name)) tagCat.set(tag.name, new Map());
@@ -75,19 +82,28 @@ hexo.extend.helper.register('doctor_checks', function() {
       });
       if (score.size) {
         const ranked = [...score.entries()].sort((a, b) => b[1] - a[1]);
-        const [predName, predScore] = ranked[0];
+        // 受け皿カテゴリへ寄せる提案はしない（運用ルール）
+        const candidate = ranked.find(([c]) => c !== actualCat.name && !SUGGEST_IGNORE.has(c));
         const actualScore = score.get(actualCat.name) || 0;
-        // 提案が現状の2倍以上の票、かつ絶対値でも1.5票以上のときだけ出す。
-        // 緩めると数百件になりレビューできない
-        if (predName !== actualCat.name && predScore >= 2 * actualScore && predScore >= 1.5) {
-          suggestions.push({
-            title: post.title,
-            path: post.path,
-            actual: actualCat.name,
-            suggested: predName,
-            predScore: Math.round(predScore * 10) / 10,
-            actualScore: Math.round(actualScore * 10) / 10,
-          });
+        if (candidate) {
+          const [predName, predScore] = candidate;
+          // 迷ったら数の少ない専門カテゴリへ寄せる、という運用ルールを写す。
+          // 大きいカテゴリから小さいカテゴリへの提案は現状と同票でも出し、
+          // 逆方向は2倍以上の票を要求する。緩めすぎると数百件になりレビューできない
+          const toSmaller = (catSize.get(predName) || 0) < (catSize.get(actualCat.name) || 0);
+          const pass = toSmaller
+            ? predScore >= actualScore && predScore >= 1.0
+            : predScore >= 2 * actualScore && predScore >= 1.5;
+          if (pass) {
+            suggestions.push({
+              title: post.title,
+              path: post.path,
+              actual: actualCat.name,
+              suggested: predName,
+              predScore: Math.round(predScore * 10) / 10,
+              actualScore: Math.round(actualScore * 10) / 10,
+            });
+          }
         }
       }
     }

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const pagination = require('hexo-pagination');
+
+/**
+ * /doctor/ 運営向けのメンテナンス画面 (#2058)。
+ * タグ・カテゴリの付与漏れの候補を機械判定で列挙する。あくまで提案で、
+ * 自動修正はしない。head.ejs で noindex にしており、メニューからも張らない。
+ */
+hexo.extend.generator.register('doctor', function(locals) {
+  // ページ生成に1件必要なだけのダミー。並べてから取らないと OGP 画像が実行ごとに変わる
+  return pagination('doctor', locals.posts.sort('-date').slice(0, 1), {
+    layout: ['doctor'],
+    data: {title: '記事ドクター'}
+  });
+});
+
+// タイトル照合の対象とするタグ名。短い名前は一般語に当たりやすい
+// （Go が Google に当たる等）ので、英数3文字・和文4文字を下限にする
+function matchableTag(name) {
+  if (/^[\x20-\x7e]+$/.test(name)) return name.length >= 3;
+  return name.length >= 4;
+}
+
+hexo.extend.helper.register('doctor_checks', function() {
+  const posts = this.site.posts.sort('-date');
+
+  // タグ→カテゴリの分布。提案の判定は記事自身の票を抜いて行う（leave-one-out）。
+  // 自分の票が入ると、小さいタグでは現状カテゴリが常に勝って検出できない
+  const tagCat = new Map(); // タグ -> (カテゴリ -> 記事数)
+  const tagN = new Map();
+  posts.forEach(post => {
+    const cat = post.categories.first();
+    if (!cat) return;
+    post.tags.forEach(tag => {
+      if (tag.name === 'インデックス') return;
+      if (!tagCat.has(tag.name)) tagCat.set(tag.name, new Map());
+      const dist = tagCat.get(tag.name);
+      dist.set(cat.name, (dist.get(cat.name) || 0) + 1);
+      tagN.set(tag.name, (tagN.get(tag.name) || 0) + 1);
+    });
+  });
+
+  const suggestions = [];
+  const untagged = [];
+  const missingByTag = new Map(); // タグ名 -> {path, posts: []}
+
+  const allTagNames = [];
+  this.site.tags.forEach(tag => {
+    if (tag.length >= 3 && matchableTag(tag.name)) {
+      allTagNames.push({name: tag.name, path: tag.path});
+    }
+  });
+
+  posts.forEach(post => {
+    const tagNames = post.tags.map(t => t.name);
+
+    // 1) タグ無し
+    if (tagNames.length === 0) {
+      untagged.push({title: post.title, path: post.path});
+    }
+
+    // 2) カテゴリ提案
+    const actualCat = post.categories.first();
+    if (actualCat) {
+      const score = new Map();
+      tagNames.forEach(name => {
+        if (name === 'インデックス') return;
+        const n = tagN.get(name) || 0;
+        if (n < 4) return; // 自票を抜くと3本未満。判断材料にしない
+        for (const [c, cnt] of tagCat.get(name)) {
+          const loo = c === actualCat.name ? cnt - 1 : cnt;
+          score.set(c, (score.get(c) || 0) + loo / (n - 1));
+        }
+      });
+      if (score.size) {
+        const ranked = [...score.entries()].sort((a, b) => b[1] - a[1]);
+        const [predName, predScore] = ranked[0];
+        const actualScore = score.get(actualCat.name) || 0;
+        // 提案が現状の2倍以上の票、かつ絶対値でも1.5票以上のときだけ出す。
+        // 緩めると数百件になりレビューできない
+        if (predName !== actualCat.name && predScore >= 2 * actualScore && predScore >= 1.5) {
+          suggestions.push({
+            title: post.title,
+            path: post.path,
+            actual: actualCat.name,
+            suggested: predName,
+            predScore: Math.round(predScore * 10) / 10,
+            actualScore: Math.round(actualScore * 10) / 10,
+          });
+        }
+      }
+    }
+
+    // 3) タイトルにタグ名を含むのに、そのタグが付いていない
+    const has = new Set(tagNames);
+    for (const t of allTagNames) {
+      if (has.has(t.name)) continue;
+      let hit;
+      if (/^[\x20-\x7e]+$/.test(t.name)) {
+        // 英数タグは単語境界で照合する（SQL が PostgreSQL に当たるのを防ぐ）
+        const escaped = t.name.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&');
+        hit = new RegExp(`(^|[^A-Za-z0-9])${escaped}([^A-Za-z0-9]|$)`, 'i').test(post.title);
+      } else {
+        hit = post.title.includes(t.name);
+      }
+      if (hit) {
+        if (!missingByTag.has(t.name)) missingByTag.set(t.name, {path: t.path, posts: []});
+        missingByTag.get(t.name).posts.push({title: post.title, path: post.path});
+      }
+    }
+  });
+
+  suggestions.sort((a, b) => b.predScore - a.predScore);
+  const missing = [...missingByTag.entries()]
+    .map(([name, v]) => ({name, path: v.path, posts: v.posts}))
+    .sort((a, b) => b.posts.length - a.posts.length);
+  const missingTotal = missing.reduce((acc, m) => acc + m.posts.length, 0);
+
+  return {suggestions, untagged, missing, missingTotal};
+});

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -50,7 +50,16 @@ hexo.extend.helper.register('doctor_checks', function() {
 
   const suggestions = [];
   const untagged = [];
+  const overTagged = [];
   const missingByTag = new Map(); // タグ名 -> {path, posts: []}
+
+  // タグ -> 記事IDの集合。ほぼ重なるタグ（統合候補）と1記事タグの検出に使う
+  const tagPostSets = new Map();
+  const tagPath = new Map();
+  this.site.tags.forEach(tag => {
+    tagPath.set(tag.name, tag.path);
+    tagPostSets.set(tag.name, new Set(tag.posts.map(p => p._id)));
+  });
 
   const allTagNames = [];
   this.site.tags.forEach(tag => {
@@ -65,6 +74,10 @@ hexo.extend.helper.register('doctor_checks', function() {
     // 1) タグ無し
     if (tagNames.length === 0) {
       untagged.push({title: post.title, path: post.path});
+    }
+    // タグの付けすぎ。記事あたりの中央値は3で、その倍を超えたら見直し候補
+    if (tagNames.length >= 7) {
+      overTagged.push({title: post.title, path: post.path, count: tagNames.length});
     }
 
     // 2) カテゴリ提案
@@ -131,10 +144,53 @@ hexo.extend.helper.register('doctor_checks', function() {
   });
 
   suggestions.sort((a, b) => b.predScore - a.predScore);
+  overTagged.sort((a, b) => b.count - a.count);
   const missing = [...missingByTag.entries()]
     .map(([name, v]) => ({name, path: v.path, posts: v.posts}))
     .sort((a, b) => b.posts.length - a.posts.length);
   const missingTotal = missing.reduce((acc, m) => acc + m.posts.length, 0);
 
-  return {suggestions, untagged, missing, missingTotal};
+  // 4) ほぼ重なるタグ（統合候補）。A の記事がすべて B にも付いていて、
+  //    B 側の差分も2本以内なら、実質同じ集合に2つの名前が付いている。
+  //    Go1.27 ⊆ Go のような健全な階層（差が大きい包含）はここでは出さない
+  const nearDuplicates = [];
+  const tagEntries = [...tagPostSets.entries()].filter(([, set]) => set.size >= 2);
+  for (const [a, A] of tagEntries) {
+    for (const [b, B] of tagEntries) {
+      if (a === b || B.size < A.size || B.size - A.size > 2) continue;
+      if (A.size === B.size && a > b) continue; // 完全一致ペアの重複を防ぐ
+      let subset = true;
+      for (const x of A) {
+        if (!B.has(x)) { subset = false; break; }
+      }
+      if (subset) {
+        nearDuplicates.push({
+          a, aPath: tagPath.get(a), aN: A.size,
+          b, bPath: tagPath.get(b), bN: B.size,
+          identical: A.size === B.size,
+        });
+      }
+    }
+  }
+  nearDuplicates.sort((x, y) => (x.bN - x.aN) - (y.bN - y.aN) || y.aN - x.aN);
+
+  // 5) 1記事タグ。同じ記事に1記事タグ同士が同居している場合は、その記事の
+  //    タグ付けがまとめて薄い可能性が高いので印を付ける
+  //    （タグクラウドで * / ** として出していた仕様の移設）
+  const singleUse = [];
+  for (const [name, set] of tagPostSets) {
+    if (set.size !== 1) continue;
+    const postId = [...set][0];
+    let lonelyPair = false;
+    for (const [other, otherSet] of tagPostSets) {
+      if (other !== name && otherSet.size === 1 && otherSet.has(postId)) {
+        lonelyPair = true;
+        break;
+      }
+    }
+    singleUse.push({name, path: tagPath.get(name), lonelyPair});
+  }
+  singleUse.sort((x, y) => (y.lonelyPair - x.lonelyPair) || (x.name < y.name ? -1 : 1));
+
+  return {suggestions, untagged, overTagged, missing, missingTotal, nearDuplicates, singleUse};
 });

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -112,6 +112,9 @@ hexo.extend.helper.register('doctor_checks', function() {
     const has = new Set(tagNames);
     for (const t of allTagNames) {
       if (has.has(t.name)) continue;
+      // タイトルに連載名を含む記事（「Go 1.27 リリース連載：uuid」等）では、
+      // 連載名の一部（リリース 等）に当たっても記事の主題ではない
+      if (post.series && String(post.series).includes(t.name)) continue;
       let hit;
       if (/^[\x20-\x7e]+$/.test(t.name)) {
         // 英数タグは単語境界で照合する（SQL が PostgreSQL に当たるのを防ぐ）

--- a/scripts/tags.js
+++ b/scripts/tags.js
@@ -121,42 +121,6 @@ function customTagCloudHelper(options) {
     return '';
   }
 
-  // 「***」を付与するタグを事前に計算する
-  // 1. タグを「紐づく記事IDの集合」でグループ化するためのMap
-  const postSetToTagsMap = new Map();
-
-  site.tags.forEach(tag => {
-    // 記事が2未満のタグは今回の条件に関係ないので除外
-    if (tag.length < 2) {
-      return;
-    }
-    // 記事のIDをソートして、一意のキーを作成 (例: "id1,id2,id3")
-    const postIds = tag.posts.map(post => post._id).sort();
-    const key = postIds.join(',');
-
-    if (!postSetToTagsMap.has(key)) {
-      postSetToTagsMap.set(key, []);
-    }
-    postSetToTagsMap.get(key).push(tag.name);
-  });
-
-  // 2. 条件に合う「完全に一致する」タグの集合（Set）を作成
-  const matchedTagSet = new Set();
-  postSetToTagsMap.forEach((tagGroup, postSetKey) => {
-    // 記事リストが完全に一致するタグが2つ以上あるグループのみが対象
-    if (tagGroup.length >= 2) {
-      tagGroup.forEach(tagName => {
-        matchedTagSet.add(tagName);
-      });
-    }
-  });
-
-  // 全てのタグの完全な情報をMapに保存（「**」の判定で使用）
-  const tagDataMap = new Map();
-  site.tags.forEach(t => {
-    tagDataMap.set(t.name, t);
-  });
-
   // オプションのデフォルト値を設定
   options = options || {};
   const minFont = options.min_font || 12;
@@ -177,29 +141,9 @@ function customTagCloudHelper(options) {
     const adjustedRatio = Math.pow(ratio, boostRatio);
     const fontSize = minFont + (maxFont - minFont) * adjustedRatio;
 
-    let tagName = tag.name;
-    let suffix = '';
-
-    // 3. メインループでsuffixを付与
-    //    「***」の条件を最優先でチェック
-    if (matchedTagSet.has(tag.name)) {
-      suffix = '***';
-    }
-    // それ以外のタグで、記事数が1つの場合は「*」または「**」の判定
-    else if (tag.length === 1) {
-      suffix = '*';
-      const singlePost = tag.posts.first();
-      const otherTags = singlePost.tags.filter(t => t.name !== tag.name);
-      if (otherTags.length > 0 && otherTags.some(otherTag => {
-        const fullTagInfo = tagDataMap.get(otherTag.name);
-        return fullTagInfo && fullTagInfo.length === 1;
-      })) {
-        suffix = '**';
-      }
-    }
-
-    tagName += suffix;
-    tagName = tagName.replace(/ /g, '-');
+    // メンテ用の * / ** / *** マークは /doctor/ に移した (#2058)。
+    // クラウドは読者向けの導線なので、運営向けの印を混ぜない
+    const tagName = tag.name.replace(/ /g, '-');
     const tagLink = hexo.url_for(tag.path);
 
     result += `<a href="${tagLink}" style="font-size: ${fontSize.toFixed(2)}${fontUnit};">${tagName}</a>\n`;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1248,6 +1248,20 @@ code {
 .year-tabs input:checked + .tab_item + .tab_content {
   display: block;
 }
+/* /doctor/ の検査結果リスト */
+.doctor-list {
+  padding-left: 0;
+  list-style: none;
+}
+.doctor-list > li {
+  padding: 6px 0;
+  border-bottom: 1px solid #ECEBEB;
+}
+.doctor-note {
+  display: block;
+  color: #6e6e6e;
+  font-size: 0.9em;
+}
 .author-list {
   padding-inline-start: 0px;
   display: flex;

--- a/themes/future/layout/_partial/head.ejs
+++ b/themes/future/layout/_partial/head.ejs
@@ -118,7 +118,9 @@
     const noindexPaths = [
       'articles/index.html',
       'tags/index.html',
-      'categories/index.html'
+      'categories/index.html',
+      // 運営向けのメンテナンス画面。検索から人を呼ぶページではない (#2058)
+      'doctor/index.html'
     ];
 
     // 年月日のアーカイブパスを動的に追加

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -1,0 +1,61 @@
+<div class="container">
+  <%- partial('_partial/breadcrumb', {items: [
+        {label: 'ホーム', url: '/'},
+        {label: '記事ドクター'}
+      ]}) %>
+  <section id="main" class="margin-top-30">
+    <div class="footer-gap">
+      <h1 class="list-page margin-bottom-20">記事ドクター</h1>
+      ※運営向けのメンテナンス画面です。タグ・カテゴリの付与漏れの候補を機械判定で列挙します（提案であって、正とは限りません）
+      <% const checks = doctor_checks(); %>
+      <ul class="summary">
+        <li><span class="summary-count"><%= checks.suggestions.length %></span><br><span class="summary-label">カテゴリ見直し候補</span></li>
+        <li><span class="summary-count"><%= checks.untagged.length %></span><br><span class="summary-label">タグ無し</span></li>
+        <li><span class="summary-count"><%= checks.missingTotal %></span><br><span class="summary-label">タグ付け漏れ候補</span></li>
+      </ul>
+
+      <h2 class="bottom-content-header">カテゴリの見直し候補</h2>
+      ※タグの顔ぶれから推定したカテゴリが、現在のカテゴリと大きく食い違う記事（推定の確からしさ順）
+      <% if (checks.suggestions.length) { %>
+      <ul class="doctor-list">
+        <% checks.suggestions.forEach(function(s){ %>
+        <li>
+          <a href="<%- url_for(s.path) %>"><%= s.title %></a>
+          <span class="doctor-note"><%= s.actual %> → <strong><%= s.suggested %></strong>（票 <%= s.predScore %> 対 <%= s.actualScore %>）</span>
+        </li>
+        <% }) %>
+      </ul>
+      <% } else { %>
+      <p>該当なし</p>
+      <% } %>
+
+      <h2 class="bottom-content-header">タグが1つも無い記事</h2>
+      <% if (checks.untagged.length) { %>
+      <ul class="doctor-list">
+        <% checks.untagged.forEach(function(p){ %>
+        <li><a href="<%- url_for(p.path) %>"><%= p.title %></a></li>
+        <% }) %>
+      </ul>
+      <% } else { %>
+      <p>該当なし</p>
+      <% } %>
+
+      <h2 class="bottom-content-header">タイトルにタグ名を含むのに、そのタグが付いていない記事</h2>
+      ※英数3文字・和文4文字未満のタグ名は一般語に当たりやすいので照合していません
+      <ul class="doctor-list">
+        <% checks.missing.forEach(function(m){ %>
+        <li>
+          <details>
+            <summary><a href="<%- url_for(m.path) %>"><%= m.name %></a>（<%= m.posts.length %>記事）</summary>
+            <ul>
+              <% m.posts.forEach(function(p){ %>
+              <li><a href="<%- url_for(p.path) %>"><%= p.title %></a></li>
+              <% }) %>
+            </ul>
+          </details>
+        </li>
+        <% }) %>
+      </ul>
+    </div>
+  </section>
+</div>

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -11,7 +11,10 @@
       <ul class="summary">
         <li><span class="summary-count"><%= checks.suggestions.length %></span><br><span class="summary-label">カテゴリ見直し候補</span></li>
         <li><span class="summary-count"><%= checks.untagged.length %></span><br><span class="summary-label">タグ無し</span></li>
+        <li><span class="summary-count"><%= checks.overTagged.length %></span><br><span class="summary-label">タグ付けすぎ</span></li>
         <li><span class="summary-count"><%= checks.missingTotal %></span><br><span class="summary-label">タグ付け漏れ候補</span></li>
+        <li><span class="summary-count"><%= checks.nearDuplicates.length %></span><br><span class="summary-label">統合候補のタグ</span></li>
+        <li><span class="summary-count"><%= checks.singleUse.length %></span><br><span class="summary-label">1記事タグ</span></li>
       </ul>
 
       <h2 class="bottom-content-header">カテゴリの見直し候補</h2>
@@ -39,6 +42,41 @@
       <% } else { %>
       <p>該当なし</p>
       <% } %>
+
+      <h2 class="bottom-content-header">タグが付きすぎている記事</h2>
+      ※記事あたりのタグ数の中央値は3。その倍を超える7本以上を見直し候補として出しています
+      <% if (checks.overTagged.length) { %>
+      <ul class="doctor-list">
+        <% checks.overTagged.forEach(function(p){ %>
+        <li><a href="<%- url_for(p.path) %>"><%= p.title %></a> <span class="doctor-note"><%= p.count %>タグ</span></li>
+        <% }) %>
+      </ul>
+      <% } else { %>
+      <p>該当なし</p>
+      <% } %>
+
+      <h2 class="bottom-content-header">ほぼ重なるタグ（統合候補）</h2>
+      ※片方の記事すべてがもう片方にも付いていて、差が2本以内のペア。実質同じ集合に2つの名前が付いています。Go1.27 ⊆ Go のような差の大きい健全な階層は出しません
+      <% if (checks.nearDuplicates.length) { %>
+      <ul class="doctor-list">
+        <% checks.nearDuplicates.forEach(function(d){ %>
+        <li>
+          <a href="<%- url_for(d.aPath) %>"><%= d.a %></a>（<%= d.aN %>本）<%= d.identical ? ' ＝ ' : ' ⊆ ' %><a href="<%- url_for(d.bPath) %>"><%= d.b %></a>（<%= d.bN %>本）
+          <% if (d.identical) { %><span class="doctor-note">記事集合が完全に一致</span><% } %>
+        </li>
+        <% }) %>
+      </ul>
+      <% } else { %>
+      <p>該当なし</p>
+      <% } %>
+
+      <h2 class="bottom-content-header">1記事にしか使われていないタグ</h2>
+      ※「同居」は、同じ記事に1記事タグ同士が付いているもの。その記事のタグ付けがまとめて薄い可能性が高い
+      <ul class="doctor-list">
+        <% checks.singleUse.forEach(function(t){ %>
+        <li><a href="<%- url_for(t.path) %>"><%= t.name %></a><% if (t.lonelyPair) { %> <span class="doctor-note">1記事タグ同士が同居</span><% } %></li>
+        <% }) %>
+      </ul>
 
       <h2 class="bottom-content-header">タイトルにタグ名を含むのに、そのタグが付いていない記事</h2>
       ※英数3文字・和文4文字未満のタグ名は一般語に当たりやすいので照合していません


### PR DESCRIPTION
## 概要

Fixes #2058

運営向けのメンテナンス画面 **/doctor/** を新設しました。タグ・カテゴリの健全性チェックを機械判定で列挙します（提案であって自動修正はしません）。noindex 済み・メニューからのリンクなし。

## 検査内容（現在の検出数）

1. **カテゴリの見直し候補（42件）**: タグの顔ぶれから推定したカテゴリと現在の食い違い。leave-one-out 判定 + カテゴリ運用ルールの反映（受け皿の Programming / DevOps へ寄せる提案はしない・大→小カテゴリの提案は同票でも出し、小→大は2倍の票を要求）
2. **タグが1つも無い記事（0件）**
3. **タグが付きすぎている記事（16件）**: 中央値3の倍を超える7本以上
4. **タグ付け漏れ候補（192件）**: タイトルにタグ名を含むのに未付与。タグごとに畳んで表示。連載名由来のヒット（「Go 1.27 リリース連載」の「リリース」等）は除外
5. **ほぼ重なるタグ・統合候補（29件）**: 片方の記事すべてがもう片方にも付き差2本以内。例: Zuora＝サブスクリプション（完全一致）、PlantUML⊆UML、Cassandra⊆NoSQL。完全包含は309ペアあるため、Go1.27⊆Go のような健全な階層は出しません
6. **1記事タグ（45件）**: 1記事タグ同士が同じ記事に同居するものに印

## タグクラウドの * / ** / *** を移設・除去

上記 5・6 は、タグクラウドが `*` 系サフィックスで表現していた運営向けの印の移設です。読者向けの導線に運営の印が混ざっていたため、クラウド側からは除去しました（`custom_tagcloud` がシンプルになります）。

## 動作確認

- /doctor/ の6セクション・件数タイル・noindex を確認
- /tags/ のクラウドから * マークが消えたことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)