### PR TITLE
doctor の1記事タグの改行を抑制し、付きすぎ閾値を10タグにする

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -75,8 +75,9 @@ hexo.extend.helper.register('doctor_checks', function() {
     if (tagNames.length === 0) {
       untagged.push({title: post.title, path: post.path});
     }
-    // タグの付けすぎ。記事あたりの中央値は3で、その倍を超えたら見直し候補
-    if (tagNames.length >= 7) {
+    // タグの付けすぎ。10タグ以上を見直し候補にする。
+    // 中央値3の倍（7タグ）で拾うと件数が多すぎて手が付かない (#2259)
+    if (tagNames.length >= 10) {
       overTagged.push({title: post.title, path: post.path, count: tagNames.length});
     }
 

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -44,7 +44,7 @@
       <% } %>
 
       <h2 class="bottom-content-header">タグが付きすぎている記事</h2>
-      ※記事あたりのタグ数の中央値は3。その倍を超える7本以上を見直し候補として出しています
+      ※10タグ以上を見直し候補として出しています（記事あたりのタグ数の中央値は3）
       <% if (checks.overTagged.length) { %>
       <ul class="doctor-list">
         <% checks.overTagged.forEach(function(p){ %>
@@ -72,9 +72,20 @@
 
       <h2 class="bottom-content-header">1記事にしか使われていないタグ</h2>
       ※「同居」は、同じ記事に1記事タグ同士が付いているもの。その記事のタグ付けがまとめて薄い可能性が高い
+      <%# 300件超を1タグ1行で並べると縦に長すぎる。同居あり／英数字／日本語の
+          3ブロックに分けて、ブロックの中は読点区切りで流し込む (#2259) %>
+      <%
+        const singleGroups = [
+          ['同居あり', checks.singleUse.filter(t => t.lonelyPair)],
+          ['英数字', checks.singleUse.filter(t => !t.lonelyPair && /^[\x20-\x7e]/.test(t.name))],
+          ['日本語', checks.singleUse.filter(t => !t.lonelyPair && !/^[\x20-\x7e]/.test(t.name))],
+        ];
+      %>
       <ul class="doctor-list">
-        <% checks.singleUse.forEach(function(t){ %>
-        <li><a href="<%- url_for(t.path) %>"><%= t.name %></a><% if (t.lonelyPair) { %> <span class="doctor-note">1記事タグ同士が同居</span><% } %></li>
+        <% singleGroups.forEach(function(g){ %>
+        <% if (g[1].length) { %>
+        <li><span class="doctor-note"><%= g[0] %>（<%= g[1].length %>タグ）</span><% g[1].forEach(function(t, i){ %><a href="<%- url_for(t.path) %>"><%= t.name %></a><%= i < g[1].length - 1 ? '、' : '' %><% }) %></li>
+        <% } %>
         <% }) %>
       </ul>
 


### PR DESCRIPTION
## 概要

Close #2259

/doctor の表示・判定ルールを2点更新します。

## 変更

**「1記事にしか使われていないタグ」の改行抑制**
- 1タグ1行の縦リストをやめ、**同居あり／英数字／日本語**の3ブロック（各ブロックに件数表示）に分けて、中は読点区切りで流し込む。並び順は従来（同居優先→名前順）のまま

**「タグが付きすぎている記事」の閾値**
- 7タグ以上（中央値3の倍）→ **10タグ以上**。7だと件数が多すぎて手が付かないため。※注記の文言も追従

## 動作確認（ローカル）

- /doctor/ の1記事タグが「英数字（29タグ）」「日本語（16タグ）」のブロック表示になる（同居ありは現在0件のため非表示）
- 付きすぎ判定は1記事（30種類のプログラミング言語で、ループ処理を書いてみた）まで絞られる

🤖 Generated with [Claude Code](https://claude.com/claude-code)