### PR TITLE
カテゴリの色を固定し、推移グラフを積み上げ+カテゴリ内訳にする

### DIFF
--- a/scripts/category_chart_helpers.js
+++ b/scripts/category_chart_helpers.js
@@ -92,8 +92,22 @@ const CATEGORY_COLORS = {
   'VR': '#bda29a',
 };
 
+// 上の対応表に無いカテゴリが増設されたときの予備色。固定16色と被らない色を
+// 名前順に決定的に割り当てるので、ページごとに色が変わることはない。
+// ただし暫定なので、ビルドログの警告を見たら対応表に追記する
+const SPARE_COLORS = ['#6e7074', '#59c4e6', '#edafda', '#93b7e3', '#546570', '#c4ccd3'];
+
 hexo.extend.helper.register('category_colors', function() {
-  return JSON.stringify(CATEGORY_COLORS);
+  const colors = Object.assign({}, CATEGORY_COLORS);
+  let spare = 0;
+  this.site.categories.map(c => c.name).sort().forEach(name => {
+    if (!colors[name]) {
+      colors[name] = SPARE_COLORS[spare % SPARE_COLORS.length];
+      spare++;
+      hexo.log.warn(`CATEGORY_COLORS に「${name}」の色がありません。暫定色 ${colors[name]} で描画します。scripts/category_chart_helpers.js に追記してください`);
+    }
+  });
+  return JSON.stringify(colors);
 });
 
 // 指定年の月別 × カテゴリ別の投稿数 (#2171)

