### PR TITLE
タイトルにタグ名を含む記事へタグを振り下ろす（第2弾）

### DIFF
--- a/source/_posts/2020/20200715-virtual-contest.md
+++ b/source/_posts/2020/20200715-virtual-contest.md
@@ -8,6 +8,7 @@ tags:
   - 社内勉強会
   - コンテスト
   - 初心者向け
+  - Tips
 categories:
   - Culture
 thumbnail: /images/2020/20200715/thumbnail.png

--- a/source/_posts/2021/20210602a_AWS_LambdaにおけるGo_Contextの取り扱い.md
+++ b/source/_posts/2021/20210602a_AWS_LambdaにおけるGo_Contextの取り扱い.md
@@ -6,6 +6,7 @@ tags:
   - Go
   - Lambda
   - context
+  - AWS
 categories:
   - Programming
 series: "サーバレス2021"

--- a/source/_posts/2021/20210603a_静的解析によるInvalidなAWS_Lambda関数シグネチャの検知.md
+++ b/source/_posts/2021/20210603a_静的解析によるInvalidなAWS_Lambda関数シグネチャの検知.md
@@ -7,6 +7,7 @@ tags:
   - Lambda
   - Linter
   - 静的解析
+  - AWS
 categories:
   - Programming
 series: "サーバレス2021"

--- a/source/_posts/2021/20211111a_AWS_GameDay_Online参加レポート.md
+++ b/source/_posts/2021/20211111a_AWS_GameDay_Online参加レポート.md
@@ -6,6 +6,7 @@ tags:
   - AWS
   - コンテスト
   - 参戦記
+  - 参加レポート
 categories:
   - Infrastructure
 thumbnail: /images/2021/20211111a/thumbnail.png

--- a/source/_posts/2021/20211115b_IBM_Quantum_Challenge_Fall_2021参加レポート.md
+++ b/source/_posts/2021/20211115b_IBM_Quantum_Challenge_Fall_2021参加レポート.md
@@ -5,6 +5,7 @@ postid: b
 tags:
   - ハッカソン
   - コンテスト
+  - 参加レポート
 categories:
   - Programming
 thumbnail: /images/2021/20211115b/thumbnail.png

--- a/source/_posts/2022/20220401a_アジャイル開発を2年弱実践した開発者目線で語るアジャイルソフトウェア開発_2（日常編）.md
+++ b/source/_posts/2022/20220401a_アジャイル開発を2年弱実践した開発者目線で語るアジャイルソフトウェア開発_2（日常編）.md
@@ -4,6 +4,7 @@ date: 2022/04/01 00:00:00
 postid: a
 tags:
   - アジャイル
+  - ソフトウェア
 categories:
   - DevOps
 thumbnail: /images/2022/20220401a/thumbnail.png

--- a/source/_posts/2022/20221024a_Goで作ったロジックにWebUIをつけてGitHubページに公開する.md
+++ b/source/_posts/2022/20221024a_Goで作ったロジックにWebUIをつけてGitHubページに公開する.md
@@ -6,6 +6,7 @@ tags:
   - Next.js
   - Go
   - WebAssembly
+  - GitHub
 categories:
   - Frontend
 thumbnail: /images/2022/20221024a/thumbnail.png

--- a/source/_posts/2023/20231026a_【Flutter】Proxyがある社内ネットワーク環境でのAndroidエミュレータのインターネット接続方法解説！.md
+++ b/source/_posts/2023/20231026a_【Flutter】Proxyがある社内ネットワーク環境でのAndroidエミュレータのインターネット接続方法解説！.md
@@ -7,6 +7,7 @@ tags:
   - プロキシ
   - Android
   - エミュレータ
+  - ネットワーク
 categories:
   - Mobile
 thumbnail: /images/2023/20231026a/thumbnail.png

--- a/source/_posts/2024/20240205a_Go_1.22リリース連載_vet,_log／slog,_testing／slogtest.md
+++ b/source/_posts/2024/20240205a_Go_1.22リリース連載_vet,_log／slog,_testing／slogtest.md
@@ -9,6 +9,7 @@ tags:
   - slog
   - 構造化ログ
   - Vet
+  - testing
 categories:
   - Programming
 series: "Go1.22リリース"

--- a/source/_posts/2024/20240329a_GoでAWS_Lambdaのミドルウェアをジェネリクスを用いて実装する.md
+++ b/source/_posts/2024/20240329a_GoでAWS_Lambdaのミドルウェアをジェネリクスを用いて実装する.md
@@ -7,6 +7,7 @@ tags:
   - Lambda
   - デザインパターン
   - ジェネリクス
+  - AWS
 categories:
   - Programming
 thumbnail: /images/2024/20240329a/thumbnail.png

--- a/source/_posts/2024/20240822a_MSの生成AIサンプルアプリ（Chat_with_your_data_-_Solution_accelerator）コード確認.md
+++ b/source/_posts/2024/20240822a_MSの生成AIサンプルアプリ（Chat_with_your_data_-_Solution_accelerator）コード確認.md
@@ -6,6 +6,7 @@ tags:
   - LLM
   - Azure
   - Python
+  - 生成AI
 categories:
   - DataScience
 thumbnail: /images/2024/20240822a/thumbnail.png

--- a/source/_posts/2025/20250206a_Cloud_Composer_(Apache_Airflow)_実用インフラTips.md
+++ b/source/_posts/2025/20250206a_Cloud_Composer_(Apache_Airflow)_実用インフラTips.md
@@ -5,6 +5,7 @@ postid: a
 tags:
   - Airflow
   - GoogleCloud
