### PR TITLE
カテゴリの「◯以外の記事を見る」を最初と最後のページだけに出す

### DIFF
--- a/themes/future/layout/_partial/related-categories.ejs
+++ b/themes/future/layout/_partial/related-categories.ejs
@@ -4,9 +4,11 @@
     注記は件数ではなく根拠タグを名乗る。数字にするとどのタグで
     つながったのかが隠れて、読者が関連の質を判断できない %>
 <% const rc = related_categories(page.category); %>
-<% if (rc.length) { %>
+<% const without = category_without_tag(page.category); %>
+<% if (rc.length || without) { %>
 <aside>
   <section class="popular-articles margin-bottom-20">
+    <% if (rc.length) { %>
     <%- partial('section-heading', {id: 'relatedcategories', text: '関連カテゴリ'}) %>
     <ul class="tendency-panels">
       <% rc.forEach(function(c){ %>
@@ -16,6 +18,13 @@
       </li>
       <% }) %>
     </ul>
+    <% } %>
+    <%# 1つのタグがカテゴリの過半数を占めると、それ以外の記事に辿り着けない。
+        絞り込む側はタグページが担うので、除いた側だけ導線を出す (#2038)。
+        関連カテゴリと同じ「次の行き先」なので、その直下に置く (#2252) %>
+    <% if (without) { %>
+    <p class="category-without-link"><a href="<%- url_for(without.path) %>"><%= page.category %>カテゴリの<%= without.name %>以外の記事を見る（<%= without.count %>本）</a></p>
+    <% } %>
   </section>
 </aside>
 <% } %>

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -63,17 +63,8 @@
     <% } %>
     <%# 見出しの語彙はホームに合わせる。一覧は日付降順なので
         1ページ目だけが「新着」を名乗れる %>
-    <%# 1つのタグがカテゴリの過半数を占めると、それ以外の記事に辿り着けない。
-        絞り込む側はタグページが担うので、除いた側だけ導線を出す（#2038）。
-        「新着記事」の見出しの直下、一覧に入る前に置く。
-        回遊導線と同じく最初と最後のページだけに出す。ページを繰っている
-        途中の読者には毎回のノイズになる (#2252) %>
-    <% const showWithout = page.current === 1 || page.current === page.total; %>
-    <% const without = showWithout ? category_without_tag(page.category) : null; %>
-    <% const withoutLink = without
-         ? `<p class="category-without-link"><a href="${url_for(without.path)}">${page.category}カテゴリの${without.name}以外の記事を見る（${without.count}本）</a></p>`
-         : ''; %>
-    <%- partial('_partial/archive', {pagination: config.category, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧', list_note: withoutLink}) %>
+    <%# 「◯以外の記事を見る」の導線は related-categories 側が持つ (#2252) %>
+    <%- partial('_partial/archive', {pagination: config.category, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧'}) %>
 
   </section>
     </main>

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -65,8 +65,11 @@
         1ページ目だけが「新着」を名乗れる %>
     <%# 1つのタグがカテゴリの過半数を占めると、それ以外の記事に辿り着けない。
         絞り込む側はタグページが担うので、除いた側だけ導線を出す（#2038）。
-        「新着記事」の見出しの直下、一覧に入る前に置く %>
-    <% const without = category_without_tag(page.category); %>
+        「新着記事」の見出しの直下、一覧に入る前に置く。
+        回遊導線と同じく最初と最後のページだけに出す。ページを繰っている
+        途中の読者には毎回のノイズになる (#2252) %>
+    <% const showWithout = page.current === 1 || page.current === page.total; %>
+    <% const without = showWithout ? category_without_tag(page.category) : null; %>
     <% const withoutLink = without
          ? `<p class="category-without-link"><a href="${url_for(without.path)}">${page.category}カテゴリの${without.name}以外の記事を見る（${without.count}本）</a></p>`
          : ''; %>


### PR DESCRIPTION
## 概要

Close #2252

「ProgrammingカテゴリのGo以外の記事を見る（134本）」のリンク（#2038）を整理します。

- **最初と最後のページだけ**に出す（従来は全ページ。途中の読者にはノイズ）
- 位置は**関連カテゴリの直下**（レビューで確定）。関連カテゴリと同じ「次の行き先」なので並べて置く。1ページ目（一覧の前）・最終ページ（ページャー下）の両方でこの位置になる

## 実装

リンクの描画を `_partial/related-categories.ejs` に移動。この partial が1ページ目と最終ページの両位置で使われる部品なので、位置の規則が自動的に揃う。関連カテゴリが無いカテゴリでもリンク単体で表示される。

## 動作確認（ローカル）

- /categories/Programming/ → 関連カテゴリ → Go以外リンク → 新着記事 の順
- /categories/Programming/page/2/ → 出ない
- /categories/Programming/page/14/（最終）→ ページャー下に関連カテゴリ → Go以外リンク

🤖 Generated with [Claude Code](https://claude.com/claude-code)