### PR TITLE
年・月ページに前後の期間へのページャーを付ける

### DIFF
--- a/scripts/period_nav.js
+++ b/scripts/period_nav.js
@@ -1,0 +1,21 @@
+'use strict';
+
+// 年・月ページの前後の期間 (#2228)。投稿の無い期間はページ自体が
+// 生成されないため、隣接ではなく投稿のある直近の期間を返す。
+// 月は年をまたぐ（2019年12月の次は2020年1月）
+hexo.extend.helper.register('period_nav', function(year, month) {
+  const monthly = month !== undefined && month !== null;
+  const fmt = monthly ? 'YYYYMM' : 'YYYY';
+  const keys = [...new Set(this.site.posts.map(p => p.date.format(fmt)))].sort();
+  const current = monthly ? year.toString() + month.toString().padStart(2, '0') : year.toString();
+  const at = keys.indexOf(current);
+  if (at < 0) return {prev: null, next: null};
+  const entry = key => {
+    if (key === undefined) return null;
+    const y = key.slice(0, 4);
+    if (!monthly) return {label: `${y}年`, path: `articles/${y}/`};
+    const m = key.slice(4, 6);
+    return {label: `${y}年${Number(m)}月`, path: `articles/${y}/${m}/`};
+  };
+  return {prev: entry(keys[at - 1]), next: entry(keys[at + 1])};
+});

--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -147,5 +147,34 @@
         「新着記事」ではなく常に「記事一覧」 %>
     <h2 class="bottom-content-header">記事一覧</h2>
     <%- partial('_partial/archive-all', {pagination: config.archive}) %>
+    <%# 前後の期間へのページャー (#2228)。連載ナビと同じ型（前が左・
+        対象明示型のラベル＋行き先名）で、一覧を読み終えた位置に置く。
+        端では連載ナビと同じく、行き先が無いことを明示する %>
+    <% if (is_year() || is_month()) { %>
+    <% const nav = period_nav(page.year, is_month() ? page.month : null); %>
+    <% const unit = is_month() ? '月' : '年'; %>
+    <nav class="series-nav margin-top-30" data-nosnippet aria-label="前後の<%= unit %>">
+      <div class="card">
+        <div class="series-nav-pair">
+          <% if (nav.prev) { %>
+          <a class="series-nav-item series-nav-prev" href="<%- url_for(nav.prev.path) %>">
+            <span class="series-nav-dir">前の<%= unit %></span>
+            <span class="series-nav-item-title"><%= nav.prev.label %></span>
+          </a>
+          <% } else { %>
+          <span class="series-nav-item series-nav-prev series-nav-end">いちばん古い<%= unit %>です</span>
+          <% } %>
+          <% if (nav.next) { %>
+          <a class="series-nav-item series-nav-next" href="<%- url_for(nav.next.path) %>">
+            <span class="series-nav-dir">次の<%= unit %></span>
+            <span class="series-nav-item-title"><%= nav.next.label %></span>
+          </a>
+          <% } else { %>
+          <span class="series-nav-item series-nav-next series-nav-end">いちばん新しい<%= unit %>です</span>
+          <% } %>
+        </div>
+      </div>
+    </nav>
+    <% } %>
   </div>
 </div>

--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -153,7 +153,7 @@
     <% if (is_year() || is_month()) { %>
     <% const nav = period_nav(page.year, is_month() ? page.month : null); %>
     <% const unit = is_month() ? '月' : '年'; %>
-    <nav class="series-nav margin-top-30" data-nosnippet aria-label="前後の<%= unit %>">
+    <nav class="series-nav margin-top-30 footer-gap" data-nosnippet aria-label="前後の<%= unit %>">
       <div class="card">
         <div class="series-nav-pair">
           <% if (nav.prev) { %>


### PR DESCRIPTION
## 概要

Close #2228

年・月ページの記事一覧の下に、前後の期間へ移動するページャーを追加します。年・月ページ企画（#2219 導線 → #2227 統計・グラフ）の仕上げです。

## 表示

連載ナビ（series-nav）の CSS・構造をそのまま再利用し、前を左・次を右、「前の年／次の年」「前の月／次の月」＋行き先名の対象明示型にします。新規 CSS はありません。

```
┌──────────────────────┬──────────────────────┐
│ ‹ 前の月              │              次の月 › │
│ 2019年11月            │            2020年1月 │
└──────────────────────┴──────────────────────┘
```

- **月は年をまたぐ**: 2019年12月 の次は 2020年1月
- **投稿の無い月は飛ばす**: 2016年7月 の前は5月（6月は0件）、次は9月（8月は0件）。ページが生成されない月に飛ばないためで、行き先の年月を明示しているので飛んでも迷わない（#2225 のダミーカードとも整合）
- **端は行き先無しを明示**: 2016年は「いちばん古い年です」、今年は「いちばん新しい年です」（連載ナビの「この連載の最初の記事です」と同じ流儀）
- 全期間ページには付けない（前後という概念が無い）

## 動作確認（ローカル）

- /articles/2020/ → 前の年 2019年 / 次の年 2021年
- /articles/2016/ ・ /articles/2026/ → 端の表示
- /articles/2016/07/ → 前の月 2016年5月 / 次の月 2016年9月（空月スキップ）
- /articles/2019/12/ → 次の月 2020年1月（年またぎ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)