### PR TITLE
著者ページのカテゴリ・タグを1列に戻す

### DIFF
--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -84,40 +84,35 @@
     <h2 class="bottom-content-header">よく読まれている記事</h2>
     <%- authorPopular %>
     <% } %>
-    <%# 著者ページだけカテゴリとタグの2つがあるので、左右2列に統合して
-        縦の長さを抑える。見出しの動詞は「よく使う」で統一 (#2191)。
+    <%# 全幅の h2 セクションを縦に積む。左右2列にすると、直前の
+        「よく読まれている記事」の2列カードと列境界が揃ってしまい、
+        無関係な組に見える (#2191)。見出しの動詞は「よく使う」で統一。
         リンクは通常の表現のまま（チップの右肩に著者内の件数を出すと、
         他ページの「タグ総数」と同じ表現で違う意味になり、クリック先の
         件数とも食い違う）。この著者が何本書いたかはパネル側が名乗る (#2129) %>
-    <div class="row">
-      <% if (as.topCategories.length) { %>
-      <div class="col-12 col-md-6">
-        <h2 class="bottom-content-header">よく使うカテゴリ</h2>
-        <ul class="tendency-panels">
-          <% as.topCategories.forEach(function(c){ %>
-          <li class="tendency-panel">
-            <%# カテゴリはタグと誤認しないようチップにせず、記事メタデータと同じテキストリンク %>
-            <a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事へ"><%= c.name %></a>
-            <span class="tendency-panel-count"><%= c.count %>本投稿</span>
-          </li>
-          <% }) %>
-        </ul>
-      </div>
-      <% } %>
-      <% if (as.topTags.length) { %>
-      <div class="col-12 col-md-6">
-        <h2 class="bottom-content-header">よく使うタグ</h2>
-        <ul class="tendency-panels">
-          <% as.topTags.forEach(function(t){ %>
-          <li class="tendency-panel">
-            <a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.name %> タグの記事へ"><%= t.name %></a>
-            <span class="tendency-panel-count"><%= t.count %>本投稿</span>
-          </li>
-          <% }) %>
-        </ul>
-      </div>
-      <% } %>
-    </div>
+    <% if (as.topCategories.length) { %>
+    <h2 class="bottom-content-header">よく使うカテゴリ</h2>
+    <ul class="tendency-panels">
+      <% as.topCategories.forEach(function(c){ %>
+      <li class="tendency-panel">
+        <%# カテゴリはタグと誤認しないようチップにせず、記事メタデータと同じテキストリンク %>
+        <a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事へ"><%= c.name %></a>
+        <span class="tendency-panel-count"><%= c.count %>本投稿</span>
+      </li>
+      <% }) %>
+    </ul>
+    <% } %>
+    <% if (as.topTags.length) { %>
+    <h2 class="bottom-content-header">よく使うタグ</h2>
+    <ul class="tendency-panels">
+      <% as.topTags.forEach(function(t){ %>
+      <li class="tendency-panel">
+        <a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.name %> タグの記事へ"><%= t.name %></a>
+        <span class="tendency-panel-count"><%= t.count %>本投稿</span>
+      </li>
+      <% }) %>
+    </ul>
+    <% } %>
     <% } else { %>
     <%
         const perPage = 25;


### PR DESCRIPTION
## 概要

Refs #2191（レイアウトの続き）

著者ページの「よく使うカテゴリ」「よく使うタグ」の左右2列を、全幅の縦積みに戻します。

## 理由

- 直前の「よく読まれている記事」が `col-md-6` の2列カードで、直下の2列グリッドと**列境界がぴったり揃う**ため、「左のカードとカテゴリ」「右のカードとタグ」が組になっているように見えていた（存在しない対応関係の示唆）
- カテゴリ・タグページは「全幅の h2 セクションを縦に積む」文法で統一されており、著者ページだけ2列にする理由が「縦の節約」しかなかった。tendency-panel は折り返す短い行なので、節約効果は panel 1〜2行分しかない

見出し・パネルの作り・文言は変更ありません。

## 動作確認

- ローカルで /authors/真野隼記/ の2セクションが全幅の縦積みで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)