### PR TITLE
出典の見出しの表記を markdownlint で止める

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,5 +1,7 @@
 {
+    "customRules": ["./.markdownlint/heading-vocab.cjs"],
     "config": {
+      "heading-vocab": true, // 出典の見出しを「参考」「参考文献」に統一する
       "line-length": false, // MD013  行の長さ
       "no-hard-tabs": false, // MD010 Markdown中にTSVを書くとエラーになるため
       "no-duplicate-heading": false, // MD024 - Multiple headings with the same content

--- a/.markdownlint/heading-vocab.cjs
+++ b/.markdownlint/heading-vocab.cjs
@@ -1,0 +1,46 @@
+'use strict';
+
+// 出典を示す節の見出しを「参考」「参考文献」に寄せる (#2239)。
+// prh では書けない。prh に渡るのは `## ` を除いたテキストなので、
+// 見出しと地の文を区別できず「参考資料を以下に載せます」まで書き換わる
+// プロトタイプを持たせない。持たせると `### toString` のような見出しが
+// Object.prototype のメンバーに当たって誤検出する
+const VOCAB = Object.assign(Object.create(null), {
+  '参考リンク': '参考',
+  '参考資料': '参考',
+  '参考記事': '参考',
+  '参照記事': '参考',
+  '参照サイト': '参考',
+  '参考情報': '参考',
+  '参考サイト': '参考',
+  '参考書籍': '参考文献',
+  'Appendix：参考文献の紹介': '参考文献'
+});
+
+module.exports = {
+  names: ['heading-vocab'],
+  description: '出典の見出しの表記を統一する',
+  tags: ['headings'],
+  parser: 'markdownit',
+  function: (params, onError) => {
+    for (const token of params.parsers.markdownit.tokens) {
+      if (token.type !== 'inline' || !token.map) continue;
+      // 完全一致のみ。部分一致にすると `## 参考：SQLのフォーマット例` のような
+      // 本文の補足や、`### 8. 参考資料` の章番号体系まで巻き込む
+      const expected = VOCAB[token.content];
+      if (!expected) continue;
+      const line = params.lines[token.map[0]];
+      if (!/^#{1,6}\s/.test(line)) continue;
+      onError({
+        lineNumber: token.map[0] + 1,
+        detail: `「${token.content}」は「${expected}」に統一します`,
+        context: line,
+        fixInfo: {
+          editColumn: 1,
+          deleteCount: line.length,
+          insertText: line.replace(token.content, expected)
+        }
+      });
+    }
+  }
+};


### PR DESCRIPTION
Closes #2242

#2239 で「参考」「参考文献」に統一した表記が、新しい記事で再発しないようにします。

```
source/_posts/2026/20261231a_サンプル.md:12 error heading-vocab
  出典の見出しの表記を統一する [「参考リンク」は「参考」に統一します] [Context: "## 参考リンク"]
```

`--fix` が効くので `make fmt` でそのまま直ります。

## prh ではなく markdownlint にした理由

prh に渡るのは `## ` を**除いた**テキストなので、パターンに `#` を書いても一致しません。実測です。

| prh のパターン | 検出 |
| --- | --- |
| `/^## 参考書籍$/` | **0件** |
| `参考書籍` | **2件**（見出し `1:4` と地の文 `3:1` の両方） |

`参考資料` `参考記事` は地の文にも普通に出る語なので、prh に入れると誤変換が実害になります。markdownlint なら行を直接見られるため、見出しだけに限定できます。

`.markdownlint-cli2.jsonc` に `customRules` を書くだけで読まれるので、**Makefile も CI のコマンドも変えていません**（textlint でローカルルールを読むには `--rulesdir` を Makefile と reviewdog のワークフロー両方に足す必要があります）。

## 動作確認

| 入力 | 判定 |
| --- | --- |
| `## 参考書籍` | → `## 参考文献` |
| `#### 参考リンク` | → `#### 参考`（**見出しレベルは保持**） |
| `参考書籍を以下に載せます。参考資料も参照。` | 素通り（地の文） |
| `## 参考：SQLの例` | 素通り（部分一致では当たらない） |
| `### 8. 参考資料` | 素通り（章番号体系） |
| コードブロック内の `## 参考資料` | 素通り |
| `### toString` `### constructor` `### valueOf` | 素通り（下記） |

**全1467記事で指摘0件。** #2239 で揃えた状態が保たれていることの確認になっています。

### プロトタイプ汚染を踏みました

最初 `VOCAB[token.content]` で引いていたため、`### toString` が `Object.prototype.toString` に当たり

```
### toString → 「function toString() { [native code] }」に統一します
```

と誤検出しました。`node_modules` 配下の Markdown を巻き込んだときに発見しています。`Object.create(null)` を土台にして塞ぎました。記事側に `### constructor` のような見出しが現れても安全です。

## スコープ外

`make fmt` の対象には**既存の指摘が9,939件**（`source/_posts` 配下のみ）あります。本 PR とは無関係の既存分なので触っていません。別 issue に切り出します。

- `MD060/table-column-style` 6,355件 / `MD045/no-alt-text` 2,058件 / `MD040/fenced-code-language` 331件 ほか
- あわせて `ignores` が `.claude/worktrees/*/node_modules` のような**ネストした node_modules** を無視できていない点も

🤖 Generated with [Claude Code](https://claude.com/claude-code)