### PR TITLE
一覧・期間ページの構成を「統計 → グラフ → コンテンツ」に統一する

### DIFF
--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -81,6 +81,8 @@
       <li class="summary-sub"><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
       <li class="summary-sub"><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
     </ul>
+    <%- partial('_partial/section-heading', {id: 'trend', text: '投稿数の推移'}) %>
+    <%- partial('_partial/posts-chart', {year: page.year}) %>
     <%# 月ページへの唯一の導線 (#2219)。/articles/ の「年から探す」と同じ
         カード型で、位置（統計の直下）と新しい順の並びも揃える。
         マークアップは list_archives の出力（件数の span はリンクの外）を模す。
@@ -101,8 +103,6 @@
         <% } %>
       </ul>
     </section>
-    <%- partial('_partial/section-heading', {id: 'trend', text: '投稿数の推移'}) %>
-    <%- partial('_partial/posts-chart', {year: page.year}) %>
     <%# その年の中でよく読まれている記事 (#2214)。著者ページと同じく
         グラフの後・新着一覧の前。年内は経過年数がほぼ同じなので、
         ペナルティは相殺されて素直に PV 順になる %>
@@ -129,6 +129,8 @@
       <li class="summary-sub"><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
     </ul>
 
+    <%- partial('_partial/section-heading', {id: 'trend', text: '投稿数の推移'}) %>
+    <%- partial('_partial/posts-chart', {year: null}) %>
     <%- partial('_partial/section-heading', {id: 'years', text: '年から探す'}) %>
     <section class="archives">
     <%
@@ -140,9 +142,6 @@
       }
     %>
     <%- list_archives({format: "YYYY", type:"yearly", transform:trans}) %>
-
-    <%- partial('_partial/section-heading', {id: 'trend', text: '投稿数の推移'}) %>
-    <%- partial('_partial/posts-chart', {year: null}) %>
 
     <% } %>
     <%# 見出しの語彙は他の一覧ページに合わせる。ここは全記事の時系列リストなので

--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -83,8 +83,19 @@
     </ul>
     <%- partial('_partial/section-heading', {id: 'trend', text: '投稿数の推移'}) %>
     <%- partial('_partial/posts-chart', {year: page.year}) %>
+    <%# その年の中でよく読まれている記事 (#2214)。読者にまず見せたい
+        優先度の高い順に、定番 → 月の探索 → 新着一覧と並べる。
+        年内は経過年数がほぼ同じなので、ペナルティは相殺されて
+        素直に PV 順になる %>
+    <% if (page.current === 1) { %>
+    <% const yearPopular = popular_posts_in(site.posts.filter(function(p){ return p.date.format('YYYY') === page.year.toString(); }).toArray()); %>
+    <% if (yearPopular) { %>
+    <%- partial('_partial/section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
+    <%- yearPopular %>
+    <% } %>
+    <% } %>
     <%# 月ページへの唯一の導線 (#2219)。/articles/ の「年から探す」と同じ
-        カード型で、位置（統計の直下）と新しい順の並びも揃える。
+        カード型で、新しい順の並びも揃える。
         マークアップは list_archives の出力（件数の span はリンクの外）を模す。
         投稿が無い月も、歯抜けにせずリンク無しのダミーカードで置く。
         今年のまだ来ていない月だけは出さない %>
@@ -103,16 +114,6 @@
         <% } %>
       </ul>
     </section>
