### PR TITLE
記事数の単位と呼称の揺れを直す

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1170,14 +1170,15 @@ code {
   background-color: #eee;
   border-color: #ddd;
 }
-/* 年の下の段に「94件」。カッコ書きだと何の数か分からない */
+/* 年の下の段に「94本」。カッコ書きだと何の数か分からない。
+   記事数の単位はサイト全体で「本」に揃える (#2209) */
 .archive-list-count {
   display: block;
   color: #6e6e6e;
   font-size: 0.85em;
 }
 .archive-list-count:after {
-  content: "件";
+  content: "本";
 }
 .archive-list-current {
   font-weight: bold;

--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -41,7 +41,7 @@
           </a>
           <div class="panel-body">
             <a href="<%- url_for(s.index.path) %>" class="panel-title"><%= s.name %></a>
-            <div class="panel-meta">全 <%= s.total %> 本・<%= date(s.latest, 'YYYY.MM.DD') %> 更新</div>
+            <div class="panel-meta">全<%= s.total %>本・<%= date(s.latest, 'YYYY.MM.DD') %> 更新</div>
           </div>
         </div>
       </div>

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -52,7 +52,7 @@
                 <p class="series-nav-title"><span class="series-nav-kicker">連載</span><% if (series.index) { %><a href="<%- url_for(series.index.path) %>"><%= series.name %></a><% } else { %><%= series.name %><% } %></p>
                 <%# 全何本かは索引を除いた本編の数。「今何本目」は出さない。
                     本文が名乗る番号と流儀が割れており一致させられない（scripts/series.js） %>
-                <p class="series-nav-count">全 <%= series.total %> 本</p>
+                <p class="series-nav-count">全<%= series.total %>本</p>
               </div>
               <%# 前を左、次を右に置いて進行方向を示す。片方しか無いときは
                   その一方が幅いっぱいに広がる（初回は次だけ、最終回は前だけ） %>

--- a/themes/future/layout/_partial/pagination-info.ejs
+++ b/themes/future/layout/_partial/pagination-info.ejs
@@ -1,0 +1,8 @@
+<%# 2ページ目以降の現在位置。ホーム・カテゴリ・タグ・著者で共用する (#2210)。
+    呼び出し側は total（その一覧の総記事数）だけを渡す。
+    perPage は config 側の per_page（各ジェネレータで25）と合わせる。
+    記事数の単位はサイト全体で「本」に揃える (#2209) %>
+<% const perPage = 25; %>
+<div class="pagination-info">
+  全<%= total %>本のうち <%= (page.current - 1) * perPage + 1 %> ～ <%= Math.min(page.current * perPage, total) %> 本目を表示
+</div>

--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -1,17 +1,18 @@
 <div class="container">
   <%# 「Blog」はパンくず上の概念として廃止し、期間で辿る形に揃える（#2037）。
-      月別は 全期間 > 年 > 月 と親を1つずつ遡れるようにする %>
+      月別は すべての記事 > 年 > 月 と親を1つずつ遡れるようにする。
+      パンくずの語は h1・タブ表示と同じ「すべての記事」に揃える (#2209) %>
   <%
     const items = [{label: 'ホーム', url: '/'}];
     if (is_month()) {
-      items.push({label: '全期間', url: '/articles/'});
+      items.push({label: 'すべての記事', url: '/articles/'});
       items.push({label: page.year + '年', url: '/articles/' + page.year + '/'});
       items.push({label: page.month + '月', url: page.current === 1 ? null : (page.base || null)});
     } else if (is_year()) {
-      items.push({label: '全期間', url: '/articles/'});
+      items.push({label: 'すべての記事', url: '/articles/'});
       items.push({label: page.year + '年', url: page.current === 1 ? null : (page.base || null)});
     } else {
-      items.push({label: '全期間', url: page.current === 1 ? null : (page.base || '/articles/')});
+      items.push({label: 'すべての記事', url: page.current === 1 ? null : (page.base || '/articles/')});
     }
     if (page.current > 1) items.push({label: page.current + 'ページ目'});
   %>
@@ -67,7 +68,8 @@
     <% } %>
     <% } %>
     <% } else if(is_year()) { %>
-    <h1 class="list-page"><%= page.year%><span class="list-sub-text"> 年のすべての記事</span></h1>
+    <%# 単位の「年」は月ページの h1（2026年8月）と同じく数字側に付ける (#2209) %>
+    <h1 class="list-page"><%= page.year %>年<span class="list-sub-text">のすべての記事</span></h1>
     <%# 統計は1行に集約。シェアの内訳を一段小さくするのは他ページと同じ (#2096) %>
     <ul class="summary">
       <% const summary = summary_yearly_term(page.year); %>

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -115,12 +115,7 @@
     </ul>
     <% } %>
     <% } else { %>
-    <%
-        const perPage = 25;
-        const start_post = (page.current - 1) * perPage + 1;
-        const end_post = Math.min((page.current - 1) * perPage + perPage, count_author(page.author));
-    %>
-    <%= count_author(page.author) %>記事中の <%= start_post %> ～ <%= end_post %> を表示
+    <%- partial('_partial/pagination-info', {total: count_author(page.author)}) %>
     <% } %>
     <%# 見出しの語彙はホーム・カテゴリ・タグページに合わせる %>
     <%- partial('_partial/archive', {pagination: config.author, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧'}) %>

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -9,7 +9,7 @@
       <%# 全期間の統計はページの統計として h1 直下に置く。
           カテゴリ・タグ・著者の個別ページと同じ流儀 %>
       <ul class="summary">
-        <li><span class="summary-count"><%= count_authors() %></span><br><span class="summary-label">人</span></li>
+        <li><span class="summary-count"><%= count_authors() %></span><br><span class="summary-label">著者数</span></li>
         <li><span class="summary-count"><%= count_articles() %></span><br><span class="summary-label">投稿</span></li>
       </ul>
 
@@ -24,7 +24,7 @@
         <label tabindex="0" class="tab_item" for="authors-<%= year %>"><%= year %></label>
         <div class="tab_content">
           <ul class="summary">
-            <li><span class="summary-count"><%= count_authors(year.toString()) %></span><br><span class="summary-label">人</span></li>
+            <li><span class="summary-count"><%= count_authors(year.toString()) %></span><br><span class="summary-label">著者数</span></li>
             <li><span class="summary-count"><%= count_articles_year(year.toString()) %></span><br><span class="summary-label">投稿</span></li>
           </ul>
           <%- list_authors(year.toString()) %>
@@ -34,7 +34,7 @@
         <label tabindex="0" class="tab_item tab_item-all" for="authors-all">全期間</label>
         <div class="tab_content">
           <ul class="summary">
-            <li><span class="summary-count"><%= count_authors() %></span><br><span class="summary-label">人</span></li>
+            <li><span class="summary-count"><%= count_authors() %></span><br><span class="summary-label">著者数</span></li>
             <li><span class="summary-count"><%= count_articles() %></span><br><span class="summary-label">投稿</span></li>
           </ul>
           <%- list_authors() %>

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -73,12 +73,7 @@
     <% } %>
     <% } %>
     <% if (page.current !== 1) { %>
-    <%
-        const perPage = 25;
-        const start_post = (page.current - 1) * perPage + 1;
-        const end_post = Math.min((page.current - 1) * perPage + perPage, count_category(page.category));
-    %>
-    <%= count_category(page.category) %>記事中の <%= start_post %> ～ <%= end_post %> を表示
+    <%- partial('_partial/pagination-info', {total: count_category(page.category)}) %>
     <% } %>
     <%# 見出しの語彙はホームに合わせる。一覧は日付降順なので
         1ページ目だけが「新着」を名乗れる %>

