### PR TITLE
月ページの統計・グラフを年ページと同等にする

### DIFF
--- a/scripts/category_chart_helpers.js
+++ b/scripts/category_chart_helpers.js
@@ -133,6 +133,31 @@ hexo.extend.helper.register('get_monthly_category_data', function(year) {
   return JSON.stringify({months, series});
 });
 
+// 月ページの週別 × カテゴリ別の投稿数 (#2227)。週は「その月の何日目か」で
+// 決める（1〜7日 = 第1週）。posts_stack_series と同じ規則で、ISO週だと
+// 月をまたぐ週が出て合計が月の投稿数と合わなくなる
+hexo.extend.helper.register('get_weekly_category_data', function(year, month) {
+  const ym = year.toString() + month.toString().padStart(2, '0');
+  const daysInMonth = new Date(Number(year), Number(month), 0).getDate();
+  const weekCount = Math.ceil(daysInMonth / 7);
+  const byCat = new Map();
+  this.site.posts.forEach(post => {
+    if (post.date.format('YYYYMM') !== ym) return;
+    const cat = post.categories.first();
+    if (!cat) return;
+    if (!byCat.has(cat.name)) byCat.set(cat.name, new Array(weekCount).fill(0));
+    const w = Math.min(weekCount, Math.ceil(Number(post.date.format('D')) / 7)) - 1;
+    byCat.get(cat.name)[w]++;
+  });
+  const weeks = Array.from({length: weekCount}, (_, i) => `第${i + 1}週`);
+  // 並びは年ページと同じサイト累計の多い順で固定 (#2201)
+  const series = this.site.categories.toArray()
+    .sort((a, b) => b.length - a.length || (a.name < b.name ? -1 : 1))
+    .filter(c => byCat.has(c.name))
+    .map(c => ({name: c.name, data: byCat.get(c.name)}));
+  return JSON.stringify({weeks, series});
+});
+
 /**
  * カテゴリ1つ分の統計。件数・寄稿者数（累計・直近1年）と
  * よく使われるタグ（上位5個）を返す。

--- a/scripts/count_post.js
+++ b/scripts/count_post.js
@@ -77,6 +77,28 @@ hexo.extend.helper.register('summary_yearly_term', function(year) {
   };
 });
 
+// 月ページの統計。年ページ（summary_yearly_term）と同じ構成 (#2227)
+hexo.extend.helper.register('summary_monthly_term', function(year, month) {
+  const ym = year.toString() + month.toString().padStart(2, '0');
+  const posts = this.site.posts.filter(post => post.date.format("YYYYMM") === ym);
+
+  const total = posts.map(post => getSNSCnt(post.permalink)).reduce((acc, cur) => acc + cur);
+  const authors = posts.map(post => post.author).flat().unique().length;
+  const tw = posts.map(post => getTwitterCnt(post.permalink)).reduce((acc, cur) => acc + cur);
+  const fb = posts.map(post => getFacebookCnt(post.permalink)).reduce((acc, cur) => acc + cur);
+  const hatebu = posts.map(post => getHatebuCnt(post.permalink)).reduce((acc, cur) => acc + cur);
+  const pocket = posts.map(post => getPocketCnt(post.permalink)).reduce((acc, cur) => acc + cur);
+
+  return {
+    total: total,
+    authors: authors,
+    twitter: tw,
+    facebook: fb,
+    hatebu: hatebu,
+    pocket: pocket
+  };
+});
+
 /*
  * カテゴリ個別ページ
  */

--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -19,9 +19,43 @@
   <div id="main" class="margin-top-30">
     <% if(is_month()) { %>
     <h1 class="list-page"><%= page.year%>年<%= page.month %>月<span class="list-sub-text">のすべての記事</span></h1>
+    <%# 統計は年ページと同じ構成 (#2227)。「平均投稿/月」に当たる軸は
+        月の中では意味が薄いので置かない %>
     <ul class="summary">
+      <% const summary = summary_monthly_term(page.year, page.month); %>
       <li><span class="summary-count"><%= count_articles_month(page.year, page.month) %></span><br><span class="summary-label">投稿</span></li>
+      <li><span class="summary-count"><%= summary.total %></span><br><span class="summary-label">総シェア数</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.twitter %></span><br><span class="summary-label">X</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.facebook %></span><br><span class="summary-label">Facebook</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
+      <li class="summary-sub"><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
     </ul>
+    <%# 週別 × カテゴリ別の積み上げ。年ページの「投稿数の推移」の月スコープ版。
+        月の中はデータ量が少ないのでタブは設けず1枚にする (#2227) %>
+    <h2 class="bottom-content-header">投稿数の推移</h2>
+    <div id="chart-week" style="width:100%;min-height:250px"></div>
+    <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
+    <script type="text/javascript">
+      const weekData = <%- get_weekly_category_data(page.year, page.month) %>;
+      const catColors = <%- category_colors() %>;
+      echarts.init(document.getElementById('chart-week')).setOption({
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0, type: 'scroll' },
+        grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
+        xAxis: { type: 'category', data: weekData.weeks },
+        <%# 投稿数は整数。上限は最低3で、少ない月でも棒が天井に張り付かない
+            ようにする（著者ページのグラフと同じ規則） %>
+        yAxis: { type: 'value', min: 0, minInterval: 1, max: value => Math.max(3, value.max) },
+        <%# 色はカテゴリ名で固定 (#2170) %>
+        series: weekData.series.map(s => ({
+          name: s.name,
+          type: 'bar',
+          stack: 'categories',
+          itemStyle: { color: catColors[s.name] },
+          data: s.data
+        }))
+      });
+    </script>
     <%# その月の中でよく読まれている記事 (#2214)。カテゴリ・タグ・著者の
         詳細ページと同じく新着一覧の前。件数は記事数からヘルパーが決める %>
     <% if (page.current === 1) { %>


### PR DESCRIPTION
## 概要

Close #2227

月ページ（/articles/2019/11/ など）の統計が「投稿」タイル1枚だけで年ページと落差が大きかったのを、年ページと同じ構成に揃えます。#2214（よく読まれている記事）・#2225（月から探す）で月ページが読まれるページになった流れの続きです。

## 変更

- **統計タイル**: 投稿・総シェア数＋X/Facebook/はてブ/Pocket 内訳（`summary_yearly_term` の月版 `summary_monthly_term` を追加）。Issue のとおり「平均投稿/月」に当たる軸は月内では意味が薄いので置きません
- **グラフ**: h2「投稿数の推移」で週別×カテゴリ別の積み上げ棒。月内はデータ量が少ないのでタブ無しの1枚です
  - 週の区切りは `posts_stack_series` と同じ「その月の何日目か」（1〜7日=第1週）。ISO週だと月をまたいで合計が合わなくなるため
  - 週数は月の日数から算出（2月=第4週まで、30日以上の月=第5週まで）
  - カテゴリの並びはサイト累計順で固定（#2201）、色は名前で固定（#2170）、Y軸は整数目盛・上限最低3（著者ページと同じ規則）
- 配置は年ページと同じ「統計 → 投稿数の推移 → よく読まれている記事 → 記事一覧」

## 動作確認（ローカル）

- /articles/2019/11/ → タイル6枚＋第1〜5週の積み上げチャート（Programming / Infrastructure / DB / DataEngineering がサイト累計順）
- /articles/2021/02/ → 週数が第4週までになる
- よく読まれている記事・記事一覧は従来どおり

🤖 Generated with [Claude Code](https://claude.com/claude-code)