-    <%# その年の中でよく読まれている記事 (#2214)。著者ページと同じく
-        グラフの後・新着一覧の前。年内は経過年数がほぼ同じなので、
-        ペナルティは相殺されて素直に PV 順になる %>
-    <% if (page.current === 1) { %>
-    <% const yearPopular = popular_posts_in(site.posts.filter(function(p){ return p.date.format('YYYY') === page.year.toString(); }).toArray()); %>
-    <% if (yearPopular) { %>
-    <%- partial('_partial/section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
-    <%- yearPopular %>
-    <% } %>
-    <% } %>
     <% } else { %>
     <%# 全期間には「よく読まれている記事」を置かない (#2214)。
         全記事対象のランキングはホーム1ページ目が担っていて、二重になる %>

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -13,36 +13,7 @@
         <li><span class="summary-count"><%= count_articles() %></span><br><span class="summary-label">投稿</span></li>
       </ul>
 
-      <%# 全年を縦に並べると16セクションになるが、普段見るのは今年だけなので
-          タブで切り替える。既定は今年 (#2073)。ランキングと同じ radio + label 方式 %>
-      <div class="nav tabs year-tabs">
-        <%
-          const currentYear = new Date().getFullYear();
-          for (let year = currentYear; year >= 2016; year--) {
-        %>
-        <input id="authors-<%= year %>" type="radio" name="authors_year"<%= year === currentYear ? ' checked' : '' %>>
-        <label tabindex="0" class="tab_item" for="authors-<%= year %>"><%= year %></label>
-        <div class="tab_content">
-          <ul class="summary">
-            <li><span class="summary-count"><%= count_authors(year.toString()) %></span><br><span class="summary-label">著者数</span></li>
-            <li><span class="summary-count"><%= count_articles_year(year.toString()) %></span><br><span class="summary-label">投稿</span></li>
-          </ul>
-          <%- list_authors(year.toString()) %>
-        </div>
-        <% } %>
-        <input id="authors-all" type="radio" name="authors_year">
-        <label tabindex="0" class="tab_item tab_item-all" for="authors-all">全期間</label>
-        <div class="tab_content">
-          <ul class="summary">
-            <li><span class="summary-count"><%= count_authors() %></span><br><span class="summary-label">著者数</span></li>
-            <li><span class="summary-count"><%= count_articles() %></span><br><span class="summary-label">投稿</span></li>
-          </ul>
-          <%- list_authors() %>
-        </div>
-      </div>
-
-      <%# 一覧が主役なので推移グラフは補足の読み物として最後に置く。
-          /categories/ の「カテゴリ別 投稿数の推移」と同じ型 %>
+      <%# 統計の直下にグラフ、その後にコンテンツの一覧。全ページ同じ並びにする (#2211) %>
       <%- partial('_partial/section-heading', {id: 'trend', text: '年別 著者数の推移'}) %>
       <div id="chart" style="width:100%;min-height:350px"></div>
       <%# 種別の定義。凡例のホバーでも出すが、タッチ端末はホバーが無いので
@@ -114,6 +85,35 @@
         };
         myChart.setOption(option);
       </script>
+
+      <%# 全年を縦に並べると16セクションになるが、普段見るのは今年だけなので
+          タブで切り替える。既定は今年 (#2073)。ランキングと同じ radio + label 方式 %>
+      <div class="nav tabs year-tabs">
+        <%
+          const currentYear = new Date().getFullYear();
+          for (let year = currentYear; year >= 2016; year--) {
+        %>
+        <input id="authors-<%= year %>" type="radio" name="authors_year"<%= year === currentYear ? ' checked' : '' %>>
+        <label tabindex="0" class="tab_item" for="authors-<%= year %>"><%= year %></label>
+        <div class="tab_content">
+          <ul class="summary">
+            <li><span class="summary-count"><%= count_authors(year.toString()) %></span><br><span class="summary-label">著者数</span></li>
+            <li><span class="summary-count"><%= count_articles_year(year.toString()) %></span><br><span class="summary-label">投稿</span></li>
+          </ul>
+          <%- list_authors(year.toString()) %>
+        </div>
+        <% } %>
+        <input id="authors-all" type="radio" name="authors_year">
+        <label tabindex="0" class="tab_item tab_item-all" for="authors-all">全期間</label>
+        <div class="tab_content">
+          <ul class="summary">
+            <li><span class="summary-count"><%= count_authors() %></span><br><span class="summary-label">著者数</span></li>
+            <li><span class="summary-count"><%= count_articles() %></span><br><span class="summary-label">投稿</span></li>
+          </ul>
+          <%- list_authors() %>
+        </div>
+      </div>
+
     </div>
   </section>
 </div>

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -8,6 +8,12 @@
 
     <h1 class="list-page margin-bottom-20">カテゴリ一覧</h1>
 
+    <%# 統計は h1 直下。/tags/・/authors/ と同じ流儀 (#2211) %>
+    <ul class="summary">
+      <li><span class="summary-count"><%= site.categories.length %></span><br><span class="summary-label">カテゴリ数</span></li>
+      <li><span class="summary-count"><%= count_articles() %></span><br><span class="summary-label">投稿</span></li>
+    </ul>
+
     <%# 一覧がページの主役なので h1 直下に置き、推移グラフは補足の読み物として後ろへ。
         カテゴリ名は広い言葉なので、代表タグと直近1年の投稿数を添えて
         中身の見当と活発さが分かるようにする (#2056) %>
@@ -22,10 +28,13 @@
           <span class="category-index-meta">累計 <%= c.count %>本・<%= c.authorCount %>名</span>
           <span class="category-index-meta">直近1年 <%= c.recent %>本・<%= c.recentAuthorCount %>名</span>
         </div>
+        <%# チップの右肩の件数は「タグ総数」の意味で使う (#2129)。ここに出せる
+            のはカテゴリ内の本数で意味が違うため出さない（title には残す）。
+            本数付きの一覧はカテゴリ個別ページの「よく使われるタグ」が持つ %>
         <div class="blog-tags">
           <ul class="tag-list">
             <% c.topTags.forEach(function(t){ %>
-            <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= c.name %> カテゴリの <%= t.name %> の記事 <%= t.count %>本"><%= t.name %><span class="tag-list-count"><%= t.count %></span></a></li>
+            <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= c.name %> カテゴリの <%= t.name %> の記事 <%= t.count %>本"><%= t.name %></a></li>
             <% }) %>
           </ul>
         </div>

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -14,37 +14,10 @@
       <li><span class="summary-count"><%= count_articles() %></span><br><span class="summary-label">投稿</span></li>
     </ul>
 
-    <%# 一覧がページの主役なので h1 直下に置き、推移グラフは補足の読み物として後ろへ。
-        カテゴリ名は広い言葉なので、代表タグと直近1年の投稿数を添えて
-        中身の見当と活発さが分かるようにする (#2056) %>
-    ※各カテゴリに、記事数と寄稿した執筆者数（累計・直近1年）、よく使われるタグを添えています
-    <ul class="category-index">
-      <% category_index().forEach(function(c){ %>
-      <li class="category-index-item">
-        <div class="category-index-head">
-          <a class="category-index-name" href="<%- url_for(c.path) %>"><%= c.name %></a>
-          <%# 累計と直近1年を「本数・名数」の同じ形の対にする。
-              名数の意味（寄稿した執筆者数）は上の注記が説明する %>
-          <span class="category-index-meta">累計 <%= c.count %>本・<%= c.authorCount %>名</span>
-          <span class="category-index-meta">直近1年 <%= c.recent %>本・<%= c.recentAuthorCount %>名</span>
-        </div>
-        <%# チップの右肩の件数は「タグ総数」の意味で使う (#2129)。ここに出せる
-            のはカテゴリ内の本数で意味が違うため出さない（title には残す）。
-            本数付きの一覧はカテゴリ個別ページの「よく使われるタグ」が持つ %>
-        <div class="blog-tags">
-          <ul class="tag-list">
-            <% c.topTags.forEach(function(t){ %>
-            <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= c.name %> カテゴリの <%= t.name %> の記事 <%= t.count %>本"><%= t.name %></a></li>
-            <% }) %>
-          </ul>
-        </div>
-      </li>
-      <% }) %>
-    </ul>
-
+    <%# 統計の直下にグラフ、その後にコンテンツの一覧。全ページ同じ並びにする (#2211) %>
     <%- partial('_partial/section-heading', {id: 'trend', text: 'カテゴリ別 投稿数の推移'}) %>
     ※四半期ごとの投稿数を表示（2018年以前は年単位）
-    <div id="category-chart" class="footer-gap" style="width: 100%; height: 400px;"></div>
+    <div id="category-chart" style="width: 100%; height: 400px;"></div>
 
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
 
@@ -72,6 +45,34 @@
       };
       myChart.setOption(option);
     </script>
+
+    <%# カテゴリ名は広い言葉なので、代表タグと直近1年の投稿数を添えて
+        中身の見当と活発さが分かるようにする (#2056) %>
+    ※各カテゴリに、記事数と寄稿した執筆者数（累計・直近1年）、よく使われるタグを添えています
+    <ul class="category-index footer-gap">
+      <% category_index().forEach(function(c){ %>
+      <li class="category-index-item">
+        <div class="category-index-head">
+          <a class="category-index-name" href="<%- url_for(c.path) %>"><%= c.name %></a>
+          <%# 累計と直近1年を「本数・名数」の同じ形の対にする。
+              名数の意味（寄稿した執筆者数）は上の注記が説明する %>
+          <span class="category-index-meta">累計 <%= c.count %>本・<%= c.authorCount %>名</span>
+          <span class="category-index-meta">直近1年 <%= c.recent %>本・<%= c.recentAuthorCount %>名</span>
+        </div>
+        <%# チップの右肩の件数は「タグ総数」の意味で使う (#2129)。ここに出せる
+            のはカテゴリ内の本数で意味が違うため出さない（title には残す）。
+            本数付きの一覧はカテゴリ個別ページの「よく使われるタグ」が持つ %>
+        <div class="blog-tags">
+          <ul class="tag-list">
+            <% c.topTags.forEach(function(t){ %>
+            <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= c.name %> カテゴリの <%= t.name %> の記事 <%= t.count %>本"><%= t.name %></a></li>
+            <% }) %>
+          </ul>
+        </div>
+      </li>
+      <% }) %>
+    </ul>
+
 
   </section>
 </div>

--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -16,6 +16,26 @@
         <li><span class="summary-count"><%= perTag.mean %></span><br><span class="summary-label">タグあたりの記事（平均）</span></li>
         <li><span class="summary-count"><%= perTag.median %></span><br><span class="summary-label">タグあたりの記事（中央値）</span></li>
       </ul>
+      <%# 統計の直下にグラフ、その後にコンテンツの一覧。全ページ同じ並びにする (#2211)。初出の年で数える。
+          「定着したか」で積み上げる案もあったが、新しい年ほど再利用の
+          機会が無いだけで交絡するため、新規数だけを出す %>
+      <%# 見出しは他のチャートと同じ「◯別 △の推移」の型 (#2212) %>
+      <%- partial('_partial/section-heading', {id: 'newtagstrend', text: '年別 新規タグ数の推移'}) %>
+      <div id="chart" style="width:100%;min-height:250px"></div>
+      <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
+      <script type="text/javascript">
+        const chartData = <%- new_tags_by_year() %>;
+        const myChart = echarts.init(document.getElementById('chart'));
+        myChart.setOption({
+          tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+          grid: { left: 0, right: '2%', containLabel: true },
+          xAxis: { type: 'category', data: chartData.years },
+          yAxis: { type: 'value', min: 0 },
+          color: ['#337ab7'],
+          series: [{ name: '新規タグ', type: 'bar', data: chartData.counts }]
+        });
+      </script>
+
       <%# セクション見出しはホーム（archive.ejs）と同じ bottom-content-header で
           上下に余白を取り、節の塊が分かれて見えるようにする。
           h1「タグ一覧」がページの目的を宣言しているので、見出しは
@@ -38,29 +58,9 @@
       </div>
 
       <%- partial('_partial/section-heading', {id: 'tagcloud', text: 'タグクラウド'}) %>
-      <div class="tag-cloud">
+      <div class="tag-cloud footer-gap">
       <%- custom_tagcloud({min_font:12, max_font:36}) %>
       </div>
 
-      <%# 一覧が主役なので推移グラフは補足の読み物として最後に置く
-          （/categories/・/authors/ と同じ型）。初出の年で数える。
-          「定着したか」で積み上げる案もあったが、新しい年ほど再利用の
-          機会が無いだけで交絡するため、新規数だけを出す %>
-      <%# 見出しは他のチャートと同じ「◯別 △の推移」の型 (#2212) %>
-      <%- partial('_partial/section-heading', {id: 'newtagstrend', text: '年別 新規タグ数の推移'}) %>
-      <div id="chart" class="footer-gap" style="width:100%;min-height:250px"></div>
-      <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
-      <script type="text/javascript">
-        const chartData = <%- new_tags_by_year() %>;
-        const myChart = echarts.init(document.getElementById('chart'));
-        myChart.setOption({
-          tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
-          grid: { left: 0, right: '2%', containLabel: true },
-          xAxis: { type: 'category', data: chartData.years },
-          yAxis: { type: 'value', min: 0 },
-          color: ['#337ab7'],
-          series: [{ name: '新規タグ', type: 'bar', data: chartData.counts }]
-        });
-      </script>
     </section>
 </div>

--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -3,7 +3,6 @@
         {label: 'ホーム', url: '/'},
         {label: 'タグ'}
       ]}) %>
-  <main class="col-xs-12 col-sm-12 col-md-10">
     <section id="main" class="margin-top-30">
       <h1 class="list-page margin-bottom-20">タグ一覧</h1>
       <%# 平均と中央値を並べるのは、少数の大きいタグに引っ張られて
@@ -11,7 +10,7 @@
       <% const perPost = tags_per_post(); %>
       <% const perTag = posts_per_tag(); %>
       <ul class="summary">
-        <li><span class="summary-count"><%= count_tags() %></span><br><span class="summary-label">タグ</span></li>
+        <li><span class="summary-count"><%= count_tags() %></span><br><span class="summary-label">タグ数</span></li>
         <li><span class="summary-count"><%= perPost.mean %></span><br><span class="summary-label">記事あたりのタグ（平均）</span></li>
         <li><span class="summary-count"><%= perPost.median %></span><br><span class="summary-label">記事あたりのタグ（中央値）</span></li>
         <li><span class="summary-count"><%= perTag.mean %></span><br><span class="summary-label">タグあたりの記事（平均）</span></li>
@@ -37,12 +36,19 @@
           </ul>
         </div>
       </div>
-      <%# タグがどれだけ増えてきたか。初出の年で数える。
+
+      <%- partial('_partial/section-heading', {id: 'tagcloud', text: 'タグクラウド'}) %>
+      <div class="tag-cloud">
+      <%- custom_tagcloud({min_font:12, max_font:36}) %>
+      </div>
+
+      <%# 一覧が主役なので推移グラフは補足の読み物として最後に置く
+          （/categories/・/authors/ と同じ型）。初出の年で数える。
           「定着したか」で積み上げる案もあったが、新しい年ほど再利用の
           機会が無いだけで交絡するため、新規数だけを出す %>
       <%# 見出しは他のチャートと同じ「◯別 △の推移」の型 (#2212) %>
       <%- partial('_partial/section-heading', {id: 'newtagstrend', text: '年別 新規タグ数の推移'}) %>
-      <div id="chart" style="width:100%;min-height:250px"></div>
+      <div id="chart" class="footer-gap" style="width:100%;min-height:250px"></div>
       <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
       <script type="text/javascript">
         const chartData = <%- new_tags_by_year() %>;
@@ -56,11 +62,5 @@
           series: [{ name: '新規タグ', type: 'bar', data: chartData.counts }]
         });
       </script>