--- a/themes/future/layout/index.ejs
+++ b/themes/future/layout/index.ejs
@@ -16,14 +16,7 @@
     </section>
     <% } %>
     <% if (page.current > 1) { %>
-    <%
-        const perPage = 25;
-        const start_post = (page.current - 1) * perPage + 1;
-        const end_post = Math.min((page.current - 1) * perPage + perPage, site.posts.length);
-    %>
-    <div class="pagination-info">
-     <%= site.posts.length %>記事中の <%= start_post %> ～ <%= end_post %> を表示
-    </div>
+    <%- partial('_partial/pagination-info', {total: site.posts.length}) %>
     <% } %>
     <%# 以前はここに X / Facebook / はてブ / Pocket / Feedly のボタンを並べていたが、
         トップページ自体を拡散する行動はほぼ起きない。実際シェア数は

--- a/themes/future/layout/tag.ejs
+++ b/themes/future/layout/tag.ejs
@@ -31,12 +31,7 @@
     <p class="summary-note">直近1年間の投稿はありません</p>
     <% } %>
     <% } else { %>
-    <%
-        const perPage = 25;
-        const start_post = (page.current - 1) * perPage + 1;
-        const end_post = Math.min((page.current - 1) * perPage + perPage, count_tag(page.tag));
-    %>
-    <%= count_tag(page.tag) %> 記事中の <%= start_post %> ～ <%= end_post %> を表示
+    <%- partial('_partial/pagination-info', {total: count_tag(page.tag)}) %>
     <% } %>
     <% if (page.current === 1) { %>
     <%# そのタグの中でよく読まれている記事。新着より前に置く。


### PR DESCRIPTION
## 概要

Close #2209
Close #2210

ページ横断チェック（#2209）で見つかった単位・呼称の揺れをまとめて直します。ページ送り情報の文言も変えるため、コピペ4箇所の一本化（#2210）も同じ PR で行います（文言を4箇所直してから別 PR で集約するのは二度手間なので）。

## 変更

**記事数の単位は「本」に統一**
- 年・月カードの件数: 「94件」→「94本」（CSS の `content`）
- ページ送り情報: 「1466記事中の 26 ～ 50 を表示」→「**全1466本のうち 26 ～ 50 本目を表示**」
- 連載パネル・連載ナビ: 「全 12 本」→「全12本」（累計表記「12本」とスペースを揃える）

**呼称**
- /authors/ の統計タイル「人」→「**著者数**」（カテゴリ・タグ詳細と同じ語彙。3タブ分）
- 期間ページのパンくず「全期間」→「**すべての記事**」（h1・タブ表示 #2218 と同じ語。ホーム > すべての記事 > 2024年 > 8月）

**h1 の単位の位置**
- 年ページ: 「2024<small> 年のすべての記事</small>」→「**2024年**<small>のすべての記事</small>」（月ページの「2026年8月」と同じく単位を数字側に）

**ページ送り情報の一本化（#2210）**
- `_partial/pagination-info.ejs` を新設し、index / category / tag / author の4テンプレートのコピペ（スペース・ラッパー div の有無が揺れていた）を置き換え。`div.pagination-info` のスタイルも全ページに効くようになる

## 動作確認（ローカル）

- /tags/Go/page/2/ ・ /page/2/ ・ /categories/Programming/page/2/ → 「全N本のうち 26 ～ 50 本目を表示」
- /articles/ の年カード・年ページの月カード → 「94本」
- /authors/ → タイルが「著者数」
- /articles/2024/ → パンくず「すべての記事」・h1「2024年のすべての記事」

🤖 Generated with [Claude Code](https://claude.com/claude-code)