### PR TITLE
節見出しのアンカーを全ページで揃える

### DIFF
--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -5,7 +5,7 @@
 <% const isHomeFirst = isHome && page.current === 1; %>
 <% if (isHomeFirst) { %>
   <section class="popular-articles home-ranking">
-      <h2 id="popular" class="bottom-content-header"><a href="#popular" class="headerlink" title="よく読まれている記事"></a>よく読まれている記事</h2>
+      <%- partial('section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
       <div class="margin-bottom-20 nav tabs">
         <input id="monthly" type="radio" name="tab_item" checked>
         <label tabindex="0" class="tab_item" for="monthly">トレンド</label>
@@ -31,7 +31,7 @@
 <% const panels = recent_series(4); %>
 <% if (panels.length) { %>
   <section class="series-panels">
-    <h2 id="series" class="bottom-content-header"><a href="#series" class="headerlink" title="連載から探す"></a>連載から探す</h2>
+    <%- partial('section-heading', {id: 'series', text: '連載から探す'}) %>
     <div class="row g-4">
       <% panels.forEach(function(s){ %>
       <div class="col-12 col-md-6">
@@ -53,7 +53,7 @@
     <div class="blog-tags margin-bottom-20">
       <%# 実体は list_toppagetags のシェア数順・件数上限ありのリストなので
           「人気のタグ」。/tags/ の同名セクションと表記を揃える (#2052) %>
-      <h2 id="searchbytag" class="bottom-content-header"><a href="#searchbytag" class="headerlink" title="人気のタグから記事を探す"></a>人気のタグから記事を探す</h2>
+      <%- partial('section-heading', {id: 'searchbytag', text: '人気のタグから記事を探す'}) %>
       <%- partial('../_widget/tag.ejs') %>
     </div>
   </section>
@@ -81,7 +81,7 @@
         間隔を二重取りして見出しとリストが離れる %>
     <% const listHeading = (typeof list_heading !== 'undefined' && list_heading) ? list_heading : (isHome ? (page.current === 1 ? '新着記事' : '記事一覧') : null); %>
     <% if (listHeading) { %>
-    <h2 id="posts" class="bottom-content-header"><a href="#posts" class="headerlink" title="記事一覧"></a><%= listHeading %></h2>
+    <%- partial('section-heading', {id: 'posts', text: listHeading}) %>
     <% } %>
     <%# 見出しとリストの間に置きたい補足を呼び出し側から差し込む %>
     <% if (typeof list_note !== 'undefined' && list_note) { %>

--- a/themes/future/layout/_partial/related-tags.ejs
+++ b/themes/future/layout/_partial/related-tags.ejs
@@ -8,7 +8,7 @@
     <%# 見出しは記事ページの「関連記事」に合わせる。あちらも内部ではスコアで
         並べているが強度は名乗っていない。「関連が強いタグ」とすると根拠を
         問われるうえ、実際には絞り込み系と発見系が混在していて言い切れない %>
-    <h2 id="relatedtags" class="bottom-content-header"><a href="#relatedtags" class="headerlink" title="関連タグ"></a>関連タグ</h2>
+    <%- partial('section-heading', {id: 'relatedtags', text: '関連タグ'}) %>
     <%# チップだと関連の中身（何本の記事を共有しているか・同じ系列か）が
         title 属性に隠れてホバーしないと分からない。著者ページの
         「よく使うタグ」と同じ tendency-panel の作りで常時見せる (#2172)。

--- a/themes/future/layout/_partial/section-heading.ejs
+++ b/themes/future/layout/_partial/section-heading.ejs
@@ -1,0 +1,4 @@
+<%# 節見出しの共通形 (#2215)。本文の見出し（hexo-renderer-marked）と同じ
+    headerlink 付きアンカーを全ページで揃える。title は見出し文と同じにし、
+    aria-label は headerlink_a11y.js が補う %>
+<h2 id="<%= id %>" class="bottom-content-header"><a href="#<%= id %>" class="headerlink" title="<%= text %>"></a><%= text %></h2>

--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -33,7 +33,7 @@
     </ul>
     <%# 週別 × カテゴリ別の積み上げ。年ページの「投稿数の推移」の月スコープ版。
         月の中はデータ量が少ないのでタブは設けず1枚にする (#2227) %>
-    <h2 class="bottom-content-header">投稿数の推移</h2>
+    <%- partial('_partial/section-heading', {id: 'trend', text: '投稿数の推移'}) %>
     <div id="chart-week" style="width:100%;min-height:250px"></div>
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
     <script type="text/javascript">
@@ -63,7 +63,7 @@
     <% const ym = page.year.toString() + page.month.toString().padStart(2, '0'); %>
     <% const monthPopular = popular_posts_in(site.posts.filter(function(p){ return p.date.format('YYYYMM') === ym; }).toArray()); %>
     <% if (monthPopular) { %>
-    <h2 class="bottom-content-header">よく読まれている記事</h2>
+    <%- partial('_partial/section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
     <%- monthPopular %>
     <% } %>
     <% } %>
@@ -86,7 +86,7 @@
         マークアップは list_archives の出力（件数の span はリンクの外）を模す。
         投稿が無い月も、歯抜けにせずリンク無しのダミーカードで置く。
         今年のまだ来ていない月だけは出さない %>
-    <h2 class="bottom-content-header">月から探す</h2>
+    <%- partial('_partial/section-heading', {id: 'months', text: '月から探す'}) %>
     <section class="archives">
       <ul class="archive-list">
         <% const now = new Date(); %>
@@ -101,7 +101,7 @@
         <% } %>
       </ul>
     </section>
-    <h2 class="bottom-content-header">投稿数の推移</h2>
+    <%- partial('_partial/section-heading', {id: 'trend', text: '投稿数の推移'}) %>
     <%- partial('_partial/posts-chart', {year: page.year}) %>
     <%# その年の中でよく読まれている記事 (#2214)。著者ページと同じく
         グラフの後・新着一覧の前。年内は経過年数がほぼ同じなので、
@@ -109,7 +109,7 @@
     <% if (page.current === 1) { %>
     <% const yearPopular = popular_posts_in(site.posts.filter(function(p){ return p.date.format('YYYY') === page.year.toString(); }).toArray()); %>
     <% if (yearPopular) { %>
-    <h2 class="bottom-content-header">よく読まれている記事</h2>
+    <%- partial('_partial/section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
     <%- yearPopular %>
     <% } %>
     <% } %>
@@ -129,7 +129,7 @@
       <li class="summary-sub"><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
     </ul>
 
-    <h2 class="bottom-content-header">年から探す</h2>
+    <%- partial('_partial/section-heading', {id: 'years', text: '年から探す'}) %>
     <section class="archives">
     <%
       const trans = (str, path=page.path) => {
@@ -141,13 +141,13 @@
     %>
     <%- list_archives({format: "YYYY", type:"yearly", transform:trans}) %>
 
-    <h2 class="bottom-content-header">投稿数の推移</h2>
+    <%- partial('_partial/section-heading', {id: 'trend', text: '投稿数の推移'}) %>
     <%- partial('_partial/posts-chart', {year: null}) %>
 
     <% } %>
     <%# 見出しの語彙は他の一覧ページに合わせる。ここは全記事の時系列リストなので
         「新着記事」ではなく常に「記事一覧」 %>
-    <h2 class="bottom-content-header">記事一覧</h2>
+    <%- partial('_partial/section-heading', {id: 'posts', text: '記事一覧'}) %>
     <%- partial('_partial/archive-all', {pagination: config.archive}) %>
     <%# 前後の期間へのページャー (#2228)。連載ナビと同じ型（前が左・
         対象明示型のラベル＋行き先名）で、一覧を読み終えた位置に置く。

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -31,7 +31,7 @@
     <%# 並びはカテゴリ・タグページの「統計 → よく読まれている記事 → 新着」に
         揃える (#2191)。月別投稿数のグラフは統計の一種とみなして統計の直後に置く %>
     <%# 見出しは他のチャートと同じ「◯別 △の推移」の型 (#2212) %>
-    <h2 class="bottom-content-header">月別 投稿数の推移</h2>
+    <%- partial('_partial/section-heading', {id: 'trend', text: '月別 投稿数の推移'}) %>
     <div id="chart" style="width:100%;min-height:250px"></div>
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
     <script type="text/javascript">
@@ -82,7 +82,7 @@
         順位・件数の規則は共有ヘルパー（popular_posts_in）側 %>
     <% const authorPopular = popular_posts_in(site.posts.filter(function(p){ return p.author === page.author; }).toArray()); %>
     <% if (authorPopular) { %>
-    <h2 class="bottom-content-header">よく読まれている記事</h2>
+    <%- partial('_partial/section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
     <%- authorPopular %>
     <% } %>
     <%# 全幅の h2 セクションを縦に積む。左右2列にすると、直前の
@@ -92,7 +92,7 @@
         他ページの「タグ総数」と同じ表現で違う意味になり、クリック先の
         件数とも食い違う）。この著者が何本書いたかはパネル側が名乗る (#2129) %>
     <% if (as.topCategories.length) { %>
-    <h2 class="bottom-content-header">よく使うカテゴリ</h2>
+    <%- partial('_partial/section-heading', {id: 'topcategories', text: 'よく使うカテゴリ'}) %>
     <ul class="tendency-panels">
       <% as.topCategories.forEach(function(c){ %>
       <li class="tendency-panel">
@@ -104,7 +104,7 @@
     </ul>
     <% } %>
     <% if (as.topTags.length) { %>
-    <h2 class="bottom-content-header">よく使うタグ</h2>
+    <%- partial('_partial/section-heading', {id: 'toptags', text: 'よく使うタグ'}) %>
     <ul class="tendency-panels">
       <% as.topTags.forEach(function(t){ %>
       <li class="tendency-panel">

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -43,7 +43,7 @@
 
       <%# 一覧が主役なので推移グラフは補足の読み物として最後に置く。
           /categories/ の「カテゴリ別 投稿数の推移」と同じ型 %>
-      <h2 class="bottom-content-header">年別 著者数の推移</h2>
+      <%- partial('_partial/section-heading', {id: 'trend', text: '年別 著者数の推移'}) %>
       <div id="chart" style="width:100%;min-height:350px"></div>
       <%# 種別の定義。凡例のホバーでも出すが、タッチ端末はホバーが無いので
           注記でも読めるようにする %>

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -33,7 +33,7 @@
       <% }) %>
     </ul>
 
-    <h2 class="bottom-content-header">カテゴリ別 投稿数の推移</h2>
+    <%- partial('_partial/section-heading', {id: 'trend', text: 'カテゴリ別 投稿数の推移'}) %>
     ※四半期ごとの投稿数を表示（2018年以前は年単位）
     <div id="category-chart" class="footer-gap" style="width: 100%; height: 400px;"></div>
 

--- a/themes/future/layout/category-without.ejs
+++ b/themes/future/layout/category-without.ejs
@@ -28,11 +28,11 @@
     </ul>
     <% const popular = popular_posts_in(page.withoutPosts.toArray()); %>
     <% if (popular) { %>
-    <h2 class="bottom-content-header">よく読まれている記事</h2>
+    <%- partial('_partial/section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
     <%- popular %>
     <% } %>
     <% if (stats.topTags.length) { %>
-    <h2 class="bottom-content-header">よく使われるタグ</h2>
+    <%- partial('_partial/section-heading', {id: 'toptags', text: 'よく使われるタグ'}) %>
     <div class="blog-tags">
       <ul class="tag-list">
         <% stats.topTags.forEach(function(t){ %>

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -38,7 +38,7 @@
     <% const catAll = site.categories.findOne({name: page.category}); %>
     <% const popular = catAll ? popular_posts_in(catAll.posts.toArray()) : ''; %>
     <% if (popular) { %>
-    <h2 class="bottom-content-header">よく読まれている記事</h2>
+    <%- partial('_partial/section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
     <%- popular %>
     <% } %>
     <% if (cs && cs.topTags.length) { %>
@@ -46,7 +46,7 @@
         著者ページの「よく使うタグ」・タグページの「関連タグ」と同じ
         tendency-panel の作りに揃える。チップは通常のタグ表現のまま、
         カテゴリ内の本数はパネル側が「n本で使用」と名乗る (#2129) %>
-    <h2 class="bottom-content-header">よく使われるタグ</h2>
+    <%- partial('_partial/section-heading', {id: 'toptags', text: 'よく使われるタグ'}) %>
     <ul class="tendency-panels">
       <% cs.topTags.forEach(function(t){ %>
       <li class="tendency-panel">
@@ -61,7 +61,7 @@
         つながったのかが隠れて、読者が関連の質を判断できない %>
     <% const rc = related_categories(page.category); %>
     <% if (rc.length) { %>
-    <h2 class="bottom-content-header">関連カテゴリ</h2>
+    <%- partial('_partial/section-heading', {id: 'relatedcategories', text: '関連カテゴリ'}) %>
     <ul class="tendency-panels">
       <% rc.forEach(function(c){ %>
       <li class="tendency-panel">

--- a/themes/future/layout/tag.ejs
+++ b/themes/future/layout/tag.ejs
@@ -40,7 +40,7 @@
     <% const tagAll = site.tags.findOne({name: page.tag}); %>
     <% const popular = tagAll ? popular_posts_in(tagAll.posts.toArray()) : ''; %>
     <% if (popular) { %>
-    <h2 class="bottom-content-header">よく読まれている記事</h2>
+    <%- partial('_partial/section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
     <%- popular %>
     <% } %>
     <%# カテゴリページの「よく使われるタグ」の対になる導線。関連タグより
@@ -49,7 +49,7 @@
         テキストリンク。本数はパネル側が「n本が所属」と名乗る (#2129) %>
     <% const tc = tag_stats(page.tag); %>
     <% if (tc && tc.topCategories.length) { %>
-    <h2 class="bottom-content-header">よく使われるカテゴリ</h2>
+    <%- partial('_partial/section-heading', {id: 'topcategories', text: 'よく使われるカテゴリ'}) %>
     <ul class="tendency-panels">
       <% tc.topCategories.forEach(function(c){ %>
       <li class="tendency-panel">

--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -22,10 +22,10 @@
           h1「タグ一覧」がページの目的を宣言しているので、見出しは
           「〜から記事を探す」を繰り返さない体言止めにする（ホーム側は
           文脈が混在するため説明的な「人気のタグから記事を探す」のまま） %>
-      <h2 class="bottom-content-header">人気のタグ</h2>
+      <%- partial('_partial/section-heading', {id: 'populartags', text: '人気のタグ'}) %>
       <%- ranking_tags() %>
       <%# 「今年初出」ではなく件数固定の新着。トップページの「新着記事」と同じ語彙 %>
-      <h2 class="bottom-content-header">新着タグ</h2>
+      <%- partial('_partial/section-heading', {id: 'newtags', text: '新着タグ'}) %>
       <%# マークアップは「関連タグ」（archive.ejs）や _widget/tag.ejs と揃える。
           同じ見た目の要素が別の作りだとスタイルの調整が二重になる %>
       <div class="blog-tags">
@@ -41,7 +41,7 @@
           「定着したか」で積み上げる案もあったが、新しい年ほど再利用の
           機会が無いだけで交絡するため、新規数だけを出す %>
       <%# 見出しは他のチャートと同じ「◯別 △の推移」の型 (#2212) %>
-      <h2 class="bottom-content-header">年別 新規タグ数の推移</h2>
+      <%- partial('_partial/section-heading', {id: 'newtagstrend', text: '年別 新規タグ数の推移'}) %>
       <div id="chart" style="width:100%;min-height:250px"></div>
       <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
       <script type="text/javascript">
@@ -57,7 +57,7 @@
         });
       </script>
 
-      <h2 class="bottom-content-header">タグクラウド</h2>
+      <%- partial('_partial/section-heading', {id: 'tagcloud', text: 'タグクラウド'}) %>
       <div class="tag-cloud footer-gap">
       <%- custom_tagcloud({min_font:12, max_font:36}) %>
       </div>


### PR DESCRIPTION
## 概要

Close #2215

セクション見出し（h2.bottom-content-header）のアンカーリンクの有無がページで揺れていたのを統一します。

## 方針

記事本文の見出しは hexo-renderer-marked が headerlink 付きアンカーを差し込んでおり、`headerlink_a11y.js` が aria-label を補う仕組みも既にあります。つまり**アンカー付きがサイトの標準形**なので、「外す」ではなく「全セクション h2 に付ける」方向で揃えました。

## 実装

- `_partial/section-heading.ejs` を新設し、見出しの型（id ＋ headerlink ＋ title）を1箇所に集約
- ホーム・カテゴリ・タグ・著者・期間の各ページと一覧3ページ、related-tags・category-without の**計23箇所**の h2 を置き換え。既存の id（popular / series / searchbytag / posts / relatedtags）は維持し、新規セクションには toptags / topcategories / relatedcategories / trend / months / years などの id を付与（ディープリンクが可能になる）
- **title 固定バグの解消**: 一覧見出しのアンカー title が「記事一覧」固定で、「新着記事」の見出しでもズレていたのが、partial 化で見出し文に追従するようになる
- /doctor/ は運営向けページ（noindex）なので対象外

## 動作確認（ローカル）

- カテゴリ・タグ・著者・年ページ・一覧各ページで、全セクション h2 に id ＋ aria-label 付きアンカーが出ることを確認
- 1ページ目の一覧見出しが `title="新着記事"` になる（従来は記事一覧固定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)