### PR TITLE
ホームのランキングのタイトル横に小さいサムネを添える

### DIFF
--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const fs = require("fs");
-const {snsLabel} = require("./lib/post_list");
+const {postPanel} = require("./lib/post_list");
 
 const load = JSON.parse(fs.readFileSync("ga4_pv.json", 'utf-8'));
 const map = new Map();
@@ -58,16 +58,8 @@ hexo.extend.helper.register('popular_posts_in', function(posts, limit) {
 
   if (ranked.length === 0) return '';
 
-  // マークアップはホームの「連載から探す」と同じカード。2列で並べる
-  const cards = ranked.map(({post}) => {
-    const thumb = post.thumbnail
-      ? `<a href="/${post.path}" title="${post.title}" class="img_wrap panel-thumb"><img src="${post.thumbnail}" alt="" width="200" height="135" loading="lazy"></a>`
-      : '';
-    return `<div class="col-12 col-md-6"><div class="article-card post-panel h-100">${thumb}`
-      + `<div class="panel-body"><a href="/${post.path}" class="panel-title">${post.title}</a>`
-      + `<div class="panel-meta">${post.date.format('YYYY.MM.DD')}${snsLabel(post.permalink)}</div>`
-      + `</div></div></div>`;
-  }).join('');
+  // カードの形は「よく読まれている記事」系の共通部品（lib/post_list.js）
+  const cards = ranked.map(({post}) => postPanel(post)).join('');
 
   return `<div class="row g-4">${cards}</div>`;
 });

--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const fs = require("fs");
-const {postPanel} = require("./lib/post_list");
+const {snsLabel} = require("./lib/post_list");
 
 const load = JSON.parse(fs.readFileSync("ga4_pv.json", 'utf-8'));
 const map = new Map();
@@ -58,8 +58,16 @@ hexo.extend.helper.register('popular_posts_in', function(posts, limit) {
 
   if (ranked.length === 0) return '';
 
-  // カードの形は「よく読まれている記事」系の共通部品（lib/post_list.js）
-  const cards = ranked.map(({post}) => postPanel(post)).join('');
+  // マークアップはホームの「連載から探す」と同じカード。2列で並べる
+  const cards = ranked.map(({post}) => {
+    const thumb = post.thumbnail
+      ? `<a href="/${post.path}" title="${post.title}" class="img_wrap panel-thumb"><img src="${post.thumbnail}" alt="" width="200" height="135" loading="lazy"></a>`
+      : '';
+    return `<div class="col-12 col-md-6"><div class="article-card post-panel h-100">${thumb}`
+      + `<div class="panel-body"><a href="/${post.path}" class="panel-title">${post.title}</a>`
+      + `<div class="panel-meta">${post.date.format('YYYY.MM.DD')}${snsLabel(post.permalink)}</div>`
+      + `</div></div></div>`;
+  }).join('');
 
   return `<div class="row g-4">${cards}</div>`;
 });

