### PR TITLE
タブの表示をページの h1 と同じ名乗りに揃える

### DIFF
--- a/themes/future/layout/_partial/head.ejs
+++ b/themes/future/layout/_partial/head.ejs
@@ -30,35 +30,41 @@
     let keywords = 'フューチャーアーキテクト,技術ブログ,ITコンサル';
     let author = 'フューチャー技術ブログ';
 
-    if (is_archive()){
-      title = 'Archives';
+    // タブの表示はそのページの h1 と同じ名乗りにする (#2218)。
+    // 「Archives」のような、サイト内のどこにも出ない語を使わない
     if (is_month()){
-        title += ': ' + page.year + '/' + page.month;
-      } else if (is_year()){
-        title += ': ' + page.year;
-      }
+      title = page.year + '年' + page.month + '月のすべての記事';
+    } else if (is_year()){
+      title = page.year + '年のすべての記事';
+    } else if (is_archive()){
+      title = 'すべての記事';
     } else if (is_category()){
-      title = page.category + ' の記事一覧';
-      description = page.category + ' カテゴリの記事一覧 | '　+ config.description
+      title = page.category + ' カテゴリ';
+      description = page.category + ' カテゴリの記事一覧 | ' + config.description
       keywords = keywords + ',' + page.category;
     } else if (page.path === 'categories/index.html') {
       title = 'カテゴリ一覧';
       description = 'カテゴリ一覧 | ' + config.description;
     } else if (is_tag()){
-      title = page.tag + ' の記事一覧';
-      description = page.tag + ' タグの記事一覧 | '　+ config.description
+      title = page.tag + ' タグ';
+      description = page.tag + ' タグの記事一覧 | ' + config.description
       keywords = keywords + ',' + page.tag;
     } else if (page.path === 'tags/index.html') {
       title = 'タグ一覧';
       description = 'タグ一覧 | ' + config.description;
-    } else if (path.indexOf('authors/' + page.author) >= 0) {
-      title = page.author;
-      description = page.author + ' が執筆した記事一覧 | '　+ config.description
+    } else if (page.author && path.indexOf('authors/') === 0) {
+      title = page.author + 'さんのページ';
+      description = page.author + ' が執筆した記事一覧 | ' + config.description
       keywords = keywords + ',' + page.author;
       author = page.author;
     } else if (page.path === 'authors/index.html') {
       title = '著者一覧';
       description = '著者一覧 | ' + config.description;
+    }
+
+    // 2ページ目以降は同じタイトルのタブが並ばないよう、パンくずと同じ語で区別する
+    if (page.current > 1) {
+      title = (title ? title + ' ' : '') + page.current + 'ページ目';
     }
 
     if (title) {


### PR DESCRIPTION
## 概要

Close #2218

ブラウザのタブ表示（title 要素）を「そのページの h1 と同じ名乗り」に統一します。OGP のタイトルも同じ変数を使っているので連動します。

## 変更前後

| ページ | 変更前 | 変更後 |
| --- | --- | --- |
| /articles/ | Archives | すべての記事 |
| /articles/2024/ | Archives: 2024 | 2024年のすべての記事 |
| /articles/2026/07/ | Archives: 2026/7 | 2026年7月のすべての記事 |
| カテゴリ詳細 | Programming の記事一覧 | Programming カテゴリ |
| タグ詳細 | Go の記事一覧 | Go タグ |
| 著者詳細 | 真野隼記 | 真野隼記さんのページ |
| 2ページ目以降 | 1ページ目と同一 | 「Programming カテゴリ 2ページ目」のように区別 |

各一覧（カテゴリ一覧・タグ一覧・著者一覧）と記事ページは従来どおりです。末尾の「 | フューチャー技術ブログ」も従来どおり。

## ついで修正（Issue 記載分）

- 文字列連結に混ざっていた全角スペース3箇所を通常のスペースに
- 著者ページ判定を `path.indexOf('authors/' + page.author) >= 0` から `page.author && path.indexOf('authors/') === 0` に（記事ページには page.author があるため、パス先頭の確認に寄せた）

## 動作確認（ローカル）

全ページ種別（全期間・年・月・カテゴリ・タグ・著者の各詳細と一覧、ホーム、記事、2ページ目）で `<title>` を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)