-
-      <%- partial('_partial/section-heading', {id: 'tagcloud', text: 'タグクラウド'}) %>
-      <div class="tag-cloud footer-gap">
-      <%- custom_tagcloud({min_font:12, max_font:36}) %>
-      </div>
     </section>
-  </main>
 </div>


### PR DESCRIPTION
## 概要

Close #2211

一覧3ページ（/categories/・/tags/・/authors/）と期間ページ（すべての記事・年）の構成を統一します。

## 表示ルール

**h1 → 統計タイル → グラフ → コンテンツ** の並びに全ページを揃えます（レビューで「グラフは最後」から方針転換）。コンテンツ内は読者にまず見せたい優先度の高い順で、**定番（よく読まれている記事）→ 探索の入口（月から探す等）→ 新着一覧** の導線にします。

| ページ | 変更後の並び |
| --- | --- |
| /categories/ | 統計（**カテゴリ数・投稿 を新設**）→ カテゴリ別 投稿数の推移 → カテゴリ一覧 |
| /tags/ | 統計 → 年別 新規タグ数の推移 → 人気のタグ → 新着タグ → タグクラウド |
| /authors/ | 統計 → 年別 著者数の推移 → 年タブの著者一覧 |
| /articles/ | 統計 → 投稿数の推移 → 年から探す → 記事一覧 |
| 年ページ | 統計 → 投稿数の推移 → **よく読まれている記事 → 月から探す** → 記事一覧 |

フッター前の間隔（footer-gap）は各ページの最後のブロックへ移動しています。

## その他（#2211 の残項目）

- /tags/ の `col-md-10`（サイドバーが無いのに 10/12 幅）を外して全幅に
- カテゴリ一覧の行の代表タグからチップ右肩の件数を削除（title には残す）。右肩の件数は「タグ総数」の意味で統一しており（#2129）、ここだけカテゴリ内の本数で意味が違っていた
- /tags/ のタイル「タグ」→「タグ数」（「著者数」「カテゴリ数」と同じ「◯数」型）

## 動作確認（ローカル）

全ページで 統計 → グラフ → コンテンツ の順（年ページは popular → 月から探す → 記事一覧）とフッター間隔を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)