### PR TITLE
コードブロック内の見出しの誤変換を直す

### DIFF
--- a/source/_posts/2023/20230202a_Go_1.20_vetのアップデート.md
+++ b/source/_posts/2023/20230202a_Go_1.20_vetのアップデート.md
@@ -34,7 +34,7 @@ Goの標準ライブラリに組み込まれている、コンパイラによっ
 * [staticcheck](https://github.com/dominikh/go-tools)
 * [errcheck](https://github.com/kisielk/errcheck)
 
-# ループ変数が関数内に多重にネストされていた場合の検知
+## ループ変数が関数内に多重にネストされていた場合の検知
 
 次のようなコードはよくあるケースでバグを含んでいます。
 
@@ -80,11 +80,11 @@ go1.20ではこのような問題を検知してくれるようになります�
 
 ```sh
 >go1.20rc3 vet
-## /src
+# /src
 .\main_test.go:60:16: loop variable tt captured by func literal
 ```
 
-# 不正な時刻形式の検知
+## 不正な時刻形式の検知
 
 time layoutが2006-01-02(yyyy-mm-dd) ではなく、2006-02-01(yyyy-dd-mm) となっていた場合に検知してくれるようになりました。
 わたしにとってはいまいちピンときませんが、アメリカ式時刻が馴染み深い方は間違えてしまったりするのでしょうか...？
@@ -113,7 +113,7 @@ juju/juju@f992f35
 ただ、 [Go 1.20連載の4本目](https://future-architect.github.io/articles/20230127a/)で宮永さんに紹介いただいている通りlayoutにDateTime,DateOnly,TimeOnlyが追加されました。
 新しいlayoutを使用することでこのミスは防ぐことができると思慮します。
 
-# おわりに
+## おわりに
 
 今回はgo vetのアップデートについて紹介させていただきました。
 


### PR DESCRIPTION
Refs #2070

`20230202a_Go_1.20_vetのアップデート.md` が**壊れた状態で公開されています**。

```
18: ## はじめに                    ← 変換済み
22: ## そもそもvetとは              ← 変換済み
22: # ループ変数が…                 ← 未変換
68: ## /src                       ← コードブロック内なのに変換された
72: # 不正な時刻形式の検知            ← 未変換
101: # おわりに                     ← 未変換
```

## 経緯

#2159 のレビュー中にこの誤変換が見つかり、修正コミットを用意しましたが、**PR に反映される前にマージされた**ため取り残されました。

## 原因

変換スクリプトが**1行で完結するインラインコードをフェンスと誤認**していました。

```
27: ```go tool vet help```   ← フェンスの開始と誤認
41: ```go                     ← 開始のはずが「閉じ」と解釈される
83: # /src                    ← コードブロック内なのに見出し扱い
```

CommonMark では、バッククォートのフェンスは**情報文字列にバッククォートを含められません**。

全1467記事のうちこの誤認を起こす行を持つのは3記事で、2022年の1件は #2183 で修正済み、残る1件は結果的に正しく変換されていました。**本件が最後の1件**です。

## 修正後

```
18: ## はじめに
22: ## そもそもvetとは
37: ## ループ変数が関数内に多重にネストされていた場合の検知
83: # /src          ← コードブロック内。手を触れない
87: ## 不正な時刻形式の検知
116: ## おわりに
```

## 検証

部分的に変換済みのファイルの修復なので、通常の「HEAD +1 == 新」では検証できません。**変換前の原本**（#2159 の直前）から作り直し、次を確認しました。

| 検証 | 結果 |
| --- | --- |
| 原本の見出しレベル +1 == 修正後 | ✅ |
| 行数が変わっていない | ✅ |
| 原本との差分はすべて行頭への `#` 1文字追加 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)