### PR TITLE
よく読まれている記事の古さペナルティを1.5乗にする

### DIFF
--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -36,10 +36,17 @@ hexo.extend.helper.register('popular_posts_in', function(posts, limit) {
   if (limit === 0) return '';
   // PV は累積なので、古い記事ほど有利になる。経過年数で割って、
   // 何年もかけて積んだ数字と最近読まれている数字を並べられるようにする。
-  // 分母を 1+年数 にしているのは、公開直後の記事で 0 除算にしないため
+  // 分母を 1+... にしているのは、公開直後の記事で 0 除算にしないため。
+  // 年数のペナルティは線形だと弱く、累積PVの大きい古典が上位に残り続けた。
+  // 2乗だと直近1年の記事しか残らずきつい。中間の1.5乗にする
+  // （1年落ち=1/2、2年=1/3.8、4年=1/9）。中間はこの一点だけで、
+  // 効きが合わなければ線形か2乗に倒す。連続的な係数調整はしない (#2174)
   const YEAR = 365 * 24 * 60 * 60 * 1000;
   const now = Date.now();
-  const score = post => getGA4PV('/' + post.path) / (1 + (now - post.date.valueOf()) / YEAR);
+  const score = post => {
+    const years = (now - post.date.valueOf()) / YEAR;
+    return getGA4PV('/' + post.path) / (1 + years * Math.sqrt(years));
+  };
 
   const ranked = posts
     .map(post => ({post, pv: getGA4PV('/' + post.path), score: score(post)}))


### PR DESCRIPTION
## 概要

Fixes #2174

カテゴリ・タグページの「よく読まれている記事」の古さペナルティを、線形から**1.5乗**にしました。

```
score = pv / (1 + 経過年数^1.5)
```

## なぜ1.5乗か

- 線形（従来）は弱く、累積PVの大きい古典が上位に残り続けた
- 2乗は直近1年の記事しか残らずきつい（検証済み）
- **その中間は1.5乗の一点だけ**。効きが合わなければ線形か2乗に倒す方針で、連続的な係数調整はしない（Issue の「なぜその強さかを1文で言える」条件）
- 公開日だけから決まる簡易ルールで、GA の計測時期などのファクトには依存しない

## 効き方の比較（Programming カテゴリの上位4件）

| 順位 | 線形（従来） | 1.5乗（本PR） | 2乗（参考） |
| --- | --- | --- | --- |
| 1 | Python型ヒント(4年) | 龍が如く(2.4年) | アーキチーム(0.7年) |
| 2 | AWSリトライ | アーキチーム(0.7年) | 非同期設計(0.5年) |
| 3 | 龍が如く(2.4年) | AWSリトライ | go fix(直近) |
| 4 | アーキチーム(0.7年) | Python型ヒント(4年) | バッチ設計 |

古典（龍が如く）は残しつつ最古参が後退し、新しめが浮上する中間の効き方です。

ホームのランキング（トレンド/年間人気/SNS）は別ヘルパーのため影響ありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)