### PR TITLE
年・月ページに「よく読まれている記事」を追加する

### DIFF
--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -22,6 +22,16 @@
     <ul class="summary">
       <li><span class="summary-count"><%= count_articles_month(page.year, page.month) %></span><br><span class="summary-label">投稿</span></li>
     </ul>
+    <%# その月の中でよく読まれている記事 (#2214)。カテゴリ・タグ・著者の
+        詳細ページと同じく新着一覧の前。件数は記事数からヘルパーが決める %>
+    <% if (page.current === 1) { %>
+    <% const ym = page.year.toString() + page.month.toString().padStart(2, '0'); %>
+    <% const monthPopular = popular_posts_in(site.posts.filter(function(p){ return p.date.format('YYYYMM') === ym; }).toArray()); %>
+    <% if (monthPopular) { %>
+    <h2 class="bottom-content-header">よく読まれている記事</h2>
+    <%- monthPopular %>
+    <% } %>
+    <% } %>
     <% } else if(is_year()) { %>
     <h1 class="list-page"><%= page.year%><span class="list-sub-text"> 年のすべての記事</span></h1>
     <%# 統計は1行に集約。シェアの内訳を一段小さくするのは他ページと同じ (#2096) %>
@@ -37,7 +47,19 @@
     </ul>
     <h2 class="bottom-content-header">投稿数の推移</h2>
     <%- partial('_partial/posts-chart', {year: page.year}) %>
+    <%# その年の中でよく読まれている記事 (#2214)。著者ページと同じく
+        グラフの後・新着一覧の前。年内は経過年数がほぼ同じなので、
+        ペナルティは相殺されて素直に PV 順になる %>
+    <% if (page.current === 1) { %>
+    <% const yearPopular = popular_posts_in(site.posts.filter(function(p){ return p.date.format('YYYY') === page.year.toString(); }).toArray()); %>
+    <% if (yearPopular) { %>
+    <h2 class="bottom-content-header">よく読まれている記事</h2>
+    <%- yearPopular %>
+    <% } %>
+    <% } %>
     <% } else { %>
+    <%# 全期間には「よく読まれている記事」を置かない (#2214)。
+        全記事対象のランキングはホーム1ページ目が担っていて、二重になる %>
     <h1 class="list-page">すべての記事</h1>
     <%# 統計は1行に集約。シェアの内訳を一段小さくするのは他ページと同じ (#2096) %>
     <ul class="summary">


### PR DESCRIPTION
## 概要

Close #2214

期間で絞った年ページ・月ページに「よく読まれている記事」を追加し、カテゴリ・タグ・著者の詳細ページと同じ「統計 →（グラフ）→ よく読まれている記事 → 記事一覧」の構成に揃えます。

## 方針

- **年ページ**: 「投稿数の推移」グラフの後に配置（著者ページのグラフ→popular の並びと同じ）。年内は経過年数がほぼ同じなので、鮮度ペナルティは相殺されて素直に PV 順になります
- **月ページ**: 統計の後に配置。件数は共有ヘルパー `popular_posts_in` の `recommendLimit`（3本以下=0 / 4〜7本=2 / 8本以上=4）が自動で決めるので、記事の少ない月でも破綻しません
- **全期間（/articles/）には置きません**。全記事対象のランキングはホーム1ページ目（トレンド/年間人気/SNS人気）が既に担っており、二重になるため。この判断はテンプレートのコメントにも残しています

## 動作確認（ローカル）

- /articles/2024/ → 「よく読まれている記事」4件（Dockerfileの考え方 ほか、2024年の記事のみ）
- /articles/2026/07/ → 月内の記事から表示
- /articles/ → セクションなし（従来どおり）

🤖 Generated with [Claude Code](https://claude.com/claude-code)