### PR TITLE
カテゴリページのよく使われるタグを tendency-panel に揃える

### DIFF
--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -42,16 +42,19 @@
     <%- popular %>
     <% } %>
     <% if (cs && cs.topTags.length) { %>
-    <%# 一覧と同じ代表タグ。マークアップも /categories/ と揃える。
-        カテゴリ名は h1 が名乗っているので見出しでは繰り返さない %>
+    <%# カテゴリ名は h1 が名乗っているので見出しでは繰り返さない。
+        著者ページの「よく使うタグ」・タグページの「関連タグ」と同じ
+        tendency-panel の作りに揃える。チップは通常のタグ表現のまま、
+        カテゴリ内の本数はパネル側が「n本で使用」と名乗る (#2129) %>
     <h2 class="bottom-content-header">よく使われるタグ</h2>
-    <div class="blog-tags">
-      <ul class="tag-list">
-        <% cs.topTags.forEach(function(t){ %>
-        <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= page.category %> カテゴリの <%= t.name %> の記事 <%= t.count %>本"><%= t.name %><span class="tag-list-count"><%= t.count %></span></a></li>
-        <% }) %>
-      </ul>
-    </div>
+    <ul class="tendency-panels">
+      <% cs.topTags.forEach(function(t){ %>
+      <li class="tendency-panel">
+        <a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.name %> タグの記事へ"><%= t.name %></a>
+        <span class="tendency-panel-count"><%= t.count %>本で使用</span>
+      </li>
+      <% }) %>
+    </ul>
     <% } %>
     <% } %>
     <% if (page.current !== 1) { %>


### PR DESCRIPTION
## 概要

カテゴリ個別ページの「よく使われるタグ」が、著者ページ（よく使うタグ）・タグページ（関連タグ）のパネル化後も、チップの右肩にカテゴリ内件数を載せる元の表記のまま残っており、タグ表示の揺れになっていました。

## 対応

tendency-panel 形式に統一しました。

```
┌────────────────────┐ ┌────────────────────┐
│ [Go] 203本で使用     │ │ [Java] 31本で使用   │
└────────────────────┘ └────────────────────┘
```

- チップは通常のタグ表現（件数なし・クリック先はタグページ全体）に戻り、#2129 の「チップの意味を揺らさない」原則にも沿います
- 注記は他ページと同じ「数字＋動詞」型: 著者=「61本投稿」／関連タグ=「15本を共有」／カテゴリ=「**203本で使用**」

## 補足

/categories/ 一覧の各行に出る代表タグ（チップ右肩に件数）は、行内の注記が意味を宣言しているコンパクト表示のため今回は据え置いています。こちらも揃えたければ言ってください（1行あたりの高さが増えます）。

## 動作確認

- /categories/Programming/ でパネル表示（Go 203本で使用 など）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)