### PR TITLE
年ページの推移グラフのカテゴリ並びをサイト累計順に固定する

### DIFF
--- a/scripts/category_chart_helpers.js
+++ b/scripts/category_chart_helpers.js
@@ -41,8 +41,9 @@ function getQuarterlyCategoryData() {
     });
   });
 
-  // 2. サイトの全カテゴリを取得し、「合計記事数」で降順にソートする
-  const sortedCategoryObjects = this.site.categories.toArray().sort((a, b) => b.length - a.length);
+  // 2. サイトの全カテゴリを取得し、「合計記事数」で降順にソートする。
+  //    同点の決着が無いとビルドごとに並びが変わる
+  const sortedCategoryObjects = this.site.categories.toArray().sort((a, b) => b.length - a.length || (a.name < b.name ? -1 : 1));
   const sortedCategoryNames = sortedCategoryObjects.map(cat => cat.name);
 
   // 3. X軸のラベル（時間軸）を生成し、ソートする
@@ -113,20 +114,22 @@ hexo.extend.helper.register('category_colors', function() {
 // 指定年の月別 × カテゴリ別の投稿数 (#2171)
 hexo.extend.helper.register('get_monthly_category_data', function(year) {
   const byCat = new Map(); // カテゴリ -> 12ヶ月分の配列
-  const catTotal = new Map();
   this.site.posts.forEach(post => {
     if (String(post.date.year()) !== String(year)) return;
     const cat = post.categories.first();
     if (!cat) return;
     if (!byCat.has(cat.name)) byCat.set(cat.name, new Array(12).fill(0));
     byCat.get(cat.name)[post.date.month()]++;
-    catTotal.set(cat.name, (catTotal.get(cat.name) || 0) + 1);
   });
   const months = [];
   for (let m = 1; m <= 12; m++) months.push(`${m}月`);
-  const series = [...catTotal.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .map(([name]) => ({name, data: byCat.get(name)}));
+  // 並びはその年の多い順ではなく、全期間ページと同じサイト累計の多い順で
+  // 固定する。年ごとに入れ替わると、年を移動したとき凡例と積み上げの
+  // 色の位置が動いて比較しにくい (#2201)
+  const series = this.site.categories.toArray()
+    .sort((a, b) => b.length - a.length || (a.name < b.name ? -1 : 1))
+    .filter(c => byCat.has(c.name))
+    .map(c => ({name: c.name, data: byCat.get(c.name)}));
   return JSON.stringify({months, series});
 });
 


### PR DESCRIPTION
## 概要

Close #2201

全期間・年ページの「投稿数の推移（カテゴリ別）」で、カテゴリの並び（凡例・積み上げ順）がページごとに変わっていたのを修正します。

## 原因と対応

色自体は #2170 で名前固定済みでしたが、年ページの `get_monthly_category_data` が**その年の投稿数順**に系列を並べていたため、年を移動すると凡例と積み上げの色の位置が入れ替わっていました（2019年は3番目が Infrastructure、2025年は DataScience）。

全期間ページと同じ**サイト累計の多い順**に統一し、どの年のページでも同じ並びになるようにしました。その年に投稿が無いカテゴリは従来どおり出しません。あわせて両ヘルパーの並び替えに名前の同点決着を入れ、ビルド間で並びが揺れないようにしています。

著者ページのグラフ（著者内の合計順）は変更していません。

## 動作確認（ローカル）

- /articles/2019/ と /articles/2025/ の系列順がいずれも Programming / DevOps / Infrastructure / Frontend / Culture / DataScience … と全期間ページと同じ並びになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)