### PR TITLE
markdownlint の MD025 を有効にする

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -5,7 +5,6 @@
       "line-length": false, // MD013  行の長さ
       "no-hard-tabs": false, // MD010 Markdown中にTSVを書くとエラーになるため
       "no-duplicate-heading": false, // MD024 - Multiple headings with the same content
-      "single-h1": false, // MD025 - Multiple top-level headings in the same document
       "no-trailing-punctuation": false, // MD026 ヘディングに句読点（.,;:!?）を許容したい
       "no-inline-html": false, // MD033 HTMLは許容
       "no-bare-urls": false, // MD034 URLのリンク化条件


### PR DESCRIPTION
Closes #2178

#2070 と #2144 で全1467記事が h2 開始になったので、本文の h1 を lint で止めます。放置すると新しい記事で `#` 開始が復活します。

```diff
   "no-duplicate-heading": false, // MD024 - Multiple headings with the same content
-  "single-h1": false, // MD025 - Multiple top-level headings in the same document
   "no-trailing-punctuation": false, // MD026 ヘディングに句読点（.,;:!?）を許容したい
```

**1行削るだけ**です。この設定ファイルは既定から外すルールだけを並べる形なので、有効化＝行の削除になります。

## 動くことの確認

MD025 は**フロントマターの `title` を h1 とみなす**ため、本文の `#` が「2つ目の h1」として引っかかります。

```
---
title: "テスト記事"
---

本文の書き出し。

# 本文の h1        ← MD025/single-title/single-h1
```

```
---
title: "テスト記事"
---

本文。

## 本文の h2       ← 通る
```

| 対象 | MD025 |
| --- | --- |
| `source/_posts` 全1467記事 | **0件** |
| リポジトリ全体（`node_modules` 除く） | **0件** |

## 効く範囲

現状 markdownlint は **CI で回っていません**（reviewdog は textlint のみ）。効くのは `make fmt` を叩いたときです。

CI に載せるには既存の指摘9,939件を片付ける必要があり、#2245 に切り出してあります。それでも設定を先に入れておけば、手元で気付けます。

## 入れなかったもの

`MD001`（heading-increment、`h2 → h4` のような飛び）は #2155 と同じ対象で、全期間で数百件出ます。別問題なので触っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)