### PR TITLE
カテゴリページに「関連カテゴリ」を追加する

### DIFF
--- a/scripts/category_chart_helpers.js
+++ b/scripts/category_chart_helpers.js
@@ -182,3 +182,43 @@ hexo.extend.helper.register('category_stats', function(name) {
   const category = this.site.categories.findOne({name});
   return category ? buildCategoryStats.call(this, category) : null;
 });
+
+// 関連カテゴリ (#2200)。独自の採点は持ち込まず、ページに出ている2つの規則の
+// 合成で定める: このカテゴリの「よく使われるタグ」（上位5）が、他に
+// 「よく使われているカテゴリ」（タグページと同じ 2本以上かつ10%以上）。
+// 読者がカテゴリ→タグ→カテゴリとリンクを辿っても同じ結論になる。
+// 登壇レポート・初心者向けのような形式タグ経由の関連もあえて除外しない。
+// 根拠タグを注記で名乗るので、関連の質は読者が判断できる
+hexo.extend.helper.register('related_categories', function(name) {
+  const category = this.site.categories.findOne({name});
+  if (!category) return [];
+  const {topTags} = buildCategoryStats.call(this, category);
+  const related = new Map();
+  topTags.forEach(t => {
+    const tag = this.site.tags.findOne({name: t.name});
+    if (!tag) return;
+    const total = tag.posts.length;
+    const byCat = new Map();
+    tag.posts.forEach(post => {
+      post.categories.forEach(c => {
+        if (c.name === name) return;
+        byCat.set(c.name, (byCat.get(c.name) || 0) + 1);
+      });
+    });
+    byCat.forEach((count, catName) => {
+      if (count < 2 || count / total < 0.10) return;
+      if (!related.has(catName)) {
+        const c = this.site.categories.findOne({name: catName});
+        related.set(catName, {name: catName, path: c ? c.path : `categories/${catName}/`, tags: [], strength: 0});
+      }
+      const e = related.get(catName);
+      e.tags.push(t.name);
+      e.strength += count;
+    });
+  });
+  // 共有タグが多い順。同数なら相手カテゴリ側の本数合計が多い方が関連が濃い。
+  // 同点の決着が無いとビルドごとに並びが変わる
+  return [...related.values()]
+    .sort((a, b) => b.tags.length - a.tags.length || b.strength - a.strength || (a.name < b.name ? -1 : 1))
+    .slice(0, 5);
+});

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -56,6 +56,21 @@
       <% }) %>
     </ul>
     <% } %>
+    <%# タグページの「関連タグ」の対 (#2200)。定義はヘルパー側を参照。
+        注記は件数ではなく根拠タグを名乗る。数字にするとどのタグで
+        つながったのかが隠れて、読者が関連の質を判断できない %>
+    <% const rc = related_categories(page.category); %>
+    <% if (rc.length) { %>
+    <h2 class="bottom-content-header">関連カテゴリ</h2>
+    <ul class="tendency-panels">
+      <% rc.forEach(function(c){ %>
+      <li class="tendency-panel">
+        <a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事へ"><%= c.name %></a>
+        <span class="tendency-panel-count"><%= c.tags.join('・') %>を共有</span>
+      </li>
+      <% }) %>
+    </ul>
+    <% } %>
     <% } %>
     <% if (page.current !== 1) { %>
     <%


### PR DESCRIPTION
## 概要

Close #2200

カテゴリ個別ページの「よく使われるタグ」の直後に「関連カテゴリ」を追加します。タグページの「関連タグ」の対で、これでカテゴリ・タグ・著者の3ページが「統計 → よく読まれている記事 → 傾向パネル群 → 新着記事」の同じ文法で揃います。

## 関連の定義

独自の採点は持ち込まず、**ページに表示済みの2つの規則の合成**で定めます:

> このカテゴリの「よく使われるタグ」（上位5）が、他に「よく使われているカテゴリ」（タグページと同じ 2本以上かつ10%以上）

読者がカテゴリ→タグ→カテゴリとリンクを辿っても同じ結論に到達できる、UI上で検証可能な定義です。並びは共有タグ数 → 相手カテゴリ側の本数合計 → 名前で決定的。上限5件。

登壇レポート・初心者向けのような形式タグ経由の関連は除外しません（合意済み）。注記が根拠タグを名乗るので、関連の質は読者が判断できます。

## 表示

```
関連カテゴリ
┌──────────────────────────────────┐ ┌──────────────────┐
│ Infrastructure Terraform・GoogleCloudを共有 │ │ Programming Goを共有 │ …
└──────────────────────────────────┘ └──────────────────┘
```

## 動作確認（ローカル）

- /categories/DevOps/ → Infrastructure（Terraform・GoogleCloud）/ Programming（Go）/ DataEngineering（GoogleCloud）
- /categories/AIDD/ → DataScience（生成AI・LLM・AIエージェント・Claude）/ Business（生成AI）
- /categories/Programming/ → 5件（上限で最弱の Frontend が落ちる）
- /categories/Mobile/ と /categories/VR/ → 関連なしのためセクション自体が出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)