--- a/scripts/lib/post_list.js
+++ b/scripts/lib/post_list.js
@@ -32,28 +32,22 @@ const newLabel = date => {
  * @param {object} post          Hexo の post
  * @param {string} itemClass     li に付けるクラス
  * @param {string} [titleAttr]   a の title 属性。省略時は lede
+ * @param {boolean} [withThumb]  タイトルの左に小さいサムネを添える (#2230)
  */
-const postListItem = (post, itemClass, titleAttr) => {
+const postListItem = (post, itemClass, titleAttr, withThumb = false) => {
   const attr = (titleAttr === undefined ? post.lede : titleAttr) || '';
-  return `<li class="${itemClass}"><a href="/${post.path}" title="${attr}">${post.title}</a>`
+  const body = `<a href="/${post.path}" title="${attr}">${post.title}</a>`
     + `${newLabel(post.date)}`
-    + `<span class="post-meta"><span class="post-meta-date">${post.date.format('YYYY.MM.DD')}</span>${snsLabel(post.permalink)}</span></li>`;
-};
-
-/**
- * サムネ付きのカード1枚。row g-4 の中に並べる前提の col ごと返す。
- * 「よく読まれている記事」系のセクション（ホームのランキング・
- * カテゴリ / タグ / 著者 / 年ページ）で共用する。
- * マークアップはホームの「連載から探す」と同じカード
- */
-const postPanel = post => {
+    + `<span class="post-meta"><span class="post-meta-date">${post.date.format('YYYY.MM.DD')}</span>${snsLabel(post.permalink)}</span>`;
+  if (!withThumb) {
+    return `<li class="${itemClass}">${body}</li>`;
+  }
+  // タイトルと重複するリンクなので、タブ移動と読み上げからは外す。
+  // サムネの無い記事は同じ大きさの空き枠を置いて行頭を揃える
   const thumb = post.thumbnail
-    ? `<a href="/${post.path}" title="${post.title}" class="img_wrap panel-thumb"><img src="${post.thumbnail}" alt="" width="200" height="135" loading="lazy"></a>`
-    : '';
-  return `<div class="col-12 col-md-6"><div class="article-card post-panel h-100">${thumb}`
-    + `<div class="panel-body"><a href="/${post.path}" class="panel-title">${post.title}</a>`
-    + `<div class="panel-meta">${post.date.format('YYYY.MM.DD')}${snsLabel(post.permalink)}</div>`
-    + `</div></div></div>`;
+    ? `<a href="/${post.path}" class="post-list-icon" tabindex="-1" aria-hidden="true"><img src="${post.thumbnail}" alt="" width="48" height="32" loading="lazy"></a>`
+    : `<span class="post-list-icon post-list-icon-empty"></span>`;
+  return `<li class="${itemClass} post-list-item-thumb">${thumb}<div class="post-list-body">${body}</div></li>`;
 };
 
-module.exports = {snsLabel, newLabel, postListItem, postPanel};
+module.exports = {snsLabel, newLabel, postListItem};

--- a/scripts/lib/post_list.js
+++ b/scripts/lib/post_list.js
@@ -40,4 +40,20 @@ const postListItem = (post, itemClass, titleAttr) => {
     + `<span class="post-meta"><span class="post-meta-date">${post.date.format('YYYY.MM.DD')}</span>${snsLabel(post.permalink)}</span></li>`;
 };
 
-module.exports = {snsLabel, newLabel, postListItem};
+/**
+ * サムネ付きのカード1枚。row g-4 の中に並べる前提の col ごと返す。
+ * 「よく読まれている記事」系のセクション（ホームのランキング・
+ * カテゴリ / タグ / 著者 / 年ページ）で共用する。
+ * マークアップはホームの「連載から探す」と同じカード
+ */
+const postPanel = post => {
+  const thumb = post.thumbnail
+    ? `<a href="/${post.path}" title="${post.title}" class="img_wrap panel-thumb"><img src="${post.thumbnail}" alt="" width="200" height="135" loading="lazy"></a>`
+    : '';
+  return `<div class="col-12 col-md-6"><div class="article-card post-panel h-100">${thumb}`
+    + `<div class="panel-body"><a href="/${post.path}" class="panel-title">${post.title}</a>`
+    + `<div class="panel-meta">${post.date.format('YYYY.MM.DD')}${snsLabel(post.permalink)}</div>`
+    + `</div></div></div>`;
+};
+
+module.exports = {snsLabel, newLabel, postListItem, postPanel};

--- a/scripts/popular_posts.js
+++ b/scripts/popular_posts.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {getSNSCnt} = require('./lib/sns');
-const {postPanel} = require('./lib/post_list');
+const {postListItem} = require('./lib/post_list');
 
 const fs = require("fs");
 const gaCache = JSON.parse(fs.readFileSync("ga_cache.json", 'utf-8'));
@@ -73,9 +73,17 @@ hexo.extend.helper.register('popular_posts', function(term='weekly') {
     .sort(compareFunc)
     .slice(0, RANKING_DISPLAY_COUNT);
 
-  // カードの形は他ページの「よく読まれている記事」と共通（lib/post_list.js）。
-  // 同じ名前のセクションはどのページでも同じ見た目にする (#2230)
-  return `<div class="row g-4">${popularPosts.map(postPanel).join('')}</div>`;
+  // マークアップは「関連記事」「この記事を参照している記事」と共通（lib/post_list.js）。
+  // ランキングだけタイトルの手がかりに小さいサムネを添える (#2230)
+  const links = popularPosts.map(post => postListItem(post, 'featured-posts-item', undefined, true)).join("\n")
+
+  return `
+  <div class="widget">
+    <ul class="nav featured-post-link">
+      ${links}
+    </ul>
+  </div>
+  `
 });
 
 hexo.extend.helper.register('sns_popular_posts', function() {
@@ -84,5 +92,13 @@ hexo.extend.helper.register('sns_popular_posts', function() {
   allPosts.sort((a, b) => getSNSCnt(b.permalink) - getSNSCnt(a.permalink))
   const popularPost = allPosts.slice(0, RANKING_DISPLAY_COUNT)
 
-  return `<div class="row g-4">${popularPost.map(postPanel).join('')}</div>`;
+  const links = popularPost.map(post => postListItem(post, 'featured-posts-item', undefined, true)).join("\n")
+
+  return `
+  <div class="widget">
+    <ul class="nav featured-post-link">
+      ${links}
+    </ul>
+  </div>
+  `
 });

--- a/scripts/popular_posts.js
+++ b/scripts/popular_posts.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {getSNSCnt} = require('./lib/sns');
-const {postListItem} = require('./lib/post_list');
+const {postPanel} = require('./lib/post_list');
 
 const fs = require("fs");
 const gaCache = JSON.parse(fs.readFileSync("ga_cache.json", 'utf-8'));
@@ -73,16 +73,9 @@ hexo.extend.helper.register('popular_posts', function(term='weekly') {
     .sort(compareFunc)
     .slice(0, RANKING_DISPLAY_COUNT);
 
-  // マークアップは「関連記事」「この記事を参照している記事」と共通（lib/post_list.js）
-  const links = popularPosts.map(post => postListItem(post, 'featured-posts-item')).join("\n")
-
-  return `
-  <div class="widget">
-    <ul class="nav featured-post-link">
-      ${links}
-    </ul>
-  </div>
-  `
+  // カードの形は他ページの「よく読まれている記事」と共通（lib/post_list.js）。
+  // 同じ名前のセクションはどのページでも同じ見た目にする (#2230)
+  return `<div class="row g-4">${popularPosts.map(postPanel).join('')}</div>`;
 });
 
 hexo.extend.helper.register('sns_popular_posts', function() {
@@ -91,13 +84,5 @@ hexo.extend.helper.register('sns_popular_posts', function() {
   allPosts.sort((a, b) => getSNSCnt(b.permalink) - getSNSCnt(a.permalink))
   const popularPost = allPosts.slice(0, RANKING_DISPLAY_COUNT)
 
-  const links = popularPost.map(post => postListItem(post, 'featured-posts-item')).join("\n")
-
-  return `
-  <div class="widget">
-    <ul class="nav featured-post-link">
-      ${links}
-    </ul>
-  </div>
-  `
+  return `<div class="row g-4">${popularPost.map(postPanel).join('')}</div>`;
 });

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1560,9 +1560,36 @@ a.series-nav-item:hover .series-nav-item-title {
 }
 /* ランキングはホームの主役なので、本文と同じ 1.2em で読ませる。
    関連記事・参照記事は記事に付随する自動生成の情報なので 1em に留める */
-.featured-posts-item > a {
+.featured-posts-item > a,
+.featured-posts-item .post-list-body > a {
   font-size: 1.2em;
   color: #424242;
+}
+/* ランキングのサムネ (#2230)。カードにはせず、リストの密度を保ったまま
+   タイトルの手がかりとして小さく添える。サムネの無い記事は
+   同じ大きさの空き枠を置いて行頭を揃える */
+.post-list-item-thumb {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.post-list-icon {
+  flex-shrink: 0;
+  width: 48px;
+  height: 32px;
+}
+.post-list-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 3px;
+}
+.post-list-icon-empty {
+  background: #eee;
+  border-radius: 3px;
+}
+.post-list-body {
+  min-width: 0;
 }
 .related-posts-item:last-child,
 .reference-posts-item:last-child,


### PR DESCRIPTION
## 概要

Close #2230

ホームの「よく読まれている記事」（トレンド／年間人気／SNS人気の3タブ）にサムネイルを表示します。

## 表示

カード化はせず（レビューで方針確定）、**リストの密度を保ったままタイトルの左に 48×32 の小さいサムネ**を添えます。

- サムネの無い記事は同じ大きさの空き枠（グレー）を置いて行頭を揃える
- サムネのリンクはタイトルと重複するので、タブ移動と読み上げからは外す（tabindex=-1 / aria-hidden）
- タイトル・NEW・日付・♡ の表示は従来どおり

## 実装

- 共通の `postListItem`（lib/post_list.js）に `withThumb` を追加。ランキングだけ有効にし、記事末尾の「関連記事」「この記事を参照している記事」は従来のテキストリストのまま（コンパクトさが役割のため据え置き）

## 動作確認（ローカル）

- ホームの3タブ全30項目がサムネ付き（画像28＋空き枠2）
- 記事ページの関連記事・参照記事に変化なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)