--- a/scripts/category_chart_helpers.js
+++ b/scripts/category_chart_helpers.js
@@ -48,24 +48,15 @@ function getQuarterlyCategoryData() {
   // 3. X軸のラベル（時間軸）を生成し、ソートする
   const sortedTimeKeys = Array.from(dataByTimeBucket.keys()).sort();
 
-  // 4. EChartsのseries形式にデータを整形
+  // 4. カテゴリごとの時系列に整形する。チャートの種類（棒・折れ線）や色は
+  //    表示側の関心なので、ここでは名前とデータだけを返す
   const series = sortedCategoryObjects.map(category => {
     const catName = category.name;
     const data = sortedTimeKeys.map(timeKey => {
       const bucketData = dataByTimeBucket.get(timeKey);
       return bucketData.get(catName) || 0; // その期間に投稿がなければ0
     });
-
-    return {
-      name: catName,
-      type: 'line',
-      stack: 'Total',
-      areaStyle: {},
-      emphasis: {
-        focus: 'series'
-      },
-      data: data
-    };
+    return {name: catName, data: data};
   });
 
   return {
@@ -77,6 +68,53 @@ function getQuarterlyCategoryData() {
 
 // ヘルパーとして登録
 hexo.extend.helper.register('get_quarterly_category_data', getQuarterlyCategoryData);
+
+// カテゴリの色は名前で固定する (#2170)。系列順に既定パレットを当てると、
+// 著者やページごとにカテゴリの並びが違うため、同じ Programming が青だったり
+// 緑だったりして色が手がかりにならない。記事数の多いカテゴリから
+// 判別しやすい色を割り当てている（ECharts 既定9色 + 旧パレット7色）
+const CATEGORY_COLORS = {
+  'Programming': '#5470c6',
+  'DevOps': '#91cc75',
+  'Infrastructure': '#fac858',
+  'Frontend': '#ee6666',
+  'Culture': '#73c0de',
+  'DataScience': '#3ba272',
+  'DB': '#fc8452',
+  'Mobile': '#9a60b4',
+  'IoT': '#ea7ccc',
+  'Business': '#c23531',
+  'DataEngineering': '#2f4554',
+  'Security': '#61a0a8',
+  'Management': '#d48265',
+  'AIDD': '#749f83',
+  '認証認可': '#ca8622',
+  'VR': '#bda29a',
+};
+
+hexo.extend.helper.register('category_colors', function() {
+  return JSON.stringify(CATEGORY_COLORS);
+});
+
+// 指定年の月別 × カテゴリ別の投稿数 (#2171)
+hexo.extend.helper.register('get_monthly_category_data', function(year) {
+  const byCat = new Map(); // カテゴリ -> 12ヶ月分の配列
+  const catTotal = new Map();
+  this.site.posts.forEach(post => {
+    if (String(post.date.year()) !== String(year)) return;
+    const cat = post.categories.first();
+    if (!cat) return;
+    if (!byCat.has(cat.name)) byCat.set(cat.name, new Array(12).fill(0));
+    byCat.get(cat.name)[post.date.month()]++;
+    catTotal.set(cat.name, (catTotal.get(cat.name) || 0) + 1);
+  });
+  const months = [];
+  for (let m = 1; m <= 12; m++) months.push(`${m}月`);
+  const series = [...catTotal.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([name]) => ({name, data: byCat.get(name)}));
+  return JSON.stringify({months, series});
+});
 
 /**
  * カテゴリ1つ分の統計。件数・寄稿者数（累計・直近1年）と

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1219,6 +1219,33 @@ code {
    年ごとの ID ルールを毎年 CSS に足さずに済むよう、input+label+content を
    隣接させて flex の order で並べ替える。ラベルだけ order:1 で帯に並び、
    選択された組のコンテンツが order:2 + 全幅で下段に出る */
+/* 期間ページのグラフ切り替えタブ (#2171)。year-tabs と同じ input+label+content
+   方式だが、非表示側を display:none にすると ECharts が幅0のまま初期化されて
+   描画が壊れるため、高さ0で畳んで幅は保つ */
+.tabs.chart-tabs {
+  display: flex;
+  flex-wrap: wrap;
+}
+.chart-tabs input {
+  display: none;
+}
+.chart-tabs .tab_item {
+  float: none;
+  order: 1;
+}
+.chart-tabs .tab_content {
+  order: 2;
+  width: 100%;
+  display: block;
+  height: 0;
+  padding: 0 22px;
+  overflow: hidden;
+}
+.chart-tabs input:checked + .tab_item + .tab_content {
+  height: auto;
+  padding: 18px 22px;
+  overflow: visible;
+}
 .tabs.year-tabs {
   /* 後方の .tabs { display: flow-root } と同詳細度だと記述順で負けて
      flex が効かず、ラベルがインライン扱いで選択コンテンツの後ろに

--- a/themes/future/layout/_partial/posts-chart.ejs
+++ b/themes/future/layout/_partial/posts-chart.ejs
@@ -3,15 +3,17 @@
     ランキングと同じ radio + label 方式で JS は足さない。
     year が渡されればその年の月別、無ければ全期間の四半期別 %>
 <div class="nav tabs chart-tabs">
-  <input id="chart-tab-period" type="radio" name="chart_tab" checked>
-  <label tabindex="0" class="tab_item" for="chart-tab-period"><%= year ? '月別' : '四半期別' %></label>
-  <div class="tab_content">
-    <div id="chart-period" style="width:100%;min-height:250px"></div>
-  </div>
-  <input id="chart-tab-category" type="radio" name="chart_tab">
+  <%# 既定はカテゴリ別。週の粗密より、何のジャンルが書かれているかの方が
+      最初に見たい情報 %>
+  <input id="chart-tab-category" type="radio" name="chart_tab" checked>
   <label tabindex="0" class="tab_item" for="chart-tab-category">カテゴリ別</label>
   <div class="tab_content">
     <div id="chart-category" style="width:100%;min-height:250px"></div>
+  </div>
+  <input id="chart-tab-period" type="radio" name="chart_tab">
+  <label tabindex="0" class="tab_item" for="chart-tab-period"><%= year ? '月別' : '四半期別' %></label>
+  <div class="tab_content">
+    <div id="chart-period" style="width:100%;min-height:250px"></div>
   </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>

--- a/themes/future/layout/_partial/posts-chart.ejs
+++ b/themes/future/layout/_partial/posts-chart.ejs
@@ -1,0 +1,54 @@
+<%# 投稿推移のグラフ。期間内訳（週の積み上げ）とカテゴリ内訳は別の軸で
+    同時に積めないため、タブで切り替える (#2171)。
+    ランキングと同じ radio + label 方式で JS は足さない。
+    year が渡されればその年の月別、無ければ全期間の四半期別 %>
+<div class="nav tabs chart-tabs">
+  <input id="chart-tab-period" type="radio" name="chart_tab" checked>
+  <label tabindex="0" class="tab_item" for="chart-tab-period"><%= year ? '月別' : '四半期別' %></label>
+  <div class="tab_content">
+    <div id="chart-period" style="width:100%;min-height:250px"></div>
+  </div>
+  <input id="chart-tab-category" type="radio" name="chart_tab">
+  <label tabindex="0" class="tab_item" for="chart-tab-category">カテゴリ別</label>
+  <div class="tab_content">
+    <div id="chart-category" style="width:100%;min-height:250px"></div>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
+<script type="text/javascript">
+  const periodData = <%- year ? posts_stack_series(year) : posts_stack_series() %>;
+  echarts.init(document.getElementById('chart-period')).setOption({
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
+    xAxis: { type: 'category', data: periodData.buckets },
+    yAxis: { type: 'value', min: 0, max: <%= year ? max_posts(year) : max_posts() %> },
+    <%# 棒の高さが期間の合計、内訳はその中の週。第1週→第5週と順序に意味が
+        あるので同系の濃淡で塗る。ページャの現在地と同じ #337ab7 を最も濃い段に %>
+    color: ['#337ab7', '#6097c7', '#8db5d7', '#b6cfe5', '#d2e2ef'],
+    series: periodData.slots.map((data, i) => ({
+      name: periodData.labels[i],
+      type: 'bar',
+      stack: 'posts',
+      data
+    }))
+  });
+
+  const catData = <%- year ? get_monthly_category_data(year) : JSON.stringify(get_quarterly_category_data()) %>;
+  const catColors = <%- category_colors() %>;
+  echarts.init(document.getElementById('chart-category')).setOption({
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0, type: 'scroll' },
+    grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
+    xAxis: { type: 'category', data: catData.<%= year ? 'months' : 'quarters' %> },
+    yAxis: { type: 'value', min: 0, max: <%= year ? max_posts(year) : max_posts() %> },
+    <%# カテゴリは順序に意味が無いので色相で分け、名前で固定する (#2170) %>
+    series: catData.series.map(s => ({
+      name: s.name,
+      type: 'bar',
+      stack: 'categories',
+      itemStyle: { color: catColors[s.name] },
+      data: s.data
+    }))
+  });
+</script>

--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -35,41 +35,8 @@
       <li class="summary-sub"><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
       <li class="summary-sub"><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
     </ul>
-    <h2 class="bottom-content-header">月別 投稿数の推移</h2>
-    <div>
-      <div id="chart" style="width:100%;min-height:250px"></div>
-      <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
-      <script type="text/javascript">
-        const chartData = <%- posts_stack_series(page.year) %>;
-        let myChart = echarts.init(document.getElementById('chart'));
-        let option = {
-          tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
-          legend: { bottom: 0 },
-          grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
-          xAxis: {
-              type: 'category',
-              data: chartData.buckets
-          },
-          yAxis: {
-              type: 'value',
-              min: 0,
-              max: <%= max_posts(page.year) %>
-          },
-          <%# 月の棒を、その月の第何週かで積み上げる。高さが月の合計、
-              内訳で週ごとの粗密が見える。
-              色はページャの現在地と同じ #337ab7 を最も濃い段にして、
-              そこから白へ寄せる。サイトに無い濃い青を足さない %>
-          color: ['#337ab7', '#6097c7', '#8db5d7', '#b6cfe5', '#d2e2ef'],
-          series: chartData.slots.map((data, i) => ({
-              name: chartData.labels[i],
-              type: 'bar',
-              stack: 'posts',
-              data
-          }))
-        };
-        myChart.setOption(option);
-      </script>
-    </div>
+    <h2 class="bottom-content-header">投稿数の推移</h2>
+    <%- partial('_partial/posts-chart', {year: page.year}) %>
     <% } else { %>
     <h1 class="list-page">すべての記事</h1>
     <%# 統計は1行に集約。シェアの内訳を一段小さくするのは他ページと同じ (#2096) %>
@@ -96,41 +63,8 @@
     %>
     <%- list_archives({format: "YYYY", type:"yearly", transform:trans}) %>
 
-    <h2 class="bottom-content-header">四半期別 投稿数の推移</h2>
-    <div>
-      <div id="chart" style="width:100%;min-height:250px"></div>
-      <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
-      <script type="text/javascript">
-        const chartData = <%- posts_stack_series() %>;
-        let myChart = echarts.init(document.getElementById('chart'));
-        let option = {
-          tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
-          legend: { bottom: 0 },
-          grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
-          xAxis: {
-              type: 'category',
-              data: chartData.buckets
-          },
-          yAxis: {
-              type: 'value',
-              min: 0,
-              max: <%= max_posts() %>
-          },
-          <%# 月の棒を、その月の第何週かで積み上げる。高さが月の合計、
-              内訳で週ごとの粗密が見える。
-              色はページャの現在地と同じ #337ab7 を最も濃い段にして、
-              そこから白へ寄せる。サイトに無い濃い青を足さない %>
-          color: ['#337ab7', '#6097c7', '#8db5d7', '#b6cfe5', '#d2e2ef'],
-          series: chartData.slots.map((data, i) => ({
-              name: chartData.labels[i],
-              type: 'bar',
-              stack: 'posts',
-              data
-          }))
-        };
-        myChart.setOption(option);
-      </script>
-    </div>
+    <h2 class="bottom-content-header">投稿数の推移</h2>
+    <%- partial('_partial/posts-chart', {year: null}) %>
 
     <% } %>
     <%# 見出しの語彙は他の一覧ページに合わせる。ここは全記事の時系列リストなので

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -62,6 +62,7 @@
       <%# カテゴリごとの積み上げ棒 (#2138)。期間の穴埋めと軸の下限12ヶ月は
           ヘルパー側（author_monthly_chart）が持つ (#2140) %>
       const chartData = <%- author_monthly_chart(page.author) %>;
+      const catColors = <%- category_colors() %>;
       <%# 軸が12ヶ月以下（投稿の少ない著者）なら月ラベルが全部読めるので毎月出す。
           長期の著者は潰れるため年の変わり目だけにする (#2135) %>
       const monthlyLabels = chartData.months.length <= 12;
@@ -94,7 +95,9 @@
             <%# 上限は最低3。月1本の著者が天井に張り付いて見えるのを避ける %>
             max: value => Math.max(3, value.max)
         },
-        series: chartData.series
+        <%# 色はカテゴリ名で固定 (#2170)。系列順に任せると著者ごとに
+            同じカテゴリの色が変わってしまう %>
+        series: chartData.series.map(s => Object.assign({}, s, { itemStyle: { color: catColors[s.name] } }))
       };
       myChart.setOption(option);
     </script>

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -41,14 +41,23 @@
 
     <script type="text/javascript">
       const chartData = <%- JSON.stringify(get_quarterly_category_data()) %>;
+      const catColors = <%- category_colors() %>;
       const myChart = echarts.init(document.getElementById('category-chart'));
       const option = {
-        tooltip: { trigger: 'axis', axisPointer: { type: 'cross', label: { backgroundColor: '#6a7985' } } },
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
         legend: { data: chartData.categories, type: 'scroll', orient: 'horizontal', left: 'center', top: 'bottom' },
         grid: { left: '3%', right: '4%', bottom: '15%', containLabel: true },
-        xAxis: [ { type: 'category', boundaryGap: false, data: chartData.quarters } ],
+        xAxis: [ { type: 'category', boundaryGap: true, data: chartData.quarters } ],
         yAxis: [ { name: '投稿数', type: 'value' } ],
-        series: chartData.series
+        <%# 16本の折れ線の重なりは読めないので積み上げ棒にする (#2169)。
+            棒の高さが四半期の合計、内訳がカテゴリ。色は名前で固定 (#2170) %>
+        series: chartData.series.map(s => ({
+          name: s.name,
+          type: 'bar',
+          stack: 'categories',
+          itemStyle: { color: catColors[s.name] },
+          data: s.data
+        }))
       };
       myChart.setOption(option);
     </script>


### PR DESCRIPTION
## 概要

Fixes #2169, Fixes #2170, Fixes #2171

グラフ3件をまとめて対応しました。土台は「カテゴリ色の固定」（#2170）で、それを /categories/ の積み上げ化（#2169）と期間ページのカテゴリ内訳タブ（#2171）が使います。

## 対応内容

### #2170 カテゴリの色を名前で固定

- `CATEGORY_COLORS`（`category_chart_helpers.js`）に16カテゴリ→色の対応を1箇所で定義。記事数の多いカテゴリから判別しやすい色（ECharts 既定9色 + 旧パレット7色）
- 著者ページの月別チャート・/categories/ の推移・期間ページのカテゴリ内訳、すべて同じ対応表を参照。**どのページ・どの著者でも Programming は青、DB はオレンジ**になります
- 期間内訳（週）の青の濃淡は据え置き（あちらは第1週→第5週と順序に意味があるため同系色が正しい、という Issue の整理どおり）

### #2169 /categories/ の推移グラフを積み上げ棒に

16本の折れ線の重なりを、棒の高さ＝四半期の合計・内訳＝カテゴリの積み上げに変更。期間ページと読み方が揃います。

### #2171 期間ページにカテゴリ別内訳のタブ

- /articles/（四半期別）と /articles/YYYY/（月別）のグラフに「カテゴリ別」タブを追加。ランキングと同じ radio + label 方式で JS は足していません
- 実装の要点: 非表示タブを `display:none` にすると **ECharts が幅0のまま初期化されて描画が壊れる**ため、`.chart-tabs` は高さ0で畳んで幅を保つ作りにしています
- 年ページ用に `get_monthly_category_data(year)` ヘルパーを新設。全期間は既存の四半期別データを流用
- 重複していた2つのグラフ設定は `_partial/posts-chart.ejs` に集約

## 動作確認

- /categories/（積み上げ棒・固定色）、/articles/ と /articles/2026/（タブ切り替え・カテゴリ内訳）、/authors/真野隼記/（固定色）の描画を確認
- タブ切り替えの実挙動（非表示側の初期化）はブラウザで確認してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)
