### PR TITLE
タイトルにタグ名を含む記事へタグを振り下ろす

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -128,6 +128,9 @@ hexo.extend.helper.register('doctor_checks', function() {
       // タイトルに連載名を含む記事（「Go 1.27 リリース連載：uuid」等）では、
       // 連載名の一部（リリース 等）に当たっても記事の主題ではない
       if (post.series && String(post.series).includes(t.name)) continue;
+      // 系統タグを既に持っていれば提案しない。DockerCompose が付いた記事に
+      // Docker を、Go1.22 が付いた記事に Go を重ねて振る必要はない
+      if (tagNames.some(mine => mine !== t.name && mine.toLowerCase().includes(t.name.toLowerCase()))) continue;
       let hit;
       if (/^[\x20-\x7e]+$/.test(t.name)) {
         // 英数タグは単語境界で照合する（SQL が PostgreSQL に当たるのを防ぐ）

--- a/source/_posts/2019/20190731-infra-pattern1.md
+++ b/source/_posts/2019/20190731-infra-pattern1.md
@@ -5,6 +5,7 @@ postid: ""
 tags:
   - インフラ入門
   - 要件定義
+  - デザインパターン
 categories:
   - Infrastructure
 author: 二木秀之

--- a/source/_posts/2019/20190827-gcp-ip.md
+++ b/source/_posts/2019/20190827-gcp-ip.md
@@ -7,6 +7,7 @@ tags:
   - ネットワーク
   - トラブルシュート
   - Kubernetes
+  - GKE
 categories:
   - DevOps
 author: 市川燿

--- a/source/_posts/2019/20190918-management-pattern2.md
+++ b/source/_posts/2019/20190918-management-pattern2.md
@@ -6,6 +6,8 @@ tags:
   - 組織論
   - リーダーシップ
   - キャリア
+  - デザインパターン
+  - リファクタリング
 categories:
   - Management
 author: 宮原洋祐

--- a/source/_posts/2019/20190927-gcp-2.md
+++ b/source/_posts/2019/20190927-gcp-2.md
@@ -6,6 +6,7 @@ tags:
   - GoogleCloud
   - CloudFunctions
   - LetsTryGCP
+  - VPC
 categories:
   - Infrastructure
 author: 村田靖拓

--- a/source/_posts/2019/20191017-gke-cidr.md
+++ b/source/_posts/2019/20191017-gke-cidr.md
@@ -7,6 +7,7 @@ tags:
   - ネットワーク
   - Kubernetes
   - CIDR
+  - GKE
 categories:
   - DevOps
 author: "ghost"

--- a/source/_posts/2019/20191128-gocloud7.md
+++ b/source/_posts/2019/20191128-gocloud7.md
@@ -6,6 +6,7 @@ tags:
   - Go
   - GoCDK
   - fluentd
+  - PubSub
 categories:
   - Programming
 series: "Go Cloud"

--- a/source/_posts/2020/20200206-gcp-istio.md
+++ b/source/_posts/2020/20200206-gcp-istio.md
@@ -8,6 +8,7 @@ tags:
   - Kubernetes
   - サービスメッシュ
   - skaffold
+  - GKE
 categories:
   - DevOps
 series: "GCP2020"

--- a/source/_posts/2020/20200219-gcpmanager.md
+++ b/source/_posts/2020/20200219-gcpmanager.md
@@ -5,6 +5,7 @@ postid: ""
 tags:
   - GoogleCloud
   - IaC
+  - Terraform
 categories:
   - DevOps
 series: "GCP2020"

--- a/source/_posts/2020/20200515-step-functions.md
+++ b/source/_posts/2020/20200515-step-functions.md
@@ -8,6 +8,7 @@ tags:
   - DynamoDB
   - StepFunctions
   - バッチ処理
+  - Lambda
 categories:
   - Programming
 series: "サーバレス2020"

--- a/source/_posts/2020/20200702-auth0-cicd.md
+++ b/source/_posts/2020/20200702-auth0-cicd.md
@@ -6,6 +6,7 @@ tags:
   - Auth0
   - AWS
   - GitLab
+  - バージョン管理
 categories:
   - 認証認可
 thumbnail: /images/2020/20200702/thumbnail.png

--- a/source/_posts/2020/20200715-virtual-contest.md
+++ b/source/_posts/2020/20200715-virtual-contest.md
@@ -6,6 +6,8 @@ tags:
   - 競技プログラミング
   - 新人研修
   - 社内勉強会
+  - コンテスト
+  - 初心者向け
 categories:
   - Culture
 thumbnail: /images/2020/20200715/thumbnail.png

--- a/source/_posts/2020/20200806_初めてのOSSコミュニティ活動〜ドキュメント翻訳やってみた。カンファレンススタッフもやってみた。〜.md
+++ b/source/_posts/2020/20200806_初めてのOSSコミュニティ活動〜ドキュメント翻訳やってみた。カンファレンススタッフもやってみた。〜.md
@@ -7,6 +7,7 @@ tags:
   - OSS
   - コミュニティ
   - 翻訳
+  - カンファレンス
 categories:
   - Culture
 series: "夏の自由研究2020"

--- a/source/_posts/2020/20200828_チームで推奨するVSCode拡張機能を共有するtips.md
+++ b/source/_posts/2020/20200828_チームで推奨するVSCode拡張機能を共有するtips.md
@@ -6,6 +6,7 @@ tags:
   - VSCode
   - チーム開発
   - Tips
+  - VSCode拡張
 categories:
   - DevOps
 thumbnail: /images/2020/20200828/thumbnail.png

--- a/source/_posts/2020/20200927_LambdaとGoを使ったサーバーレスWebAPI開発実践入門.md
+++ b/source/_posts/2020/20200927_LambdaとGoを使ったサーバーレスWebAPI開発実践入門.md
@@ -9,6 +9,8 @@ tags:
   - go-swagger
   - Terraform
   - 入門
+  - WebAPI
+  - Lambda
 categories:
   - DevOps
 thumbnail: /images/2020/20200927/thumbnail.png

--- a/source/_posts/2020/20201203_GoがApple_Siliconにネイティブ対応したのでベンチマークをとってみました.md
+++ b/source/_posts/2020/20201203_GoがApple_Siliconにネイティブ対応したのでベンチマークをとってみました.md
@@ -5,6 +5,7 @@ postid: ""
 tags:
   - Go
   - Mac
+  - Apple
 categories:
   - Programming
 thumbnail: /images/2020/20201203/thumbnail.png

--- a/source/_posts/2020/20201228_Future_Tech_Night(第5弾：AWS＆DataPlatform_MaaSビジネス編)を開催しました。.md
+++ b/source/_posts/2020/20201228_Future_Tech_Night(第5弾：AWS＆DataPlatform_MaaSビジネス編)を開催しました。.md
@@ -7,6 +7,7 @@ tags:
   - データレイク
   - 登壇レポート
   - TechNight
+  - MaaS
 categories:
   - DataEngineering
 thumbnail: /images/2020/20201228/thumbnail.png

--- a/source/_posts/2021/20210426b_Go_1.16のembedとgo-swaggerを組み合わせてフルスタック自動生成フレームワークを作る.md
+++ b/source/_posts/2021/20210426b_Go_1.16のembedとgo-swaggerを組み合わせてフルスタック自動生成フレームワークを作る.md
@@ -7,6 +7,7 @@ tags:
   - Go1.16
   - Go
   - go:embed
+  - go-swagger
 categories:
   - Frontend
 thumbnail: /images/2021/20210426b/thumbnail.png

--- a/source/_posts/2021/20210715a_Proxy下でのFlutter環境構築(for_Mac).md
+++ b/source/_posts/2021/20210715a_Proxy下でのFlutter環境構築(for_Mac).md
@@ -6,6 +6,7 @@ tags:
   - Flutter
   - プロキシ
   - 環境構築
+  - Mac
 categories:
   - Mobile
 series: "Dart/Flutter2021"

--- a/source/_posts/2021/20210729a_GORM_v1_と_v2_のソースコードリーディングしてみた.md
+++ b/source/_posts/2021/20210729a_GORM_v1_と_v2_のソースコードリーディングしてみた.md
@@ -6,6 +6,7 @@ tags:
   - Go
   - ORM
   - GORM
+  - コードリーディング
 categories:
   - Programming
 series: "GoのORマッパー"

--- a/source/_posts/2021/20211006a_AWS_Glue_Data_CatalogでCSVを扱う.md
+++ b/source/_posts/2021/20211006a_AWS_Glue_Data_CatalogでCSVを扱う.md
@@ -7,6 +7,7 @@ tags:
   - Python
   - AWS
   - データカタログ
+  - CSV
 categories:
   - DataEngineering
 series: "Python"

--- a/source/_posts/2021/20211105a_極小LinuxマシンでSwiftを動かそうとしてみた.md
+++ b/source/_posts/2021/20211105a_極小LinuxマシンでSwiftを動かそうとしてみた.md
@@ -6,6 +6,7 @@ tags:
   - Rust
   - M5Stack
   - Linux
+  - Swift
 categories:
   - IoT
 series: "秋のブログ週間2021"

--- a/source/_posts/2021/20211218a__Software_Design_2022年1月号に短期連載「Cypressで作る消耗しないE2Eテスト環境」を寄稿しました.md
+++ b/source/_posts/2021/20211218a__Software_Design_2022年1月号に短期連載「Cypressで作る消耗しないE2Eテスト環境」を寄稿しました.md
@@ -6,6 +6,7 @@ tags:
   - Cypress
   - SoftwareDesign
   - 出版
+  - E2Eテスト
 categories:
   - Frontend
 thumbnail: /images/2021/20211218a/thumbnail.png

--- a/source/_posts/2022/20220107a_Future社員が使っているWindows便利ツール（新人さん向け）.md
+++ b/source/_posts/2022/20220107a_Future社員が使っているWindows便利ツール（新人さん向け）.md
@@ -7,6 +7,7 @@ tags:
   - 新人向け
   - 初心者向け
   - 環境構築
+  - Windows
 categories:
   - Business
 thumbnail: /images/2022/20220107a/thumbnail.gif

--- a/source/_posts/2022/20220531a_golang.tokyo_#32_で_go-twowaysql_について紹介しました.md
+++ b/source/_posts/2022/20220531a_golang.tokyo_#32_で_go-twowaysql_について紹介しました.md
@@ -7,6 +7,7 @@ tags:
   - OSS
   - ORM
   - 2WaySQL
+  - golang.tokyo
 categories:
   - Programming
 thumbnail: /images/2022/20220531a/thumbnail.jpg

--- a/source/_posts/2022/20220831a_OpenAPI_Generatorでrust-serverのコードを生成して、GET／POSTメソッドを呼び出すまで.md
+++ b/source/_posts/2022/20220831a_OpenAPI_Generatorでrust-serverのコードを生成して、GET／POSTメソッドを呼び出すまで.md
@@ -5,6 +5,7 @@ postid: a
 tags:
   - OpenAPIGenerator
   - Rust
+  - OpenAPI
 categories:
   - Programming
 series: "夏の自由研究2022"

--- a/source/_posts/2022/20221025a_A5：SQL_Mk-2_（a5m2）のデータモデリング便利機能（初心者向け）.md
+++ b/source/_posts/2022/20221025a_A5：SQL_Mk-2_（a5m2）のデータモデリング便利機能（初心者向け）.md
@@ -6,6 +6,7 @@ tags:
   - 便利ツール
   - A5:SQLMk-2
   - データモデル
+  - 初心者向け
 categories:
   - DB
 thumbnail: /images/2022/20221025a/thumbnail.png

--- a/source/_posts/2022/20221203a_OpenAPI_GeneratorでPython_Web_API構築.md
+++ b/source/_posts/2022/20221203a_OpenAPI_GeneratorでPython_Web_API構築.md
@@ -7,6 +7,7 @@ tags:
   - WebAPI
   - Python
   - OpenAPIGenerator
+  - OpenAPI
 categories:
   - Programming
 thumbnail: /images/2022/20221203a/thumbnail.png

--- a/source/_posts/2022/20221228a_Rust製SQLフォーマッタをnapi-rsを利用してVSCode拡張機能化.md
+++ b/source/_posts/2022/20221228a_Rust製SQLフォーマッタをnapi-rsを利用してVSCode拡張機能化.md
@@ -8,6 +8,7 @@ tags:
   - VSCode
   - フォーマッター
   - コアテク
+  - VSCode拡張
 categories:
   - Programming
 thumbnail: /images/2022/20221228a/thumbnail.png

--- a/source/_posts/2023/20230105a_Python_Web_APIをAWS_Lambdaにデプロイ.md
+++ b/source/_posts/2023/20230105a_Python_Web_APIをAWS_Lambdaにデプロイ.md
@@ -6,6 +6,8 @@ tags:
   - WebAPI
   - AWS
   - Docker
+  - Python
+  - Lambda
 categories:
   - DevOps
 thumbnail: /images/2023/20230105a/thumbnail.png

--- a/source/_posts/2023/20230407a_Terraform_v1.4のリリースノートを眺める.md
+++ b/source/_posts/2023/20230407a_Terraform_v1.4のリリースノートを眺める.md
@@ -5,6 +5,7 @@ postid: a
 tags:
   - Terraform
   - Terraform1.4
+  - リリースノート
 categories:
   - DevOps
 series: "Terraform2023"

--- a/source/_posts/2023/20230508a_5分でできる。Windowsの脆弱性を「Vuls」で今すぐチェック！.md
+++ b/source/_posts/2023/20230508a_5分でできる。Windowsの脆弱性を「Vuls」で今すぐチェック！.md
@@ -5,6 +5,7 @@ postid: a
 tags:
   - OSS
   - Vuls
+  - Windows
 categories:
   - Security
 thumbnail: /images/2023/20230508a/vuls.png

--- a/source/_posts/2023/20230518b_SLOconf_Tokyo_2023というコミュニティイベントに参加しました.md
+++ b/source/_posts/2023/20230518b_SLOconf_Tokyo_2023というコミュニティイベントに参加しました.md
@@ -7,6 +7,7 @@ tags:
   - SLO
   - 参加レポート
   - 心理的安全性
+  - コミュニティ
 categories:
   - DevOps
 thumbnail: /images/2023/20230518b/thumbnail.png

--- a/source/_posts/2023/20230524a_iOSアプリのCI入門.md
+++ b/source/_posts/2023/20230524a_iOSアプリのCI入門.md
@@ -7,6 +7,7 @@ tags:
   - CI/CD
   - GitLab
   - GitLab CI
+  - iOS
 categories:
   - Mobile
 series: "春の入門祭り2023"

--- a/source/_posts/2023/20230823a_Playwrightの環境構築（VSCode_Dev_Container編）.md
+++ b/source/_posts/2023/20230823a_Playwrightの環境構築（VSCode_Dev_Container編）.md
@@ -7,6 +7,7 @@ tags:
   - VSCode
   - Docker
   - 環境構築
+  - Dev Containers
 categories:
   - Frontend
 series: "Playwright"

--- a/source/_posts/2023/20231019a_VPC外からCloud_SQL_Auth_Proxyを利用したPrivate_IP_Cloud_SQLへの接続.md
+++ b/source/_posts/2023/20231019a_VPC外からCloud_SQL_Auth_Proxyを利用したPrivate_IP_Cloud_SQLへの接続.md
@@ -7,6 +7,7 @@ tags:
   - GoogleCloud
   - IAM
   - プロキシ
+  - VPC
 categories:
   - Infrastructure
 thumbnail: /images/2023/20231019a/thumbnail.png

--- a/source/_posts/2023/20231130b_Qiita_Advent_Calendar_2023_に参加します.md
+++ b/source/_posts/2023/20231130b_Qiita_Advent_Calendar_2023_に参加します.md
@@ -5,6 +5,7 @@ postid: b
 tags:
   - アドベントカレンダー
   - インデックス
+  - Qiita
 categories:
   - Culture
 thumbnail: /images/2023/20231130b/thumbnail.JPG

--- a/source/_posts/2024/20240119a_リリース直前にライブラリのインストールエラーが発生した際にどのように対応したか.md
+++ b/source/_posts/2024/20240119a_リリース直前にライブラリのインストールエラーが発生した際にどのように対応したか.md
@@ -8,6 +8,7 @@ tags:
   - AWS
   - Glue
   - Glue Python Shell
+  - Python
 categories:
   - DataEngineering
 thumbnail: /images/2024/20240119a/thumbnail.jpeg

--- a/source/_posts/2024/20240222a_MacをWindows／Linux風な操作感にする、Hammerspoonで始める環境構築.md
+++ b/source/_posts/2024/20240222a_MacをWindows／Linux風な操作感にする、Hammerspoonで始める環境構築.md
@@ -7,6 +7,8 @@ tags:
   - Mac
   - ショートカット
   - 環境構築
+  - Linux
+  - Windows
 categories:
   - DevOps
 thumbnail: /images/2024/20240222a/thumbnail.jpg

--- a/source/_posts/2024/20240408b_Go1.22リリースパーティに「ServeMuxの競合検知と性能」というタイトルで登壇しました.md
+++ b/source/_posts/2024/20240408b_Go1.22リリースパーティに「ServeMuxの競合検知と性能」というタイトルで登壇しました.md
@@ -8,6 +8,7 @@ tags:
   - 登壇レポート
   - 排他制御
   - net/http
+  - Go1.22
 categories:
   - Programming
 thumbnail: /images/2024/20240408b/thumbnail.png

--- a/source/_posts/2024/20240829a_OpenAPIでOAuth認可周りのサーバサイドコード生成を比較.md
+++ b/source/_posts/2024/20240829a_OpenAPIでOAuth認可周りのサーバサイドコード生成を比較.md
@@ -10,6 +10,7 @@ tags:
   - OpenSSL
   - OpenAPIGenerator
   - JWT
+  - コード生成
 categories:
   - 認証認可
 series: "夏の自由研究2024"

--- a/source/_posts/2024/20241018a_uroborosql-fmtにおける2WaySQLフォーマット_(前編：_フォーマット方法編).md
+++ b/source/_posts/2024/20241018a_uroborosql-fmtにおける2WaySQLフォーマット_(前編：_フォーマット方法編).md
@@ -8,6 +8,7 @@ tags:
   - コアテク
   - 2WaySQL
   - Rust
+  - uroboroSQL
 categories:
   - Programming
 thumbnail: /images/2024/20241018a/thumbnail.png

--- a/source/_posts/2024/20241021a_uroborosql-fmtにおける2WaySQLフォーマット_(後編：_結果検証編).md
+++ b/source/_posts/2024/20241021a_uroborosql-fmtにおける2WaySQLフォーマット_(後編：_結果検証編).md
@@ -6,6 +6,7 @@ tags:
   - uroboroSQL
   - フォーマッター
   - Rust
+  - 2WaySQL
 categories:
   - Programming
 thumbnail: /images/2024/20241021a/thumbnail.png

--- a/source/_posts/2024/20241127a_Vue3で作ったWebサイトを_Vite_PWA_でPWA化する方法_2024年版.md
+++ b/source/_posts/2024/20241127a_Vue3で作ったWebサイトを_Vite_PWA_でPWA化する方法_2024年版.md
@@ -7,6 +7,7 @@ tags:
   - PWA
   - Service Worker
   - Vite
+  - Vue3
 categories:
   - Frontend
 series: "Vue.js2024"

--- a/source/_posts/2025/20250509b_BicepリンターでBicepコードを最新化：効率的なリファクタリング手法.md
+++ b/source/_posts/2025/20250509b_BicepリンターでBicepコードを最新化：効率的なリファクタリング手法.md
@@ -7,6 +7,7 @@ tags:
   - IaC
   - Linter
   - FutureOne
+  - リファクタリング
 categories:
   - Infrastructure
 thumbnail: /images/2025/20250509b/thumbnail.png

--- a/source/_posts/2025/20250527b_ユニバーサルリンクをAzure_BlobStorageでやってみる.md
+++ b/source/_posts/2025/20250527b_ユニバーサルリンクをAzure_BlobStorageでやってみる.md
@@ -6,6 +6,7 @@ tags:
   - .NET
   - iOS
   - FutureOne
+  - Azure
 categories:
   - Mobile
 thumbnail: /images/2025/20250527b/thumbnail.png

--- a/source/_posts/2025/20250617a_初めての海外カンファレンスとKubeCon_Japan参加レポート.md
+++ b/source/_posts/2025/20250617a_初めての海外カンファレンスとKubeCon_Japan参加レポート.md
@@ -6,6 +6,7 @@ tags:
   - KubeCon
   - CNCF
   - 参加レポート
+  - カンファレンス
 categories:
   - DevOps
 series: "CNCF2025"

--- a/source/_posts/2025/20250620a_Gemma3_+_Unsloth_+_GitLab_CI／CDで構築する完全オンプレミスAIコードレビュー環境.md
+++ b/source/_posts/2025/20250620a_Gemma3_+_Unsloth_+_GitLab_CI／CDで構築する完全オンプレミスAIコードレビュー環境.md
@@ -6,6 +6,7 @@ tags:
   - GitLab
   - コードレビュー
   - 生成AI
+  - オンプレミス
 categories:
   - AIDD
 series: "CI/CD"

--- a/source/_posts/2025/20250822a_はじめてGlue_Python_Shell_Jobを使う時のつまづきポイント集.md
+++ b/source/_posts/2025/20250822a_はじめてGlue_Python_Shell_Jobを使う時のつまづきポイント集.md
@@ -8,6 +8,7 @@ tags:
   - ETL
   - Glue Python Shell
   - 初心者向け
+  - Python
 categories:
   - DataEngineering
 thumbnail: /images/2025/20250822a/thumbnail.jpg

--- a/source/_posts/2025/20250929a_Pure_Rustで生まれ変わったPostgreSQL公式構文準拠SQLフォーマッター「uroborosql-fmt」をリリース🎉.md
+++ b/source/_posts/2025/20250929a_Pure_Rustで生まれ変わったPostgreSQL公式構文準拠SQLフォーマッター「uroborosql-fmt」をリリース🎉.md
@@ -7,6 +7,7 @@ tags:
   - uroboroSQL
   - Rust
   - WebAssembly
+  - PostgreSQL
 categories:
   - DB
 thumbnail: /images/2025/20250929a/thumbnail.png

--- a/source/_posts/2025/20251128b_プロによる本気の攻略本『JavaScript／TypeScript実力強化書』で発表しました.md
+++ b/source/_posts/2025/20251128b_プロによる本気の攻略本『JavaScript／TypeScript実力強化書』で発表しました.md
@@ -5,6 +5,7 @@ postid: b
 tags:
   - 登壇レポート
   - TypeScript
+  - JavaScript
 categories:
   - Programming
 thumbnail: /images/2025/20251128b/thumbnail.jpg

--- a/source/_posts/2025/20251211a_システム開発からデータ分析へ。やってみて気づいた技術選定と実装のポイント.md
+++ b/source/_posts/2025/20251211a_システム開発からデータ分析へ。やってみて気づいた技術選定と実装のポイント.md
@@ -6,6 +6,7 @@ tags:
   - データ分析
   - PostgreSQL
   - pandas
+  - 技術選定
 categories:
   - DataScience
 thumbnail: /images/2025/20251211a/thumbnail.png

--- a/source/_posts/2026/20260430a_BigQueryから直接Geminiを叩こう。BigQueryMLによるログ解析ハンズオン.md
+++ b/source/_posts/2026/20260430a_BigQueryから直接Geminiを叩こう。BigQueryMLによるログ解析ハンズオン.md
@@ -6,6 +6,7 @@ tags:
   - BigQuery
   - GoogleCloud
   - Gemini
+  - ハンズオン
 categories:
   - DataScience
 series: "春の入門祭り2026"

--- a/source/_posts/2026/20260521a_HCP_Terraform（旧Terraform_Cloud）の基礎とサーバーレスアーキテクチャ選定のポイント.md
+++ b/source/_posts/2026/20260521a_HCP_Terraform（旧Terraform_Cloud）の基礎とサーバーレスアーキテクチャ選定のポイント.md
@@ -5,6 +5,7 @@ postid: a
 tags:
   - Terraform
   - TerraformCloud
+  - サーバーレス
 categories:
   - Infrastructure
 series: "Terraform2026"

--- a/source/_posts/2026/20260525a_AWS_MCP_Server_がGAに_-_Claude_Codeから検証：IAMガードレール設計.md
+++ b/source/_posts/2026/20260525a_AWS_MCP_Server_がGAに_-_Claude_Codeから検証：IAMガードレール設計.md
@@ -5,6 +5,8 @@ postid: a
 tags:
   - AWS
   - ClaudeCode
+  - IAM
+  - MCP
 categories:
   - AIDD
 thumbnail: /images/2026/20260525a/thumbnail.png


### PR DESCRIPTION
## 概要

/doctor の「タイトルにタグ名を含むのに、そのタグが付いていない記事」の指摘のうち、レビューで妥当と判断された **60タグ・54記事** を反映します（golang.tokyo・GKE・Python・Windows・Lambda ほか。指定リストどおり）。変更は各記事のフロントマター tags への1行追記のみで、本文には触れていません。

## /doctor 側のルール改善（レビュー指摘）

**系統タグを既に持つ記事には提案を出さない**ようにしました。DockerCompose が付いた記事のタイトルに「Docker」があっても Docker タグを重ねる必要はない、という判断です（既存タグ名が提案タグ名を含むなら抑制。Go1.22 ⊃ Go も同様）。

## 反映後の /doctor

対象セクションの提案は27タグまで減少。残りは Web(19)・AWS(5)・ドキュメント(5) など判断が割れるものと、正当な指摘（例: Docker(1) は Docker系タグの無い Testcontainers 記事）です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)