### PR TITLE
著者ページの並びをカテゴリ・タグページに揃える

### DIFF
--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -28,33 +28,8 @@
     <p class="summary-note">直近1年間の投稿はありません</p>
     <% } %>
     <%- get_profile(page.author) %>
-    <%# タグ・カテゴリのリンクは通常の表現のまま（チップの右肩に著者内の
-        件数を出すと、他ページの「タグ総数」と同じ表現で違う意味になり、
-        クリック先の件数とも食い違う）。この著者が何本書いたかは、
-        リンクを囲むパネル側が「n本投稿」として名乗る (#2129) %>
-    <% if (as.topCategories.length) { %>
-    <h2 class="bottom-content-header">よく投稿するカテゴリ</h2>
-    <ul class="tendency-panels">
-      <% as.topCategories.forEach(function(c){ %>
-      <li class="tendency-panel">
-        <%# カテゴリはタグと誤認しないようチップにせず、記事メタデータと同じテキストリンク %>
-        <a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事へ"><%= c.name %></a>
-        <span class="tendency-panel-count"><%= c.count %>本投稿</span>
-      </li>
-      <% }) %>
-    </ul>
-    <% } %>
-    <% if (as.topTags.length) { %>
-    <h2 class="bottom-content-header">よく使うタグ</h2>
-    <ul class="tendency-panels">
-      <% as.topTags.forEach(function(t){ %>
-      <li class="tendency-panel">
-        <a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.name %> タグの記事へ"><%= t.name %></a>
-        <span class="tendency-panel-count"><%= t.count %>本投稿</span>
-      </li>
-      <% }) %>
-    </ul>
-    <% } %>
+    <%# 並びはカテゴリ・タグページの「統計 → よく読まれている記事 → 新着」に
+        揃える (#2191)。月別投稿数のグラフは統計の一種とみなして統計の直後に置く %>
     <h2 class="bottom-content-header">月別投稿数</h2>
     <div id="chart" style="width:95%;min-height:250px"></div>
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
@@ -109,6 +84,40 @@
     <h2 class="bottom-content-header">よく読まれている記事</h2>
     <%- authorPopular %>
     <% } %>
+    <%# 著者ページだけカテゴリとタグの2つがあるので、左右2列に統合して
+        縦の長さを抑える。見出しの動詞は「よく使う」で統一 (#2191)。
+        リンクは通常の表現のまま（チップの右肩に著者内の件数を出すと、
+        他ページの「タグ総数」と同じ表現で違う意味になり、クリック先の
+        件数とも食い違う）。この著者が何本書いたかはパネル側が名乗る (#2129) %>
+    <div class="row">
+      <% if (as.topCategories.length) { %>
+      <div class="col-12 col-md-6">
+        <h2 class="bottom-content-header">よく使うカテゴリ</h2>
+        <ul class="tendency-panels">
+          <% as.topCategories.forEach(function(c){ %>
+          <li class="tendency-panel">
+            <%# カテゴリはタグと誤認しないようチップにせず、記事メタデータと同じテキストリンク %>
+            <a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事へ"><%= c.name %></a>
+            <span class="tendency-panel-count"><%= c.count %>本投稿</span>
+          </li>
+          <% }) %>
+        </ul>
+      </div>
+      <% } %>
+      <% if (as.topTags.length) { %>
+      <div class="col-12 col-md-6">
+        <h2 class="bottom-content-header">よく使うタグ</h2>
+        <ul class="tendency-panels">
+          <% as.topTags.forEach(function(t){ %>
+          <li class="tendency-panel">
+            <a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.name %> タグの記事へ"><%= t.name %></a>
+            <span class="tendency-panel-count"><%= t.count %>本投稿</span>
+          </li>
+          <% }) %>
+        </ul>
+      </div>
+      <% } %>
+    </div>
     <% } else { %>
     <%
         const perPage = 25;


### PR DESCRIPTION
## 概要

Fixes #2191

著者ページのセクション順をカテゴリ・タグページと整合させました。

## 対応内容

1. **並び替え**: 統計 → **月別投稿数のグラフ**（統計の一種とみなす）→ **よく読まれている記事** → よく使うカテゴリ・タグ → 新着記事一覧
2. **カテゴリとタグを左右2列に統合**（`col-12 col-md-6`。モバイルは縦積み）。著者ページだけ2つあるため、縦の長さを抑えます
3. **見出しの表現統一**: 「よく投稿するカテゴリ」→「**よく使うカテゴリ**」（ページ内で「よく投稿する〜」「よく使う〜」と動詞が揺れていた）

## 動作確認

- /authors/真野隼記/ で見出しの順序（月別投稿数 → よく読まれている記事 → よく使うカテゴリ｜よく使うタグ → 新着記事）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)