### PR TITLE
ホームのランキングを details で25位まで辿れるようにする

### DIFF
--- a/scripts/lib/post_list.js
+++ b/scripts/lib/post_list.js
@@ -33,21 +33,23 @@ const newLabel = date => {
  * @param {string} itemClass     li に付けるクラス
  * @param {string} [titleAttr]   a の title 属性。省略時は lede
  * @param {boolean} [withThumb]  タイトルの左に小さいサムネを添える (#2230)
+ * @param {number} [rank]        行頭に出す順位。ランキング用 (#2249)
  */
-const postListItem = (post, itemClass, titleAttr, withThumb = false) => {
+const postListItem = (post, itemClass, titleAttr, withThumb = false, rank = null) => {
   const attr = (titleAttr === undefined ? post.lede : titleAttr) || '';
+  const rankLabel = rank === null ? '' : `<span class="post-list-rank">${rank}</span>`;
   const body = `<a href="/${post.path}" title="${attr}">${post.title}</a>`
     + `${newLabel(post.date)}`
     + `<span class="post-meta"><span class="post-meta-date">${post.date.format('YYYY.MM.DD')}</span>${snsLabel(post.permalink)}</span>`;
   if (!withThumb) {
-    return `<li class="${itemClass}">${body}</li>`;
+    return `<li class="${itemClass}">${rankLabel}${body}</li>`;
   }
   // タイトルと重複するリンクなので、タブ移動と読み上げからは外す。
   // サムネの無い記事は同じ大きさの空き枠を置いて行頭を揃える
   const thumb = post.thumbnail
     ? `<a href="/${post.path}" class="post-list-icon" tabindex="-1" aria-hidden="true"><img src="${post.thumbnail}" alt="" width="48" height="32" loading="lazy"></a>`
     : `<span class="post-list-icon post-list-icon-empty"></span>`;
-  return `<li class="${itemClass} post-list-item-thumb">${thumb}<div class="post-list-body">${body}</div></li>`;
+  return `<li class="${itemClass} post-list-item-thumb">${rankLabel}${thumb}<div class="post-list-body">${body}</div></li>`;
 };
 
 module.exports = {snsLabel, newLabel, postListItem};

--- a/scripts/popular_posts.js
+++ b/scripts/popular_posts.js
@@ -6,9 +6,30 @@ const {postListItem} = require('./lib/post_list');
 const fs = require("fs");
 const gaCache = JSON.parse(fs.readFileSync("ga_cache.json", 'utf-8'));
 
-// ランキング（トレンド・年間人気・SNS人気）の表示件数
-// 記事が長文化する傾向にあるため、トップページのスクロール量を抑える目的で絞っている
+// ランキング（トレンド・年間人気・SNS人気）の表示件数。
+// 記事が長文化する傾向にあるため、トップページのスクロール量を抑える目的で絞り、
+// 11位以下は details で畳んで25位まで辿れるようにする (#2249)。
+// details ならJSを足さずに済む（参照記事の畳みと同じ作り）
 const RANKING_DISPLAY_COUNT = 10;
+const RANKING_MAX_COUNT = 25;
+
+const rankingList = posts => {
+  const items = list => list.map(post => postListItem(post, 'featured-posts-item', undefined, true)).join("\n");
+  // 残りが1件だけなら畳む意味がないので、そのまま出す
+  const collapses = posts.length > RANKING_DISPLAY_COUNT + 1;
+  const shown = collapses ? posts.slice(0, RANKING_DISPLAY_COUNT) : posts;
+  const hidden = collapses ? posts.slice(RANKING_DISPLAY_COUNT) : [];
+  const more = hidden.length === 0 ? '' : `
+    <details class="ranking-more">
+      <summary>残り ${hidden.length}本を表示</summary>
+      <ul class="nav featured-post-link">${items(hidden)}</ul>
+    </details>`;
+  return `
+  <div class="widget">
+    <ul class="nav featured-post-link">${items(shown)}</ul>${more}
+  </div>
+  `;
+};
 
 hexo.extend.helper.register('popular_posts', function(term='weekly') {
   const yearAgo = new Date();
@@ -71,33 +92,16 @@ hexo.extend.helper.register('popular_posts', function(term='weekly') {
     })
     .filter(post => post.pv >= 0)
     .sort(compareFunc)
-    .slice(0, RANKING_DISPLAY_COUNT);
+    .slice(0, RANKING_MAX_COUNT);
 
-  // マークアップは「関連記事」「この記事を参照している記事」と共通（lib/post_list.js）
-  const links = popularPosts.map(post => postListItem(post, 'featured-posts-item', undefined, true)).join("\n")
-
-  return `
-  <div class="widget">
-    <ul class="nav featured-post-link">
-      ${links}
-    </ul>
-  </div>
-  `
+  return rankingList(popularPosts);
 });
 
 hexo.extend.helper.register('sns_popular_posts', function() {
 
   const allPosts = this.site.posts.data;
   allPosts.sort((a, b) => getSNSCnt(b.permalink) - getSNSCnt(a.permalink))
-  const popularPost = allPosts.slice(0, RANKING_DISPLAY_COUNT)
+  const popularPost = allPosts.slice(0, RANKING_MAX_COUNT)
 
-  const links = popularPost.map(post => postListItem(post, 'featured-posts-item', undefined, true)).join("\n")
-
-  return `
-  <div class="widget">
-    <ul class="nav featured-post-link">
-      ${links}
-    </ul>
-  </div>
-  `
+  return rankingList(popularPost);
 });

--- a/scripts/popular_posts.js
+++ b/scripts/popular_posts.js
@@ -14,7 +14,9 @@ const RANKING_DISPLAY_COUNT = 10;
 const RANKING_MAX_COUNT = 25;
 
 const rankingList = posts => {
-  const items = list => list.map(post => postListItem(post, 'featured-posts-item', undefined, true)).join("\n");
+  // 順位はマークアップ側で振る。CSS カウンタだと「10件で畳む」定数と
+  // 二重管理になる。畳んだ側は11位から続く
+  const items = (list, offset) => list.map((post, i) => postListItem(post, 'featured-posts-item', undefined, true, offset + i + 1)).join("\n");
   // 残りが1件だけなら畳む意味がないので、そのまま出す
   const collapses = posts.length > RANKING_DISPLAY_COUNT + 1;
   const shown = collapses ? posts.slice(0, RANKING_DISPLAY_COUNT) : posts;
@@ -22,11 +24,11 @@ const rankingList = posts => {
   const more = hidden.length === 0 ? '' : `
     <details class="ranking-more">
       <summary>残り ${hidden.length}本を表示</summary>
-      <ul class="nav featured-post-link">${items(hidden)}</ul>
+      <ul class="nav featured-post-link">${items(hidden, shown.length)}</ul>
     </details>`;
   return `
   <div class="widget">
-    <ul class="nav featured-post-link">${items(shown)}</ul>${more}
+    <ul class="nav featured-post-link">${items(shown, 0)}</ul>${more}
   </div>
   `;
 };

--- a/scripts/reference_posts.js
+++ b/scripts/reference_posts.js
@@ -36,7 +36,7 @@ hexo.extend.helper.register('list_reference_posts', function() {
   // ul の直下に details は置けないため、畳む分は別の ul にして details で包む
   const more = hidden.length === 0 ? '' : `
     <details class="reference-post-more">
-      <summary>残り ${hidden.length} 件を表示</summary>
+      <summary>残り ${hidden.length}本を表示</summary>
       <ul class="reference-post-link">${items(hidden)}</ul>
     </details>`;
 

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1610,14 +1610,16 @@ a.series-nav-item:hover .series-nav-item-title {
 .reference-post-more {
   padding: 0 0.8em 0.6em;
 }
-.reference-post-more > summary {
+.reference-post-more > summary,
+.ranking-more > summary {
   padding: 0.5em 0;
   border-top: 1px solid #ecebeb;
   color: #6e6e6e;
   font-size: 0.9em;
   cursor: pointer;
 }
-.reference-post-more > summary:hover {
+.reference-post-more > summary:hover,
+.ranking-more > summary:hover {
   color: #424242;
 }
 /* 畳んだ側の ul は details 側で余白を持つので、二重に付けない */
@@ -1625,7 +1627,8 @@ a.series-nav-item:hover .series-nav-item-title {
   padding: 0;
 }
 /* 直前の ul の最終行は、summary の上線と重なって二重線になる */
-.reference-post-link:has(+ .reference-post-more) .reference-posts-item:last-child {
+.reference-post-link:has(+ .reference-post-more) .reference-posts-item:last-child,
+.featured-post-link:has(+ .ranking-more) .featured-posts-item:last-child {
   border-bottom: none;
 }
 /* metronic の `.featured-post-link li { padding: 8px 0 6px }` は

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1577,6 +1577,14 @@ a.series-nav-item:hover .series-nav-item-title {
   align-items: center;
   gap: 10px;
 }
+/* ランキングの順位 (#2249)。2桁まで幅を揃えて右詰めにする */
+.post-list-rank {
+  flex-shrink: 0;
+  width: 1.6em;
+  color: #6e6e6e;
+  font-size: 0.9em;
+  text-align: right;
+}
 .post-list-icon {
   flex-shrink: 0;
 }


### PR DESCRIPTION
## 概要

Close #2249

ホームの「よく読まれている記事」（トレンド／年間人気／SNS人気）が10位で打ち切りで、11位以下に出会う手段がありませんでした。あわせてレビューで順位表示も追加しました。

## 変更

**details で25位まで（#2249）**
- 表示は従来どおり10件（スクロール量を抑える趣旨は維持）、11〜25位を `<details>`「残り 15本を表示」で畳む。参照記事の畳みと同じ作りで JS なし
- 参照記事の畳み文言も「残り n 件」→「残り n本」（単位は「本」#2209）

**順位表示（レビュー追加）**
- 行頭にグレーの順位（1〜25、2桁まで右詰め）。タブ名が順位付けした一覧を名乗っているので、番号でそれを裏付ける
- 順位は**マークアップ側**で振る。CSS カウンタだと「10件で畳む」定数と二重管理になるため。畳んだ側は11から続く
- カテゴリ・タグ・著者・年ページの「よく読まれている記事」（2〜4枚のカード推薦）と記事末尾の関連記事には振らない。順位を主張する場ではないため

## 動作確認（ローカル）

- ホームの3タブそれぞれ 1〜10位＋「残り 15本を表示」→ 開くと11〜25位
- 記事ページの関連記事・参照記事に順位は出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)