### PR TITLE
チャートの体裁をページ間で統一する

### DIFF
--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -30,8 +30,9 @@
     <%- get_profile(page.author) %>
     <%# 並びはカテゴリ・タグページの「統計 → よく読まれている記事 → 新着」に
         揃える (#2191)。月別投稿数のグラフは統計の一種とみなして統計の直後に置く %>
-    <h2 class="bottom-content-header">月別投稿数</h2>
-    <div id="chart" style="width:95%;min-height:250px"></div>
+    <%# 見出しは他のチャートと同じ「◯別 △の推移」の型 (#2212) %>
+    <h2 class="bottom-content-header">月別 投稿数の推移</h2>
+    <div id="chart" style="width:100%;min-height:250px"></div>
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
     <script type="text/javascript">
       <%# カテゴリごとの積み上げ棒 (#2138)。期間の穴埋めと軸の下限12ヶ月は

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -44,11 +44,11 @@
       <%# 一覧が主役なので推移グラフは補足の読み物として最後に置く。
           /categories/ の「カテゴリ別 投稿数の推移」と同じ型 %>
       <h2 class="bottom-content-header">年別 著者数の推移</h2>
-      <div id="chart" style="width:95%;min-height:350px"></div>
+      <div id="chart" style="width:100%;min-height:350px"></div>
       <%# 種別の定義。凡例のホバーでも出すが、タッチ端末はホバーが無いので
           注記でも読めるようにする %>
       ※継続=前年にも投稿 ／ 再開=2年以上あいての投稿 ／ 新規=初投稿 ／ 常連=2年連続で年2本以上
-      <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
       <script type="text/javascript">
         <%# 継続・新規・再開の3種別 (#2145)。定義はヘルパー（yearly_author_types）側 %>
         const chartData = <%- yearly_author_types() %>;
@@ -80,8 +80,9 @@
               boundaryGap: true,
               data: chartData.years
           },
-          <%# 積み上げの合計がその四半期の著者数になるので、軸は1本で足りる %>
-          yAxis: { type: 'value', name: '人', min: 0 },
+          <%# 積み上げの合計がその年の著者数になるので、軸は1本で足りる。
+              軸名は付けない。何の数かは直上の h2 が名乗っている (#2212) %>
+          yAxis: { type: 'value', min: 0 },
           <%# 土台の継続から順に積む。色は ECharts 既定パレット（他ページのチャートと同じ）%>
           series: [
               {

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -37,7 +37,7 @@
     ※四半期ごとの投稿数を表示（2018年以前は年単位）
     <div id="category-chart" class="footer-gap" style="width: 100%; height: 400px;"></div>
 
-    <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
 
     <script type="text/javascript">
       const chartData = <%- JSON.stringify(get_quarterly_category_data()) %>;
@@ -45,10 +45,12 @@
       const myChart = echarts.init(document.getElementById('category-chart'));
       const option = {
         tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
-        legend: { data: chartData.categories, type: 'scroll', orient: 'horizontal', left: 'center', top: 'bottom' },
-        grid: { left: '3%', right: '4%', bottom: '15%', containLabel: true },
+        legend: { bottom: 0, type: 'scroll' },
+        <%# 余白と凡例位置は他のチャート（posts-chart）に合わせる (#2212) %>
+        grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
         xAxis: [ { type: 'category', boundaryGap: true, data: chartData.quarters } ],
-        yAxis: [ { name: '投稿数', type: 'value' } ],
+        <%# 軸名は付けない。何の数かは直上の h2 が名乗っている %>
+        yAxis: [ { type: 'value' } ],
         <%# 16本の折れ線の重なりは読めないので積み上げ棒にする (#2169)。
             棒の高さが四半期の合計、内訳がカテゴリ。色は名前で固定 (#2170) %>
         series: chartData.series.map(s => ({

--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -40,9 +40,10 @@
       <%# タグがどれだけ増えてきたか。初出の年で数える。
           「定着したか」で積み上げる案もあったが、新しい年ほど再利用の
           機会が無いだけで交絡するため、新規数だけを出す %>
-      <h2 class="bottom-content-header">新しく使われたタグの数</h2>
+      <%# 見出しは他のチャートと同じ「◯別 △の推移」の型 (#2212) %>
+      <h2 class="bottom-content-header">年別 新規タグ数の推移</h2>
       <div id="chart" style="width:100%;min-height:250px"></div>
-      <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
       <script type="text/javascript">
         const chartData = <%- new_tags_by_year() %>;
         const myChart = echarts.init(document.getElementById('chart'));
@@ -52,7 +53,7 @@
           xAxis: { type: 'category', data: chartData.years },
           yAxis: { type: 'value', min: 0 },
           color: ['#337ab7'],
-          series: [{ name: '新しく使われたタグ', type: 'bar', data: chartData.counts }]
+          series: [{ name: '新規タグ', type: 'bar', data: chartData.counts }]
         });
       </script>
 


### PR DESCRIPTION
## 概要

Close #2212

ECharts チャートを持つページ間で揺れていた体裁を統一します。

## 変更

**SRI（セキュリティ）**
- /categories/・/tags/・/authors/ の CDN スクリプトに `integrity` + `crossorigin` を追加（author.ejs / posts-chart.ejs と同じ値。これで全6箇所に揃う）

**見出しの命名（「◯別 △の推移」の型に統一）**
- 著者ページ: 月別投稿数 → **月別 投稿数の推移**
- /tags/: 新しく使われたタグの数 → **年別 新規タグ数の推移**（ツールチップの系列名も「新規タグ」に）

**設定・寸法**
- /categories/ の grid（`left:'3%', right:'4%', bottom:'15%'` → 他と同じ `left:0, right:'2%', bottom:32, containLabel:true`）と凡例（`top:'bottom'` → `bottom:0, type:'scroll'`）
- Y軸名（/categories/ の「投稿数」・/authors/ の「人」）を削除。何の数かは直上の h2 が名乗っている
- チャート幅の 95%/100% 混在を 100% に統一（authors・author）

**変えていないもの**
- 高さ（categories 400px / authors 350px / 他 250px）は内容量とレビュー時の指定（#2104）による差なので維持

## 動作確認（ローカル）

- /categories/・/tags/・/authors/ で integrity 属性、凡例位置、軸名なしを確認
- 著者ページ・/tags/ の新しい見出しを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)