### PR TITLE
OpenCensus タグを OpenTelemetry に統合する

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -154,6 +154,7 @@ alias:
   tags/性能テスト/: tags/性能検証/
   tags/論文解説/: tags/論文紹介/
   tags/SQLLite/: tags/SQLite/ # 誤記の修正
+  tags/OpenCensus/: tags/OpenTelemetry/ # OpenCensus は OpenTelemetry に統合された旧規格
 
   # 1記事しかなく、タグ名がタイトルに含まれるため復元が容易なタグ。
   # 一覧のノイズを減らすため廃止し、タグURLは元記事へ転送する。

--- a/source/_posts/2019/20190604-trace.md
+++ b/source/_posts/2019/20190604-trace.md
@@ -4,7 +4,6 @@ date: 2019/06/04 09:00:51
 postid: ""
 tags:
   - Go
-  - OpenCensus
   - OpenTelemetry
   - Telemetry
 categories:

--- a/source/_posts/2020/20200205-gcp-stackdriver.md
+++ b/source/_posts/2020/20200205-gcp-stackdriver.md
@@ -4,7 +4,7 @@ date: 2020/02/05 09:23:10
 postid: ""
 tags:
   - GoogleCloud
-  - OpenCensus
+  - OpenTelemetry
   - Go
   - CloudOperations
   - ログ

--- a/source/_posts/2021/20210311_PythonでCloud_Operationsの機能を使ってみる.md
+++ b/source/_posts/2021/20210311_PythonでCloud_Operationsの機能を使ってみる.md
@@ -5,7 +5,6 @@ postid: ""
 tags:
   - GoogleCloud
   - Python
-  - OpenCensus
   - OpenTelemetry
   - CloudOperations
   - CloudRun


### PR DESCRIPTION
## 概要

/doctor の統合候補より。OpenCensus は OpenTelemetry に統合された旧規格で、タグとして分ける意味が薄い（記事3本のうち2本は既に両タグ持ちだった）。

## 変更

- OpenCensus タグ付きの3記事: 両タグ持ちの2本は OpenCensus 行を削除、残り1本は OpenTelemetry に置換
- `_config.yml` の alias（同義タグの統合）に `tags/OpenCensus/ → tags/OpenTelemetry/` を追加

## 動作確認（ローカル）

- /tags/OpenTelemetry/ が5本になる（4本＋統合1本）
- /tags/OpenCensus/ が OpenTelemetry へ転送される

🤖 Generated with [Claude Code](https://claude.com/claude-code)