### PR TITLE
年ページに「月から探す」を追加する

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1182,6 +1182,17 @@ code {
 .archive-list-current {
   font-weight: bold;
 }
+/* 投稿が無い月のダミーカード (#2219)。月が歯抜けだと「無い」のか
+   見落としなのか区別できない。リンクにせず、ホバーにも応えない */
+.archive-list-item-empty:hover {
+  background-color: transparent;
+  border-color: #eee;
+}
+.archive-list-empty {
+  color: #9e9e9e;
+  font-size: 1.2em;
+  font-weight: bold;
+}
 
 .post-author {
   color: #616161;

--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -47,14 +47,20 @@
     </ul>
     <%# 月ページへの唯一の導線 (#2219)。/articles/ の「年から探す」と同じ
         カード型で、位置（統計の直下）と新しい順の並びも揃える。
-        マークアップは list_archives の出力（件数の span はリンクの外）を模す %>
+        マークアップは list_archives の出力（件数の span はリンクの外）を模す。
+        投稿が無い月も、歯抜けにせずリンク無しのダミーカードで置く。
+        今年のまだ来ていない月だけは出さない %>
     <h2 class="bottom-content-header">月から探す</h2>
     <section class="archives">
       <ul class="archive-list">
-        <% for (let m = 12; m >= 1; m--) { %>
+        <% const now = new Date(); %>
+        <% const maxMonth = Number(page.year) === now.getFullYear() ? now.getMonth() + 1 : 12; %>
+        <% for (let m = maxMonth; m >= 1; m--) { %>
         <% const monthCount = count_articles_month(page.year, m); %>
         <% if (monthCount > 0) { %>
         <li class="archive-list-item"><a class="archive-list-link" href="<%- url_for('articles/' + page.year + '/' + String(m).padStart(2, '0') + '/') %>"><%= m %>月</a><span class="archive-list-count"><%= monthCount %></span></li>
+        <% } else { %>
+        <li class="archive-list-item archive-list-item-empty"><span class="archive-list-empty"><%= m %>月</span><span class="archive-list-count">0</span></li>
         <% } %>
         <% } %>
       </ul>

--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -45,6 +45,20 @@
       <li class="summary-sub"><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
       <li class="summary-sub"><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
     </ul>
+    <%# 月ページへの唯一の導線 (#2219)。/articles/ の「年から探す」と同じ
+        カード型で、位置（統計の直下）と新しい順の並びも揃える。
+        マークアップは list_archives の出力（件数の span はリンクの外）を模す %>
+    <h2 class="bottom-content-header">月から探す</h2>
+    <section class="archives">
+      <ul class="archive-list">
+        <% for (let m = 12; m >= 1; m--) { %>
+        <% const monthCount = count_articles_month(page.year, m); %>
+        <% if (monthCount > 0) { %>
+        <li class="archive-list-item"><a class="archive-list-link" href="<%- url_for('articles/' + page.year + '/' + String(m).padStart(2, '0') + '/') %>"><%= m %>月</a><span class="archive-list-count"><%= monthCount %></span></li>
+        <% } %>
+        <% } %>
+      </ul>
+    </section>
     <h2 class="bottom-content-header">投稿数の推移</h2>
     <%- partial('_partial/posts-chart', {year: page.year}) %>
     <%# その年の中でよく読まれている記事 (#2214)。著者ページと同じく


### PR DESCRIPTION
## 概要

Close #2219

月ページ（/articles/2024/07/ など）はパンくず以外にサイト内の被リンクが無い実質オーファンページだった。年ページに「月から探す」を追加して導線を作る。

## 表示

/articles/ の「年から探す」と同じ archive-list のカード型・同じ位置（統計タイルの直下、推移グラフの前）・同じ新しい順で揃える。パンくずの 全期間 > 年 > 月 の階層とも一致する。

- カードは「7月」＋件数（件数の単位表記はカード側 CSS の「件」で年カードと同じ）
- **投稿が無い月も、歯抜けにせずリンク無しのダミーカード（グレー・ホバー無反応・0件）で置く**。月が消えていると「無い」のか見落としなのか区別できないため
- 今年のまだ来ていない月（2026年9月〜12月）だけは出さない
- マークアップは hexo `list_archives` の出力（件数の span がリンクの外）を模しており、既存 CSS がそのまま効く

## 動作確認（ローカル）

- /articles/2024/ → 12月〜1月の12カードが件数付きで並び、リンク先 /articles/2024/07/ などが 200
- /articles/2016/ → 投稿ゼロの 8月・6月・1月 がリンク無しのグレーカード「0件」で並ぶ
- /articles/2026/ → 8月〜1月のみ表示（未来の月は出ない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)