+  - Tips
 categories:
   - Infrastructure
 thumbnail: /images/2025/20250206a/thumbnail.png

--- a/source/_posts/2025/20250207a_AWSのGenerative_AI_Use_Cases_JPを用いた生成AIサービスの構築検証.md
+++ b/source/_posts/2025/20250207a_AWSのGenerative_AI_Use_Cases_JPを用いた生成AIサービスの構築検証.md
@@ -8,6 +8,7 @@ tags:
   - LLM
   - Bedrock
   - AWS CDK
+  - 生成AI
 categories:
   - DataScience
 thumbnail: /images/2025/20250207a/thumbnail.png

--- a/source/_posts/2025/20250715a_日本語×ソフトウェア開発に強いLLMの開発に取り組んだ挑戦者の備忘録_(前編).md
+++ b/source/_posts/2025/20250715a_日本語×ソフトウェア開発に強いLLMの開発に取り組んだ挑戦者の備忘録_(前編).md
@@ -5,6 +5,7 @@ postid: a
 tags:
   - LLM
   - Llama
+  - ソフトウェア
 categories:
   - DataScience
 series: "AI Tips"

--- a/source/_posts/2025/20250716a_日本語×ソフトウェア開発に強いLLMの開発に取り組んだ挑戦者の備忘録_(後編).md
+++ b/source/_posts/2025/20250716a_日本語×ソフトウェア開発に強いLLMの開発に取り組んだ挑戦者の備忘録_(後編).md
@@ -5,6 +5,7 @@ postid: a
 tags:
   - LLM
   - Llama
+  - ソフトウェア
 categories:
   - DataScience
 series: "AI Tips"

--- a/source/_posts/2025/20250821a_生成AI時代に、なぜ技術ブログを書くのか.md
+++ b/source/_posts/2025/20250821a_生成AI時代に、なぜ技術ブログを書くのか.md
@@ -8,6 +8,7 @@ tags:
   - スキルアップ
   - Slackで話した
   - キャリア
+  - 生成AI
 categories:
   - Culture
 thumbnail: /images/2025/20250821a/thumbnail.jpg

--- a/source/_posts/2025/20251203a_AWSのKiroを使うハッカソン「Kiroween」に参加してみた.md
+++ b/source/_posts/2025/20251203a_AWSのKiroを使うハッカソン「Kiroween」に参加してみた.md
@@ -6,6 +6,7 @@ tags:
   - スペック駆動開発
   - Kiro
   - ハッカソン
+  - AWS
 categories:
   - AIDD
 thumbnail: /images/2025/20251203a/thumbnail.png

--- a/source/_posts/2025/20251208a_プログラミング未経験の学生が選択すると良さそうな生成AIツールと考え方.md
+++ b/source/_posts/2025/20251208a_プログラミング未経験の学生が選択すると良さそうな生成AIツールと考え方.md
@@ -6,6 +6,7 @@ tags:
   - Kiro
   - Copilot
   - 技育祭
+  - 生成AI
 categories:
   - AIDD
 thumbnail: /images/2025/20251208a/thumbnail.png

--- a/source/_posts/2026/20260417a_Mermaid.jsで簡易的な数値報告のためのグラフを作るTips.md
+++ b/source/_posts/2026/20260417a_Mermaid.jsで簡易的な数値報告のためのグラフを作るTips.md
@@ -5,6 +5,7 @@ postid: a
 tags:
   - Mermaid.js
   - Markdown
+  - Tips
 categories:
   - Management
 thumbnail: /images/2026/20260417a/thumbnail.png

--- a/source/_posts/2026/20260529a_SMART_ENERGY_WEEK_春参加レポート.md
+++ b/source/_posts/2026/20260529a_SMART_ENERGY_WEEK_春参加レポート.md
@@ -5,6 +5,7 @@ postid: a
 tags:
   - エネルギー業界
   - 展示会
+  - 参加レポート
 categories:
   - Business
 thumbnail: /images/2026/20260529a/thumbnail.jpg

--- a/source/_posts/2026/20260604a_AWS_Certified_Security_-_Specialty_合格体験記_-_Claude壁打ちとUdemy演習で一発合格.md
+++ b/source/_posts/2026/20260604a_AWS_Certified_Security_-_Specialty_合格体験記_-_Claude壁打ちとUdemy演習で一発合格.md
@@ -5,6 +5,7 @@ postid: a
 tags:
   - AWS
   - 合格記
+  - Claude
 categories:
   - Security
 thumbnail: /images/2026/20260604a/thumbnail.png

--- a/source/_posts/2026/20260605a_S3_Tables×AWS_Glueで作る次世代データ分析基盤.md
+++ b/source/_posts/2026/20260605a_S3_Tables×AWS_Glueで作る次世代データ分析基盤.md
@@ -6,6 +6,7 @@ tags:
   - Glue
   - S3
   - データレイク
+  - AWS
 categories:
   - DataEngineering
 thumbnail: /images/2026/20260605a/thumbnail.png


### PR DESCRIPTION
## 概要

/doctor の「タイトルにタグ名を含むのに、そのタグが付いていない記事」のうち、レビューで受け入れられた **9タグ・22記事** を反映します（#2258 の続き）。

- 全記事対象: AWS(5)・生成AI(4)・参加レポート(3)・Tips(3)・ソフトウェア(3)・GitHub(1)・Claude(1)
- 指定の1記事のみ: **ネットワーク**（【Flutter】Proxyがある社内ネットワーク環境での…）、**testing**（Go 1.22リリース連載 vet, log/slog, testing/slogtest）

変更は各記事のフロントマター tags への1行追記のみです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)