### PR TITLE
著者ページに「よく読まれている記事」を出す

### DIFF
--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -101,6 +101,14 @@
       };
       myChart.setOption(option);
     </script>
+    <%# その著者の中でよく読まれている記事。タグ・カテゴリページと同じく
+        新着一覧の直前に置き、ページ間でコンテンツ構成を揃える (#2189)。
+        順位・件数の規則は共有ヘルパー（popular_posts_in）側 %>
+    <% const authorPopular = popular_posts_in(site.posts.filter(function(p){ return p.author === page.author; }).toArray()); %>
+    <% if (authorPopular) { %>
+    <h2 class="bottom-content-header">よく読まれている記事</h2>
+    <%- authorPopular %>
+    <% } %>
     <% } else { %>
     <%
         const perPage = 25;


### PR DESCRIPTION
## 概要

Fixes #2189

タグ・カテゴリの個別ページにある「よく読まれている記事」を、著者個人ページにも追加しました。ページ間でコンテンツ構成が揃い、読者が迷いません。

## 対応

- 位置はタグ・カテゴリページと同じく**新着記事一覧の直前**（1ページ目のみ）
- 共有ヘルパー `popular_posts_in` をそのまま使うため、順位の古さペナルティと、記事数に応じた件数規則（#2173: 3本以下は出さない・4〜7本は2件・8本以上は4件）が自動で効きます
  - レビュー中の #2188（1.5乗化）がマージされれば、著者ページにも同時に適用されます

## 動作確認

- 真野隼記（153本）: 4件表示（新着一覧の直前）
- 小川達（1本）: 見出しごと非表示（#2173 の規則どおり）

🤖 Generated with [Claude Code](https://claude.com/claude-code)