### PR TITLE
投稿数の推移のタブ名を積み上げの内訳で名乗る

### DIFF
--- a/themes/future/layout/_partial/posts-chart.ejs
+++ b/themes/future/layout/_partial/posts-chart.ejs
@@ -1,7 +1,8 @@
-<%# 投稿推移のグラフ。期間内訳（週の積み上げ）とカテゴリ内訳は別の軸で
+<%# 投稿推移のグラフ。期間内訳（週・月の積み上げ）とカテゴリ内訳は別の軸で
     同時に積めないため、タブで切り替える (#2171)。
     ランキングと同じ radio + label 方式で JS は足さない。
-    year が渡されればその年の月別、無ければ全期間の四半期別 %>
+    棒の粒度は year が渡されればその年の月、無ければ全期間の四半期。
+    粒度は両タブ共通なので、タブ名は積み上げの内訳の方で名乗る (#2222) %>
 <div class="nav tabs chart-tabs">
   <%# 既定はカテゴリ別。週の粗密より、何のジャンルが書かれているかの方が
       最初に見たい情報 %>
@@ -11,7 +12,7 @@
     <div id="chart-category" style="width:100%;min-height:250px"></div>
   </div>
   <input id="chart-tab-period" type="radio" name="chart_tab">
-  <label tabindex="0" class="tab_item" for="chart-tab-period"><%= year ? '月別' : '四半期別' %></label>
+  <label tabindex="0" class="tab_item" for="chart-tab-period"><%= year ? '週別' : '月別' %></label>
   <div class="tab_content">
     <div id="chart-period" style="width:100%;min-height:250px"></div>
   </div>


### PR DESCRIPTION
## 概要

Close #2222

全期間ページの「投稿数の推移」のタブ「四半期別」は、棒が四半期なのは隣の「カテゴリ別」タブも同じで、区別として意味がありませんでした（Issue の指摘どおり中身は月の内訳）。

## 原因と対応

タブ名の基準が混在していました。「カテゴリ別」は**積み上げの内訳**を、「四半期別／月別」は**棒の粒度**を名乗っていた。棒の粒度は両タブ共通なので、タブ名は内訳の方で名乗るように統一します。

| ページ | 棒の粒度（共通） | タブ名（変更前 → 後） |
| --- | --- | --- |
| 全期間 | 四半期 | カテゴリ別 / 四半期別 → カテゴリ別 / **月別** |
| 年 | 月 | カテゴリ別 / 月別 → カテゴリ別 / **週別** |

全期間の「月別」タブの中身（四半期棒を1か月目/2か月目/3か月目で積む）、年ページの「週別」タブの中身（月棒を第1〜5週で積む）は従来どおりで、名前が中身と一致するようになります。

## 動作確認（ローカル）

- /articles/ → タブが「カテゴリ別」「月別」
- /articles/2024/ → タブが「カテゴリ別」「週別」

🤖 Generated with [Claude Code](https://claude.com/claude-code)