### PR TITLE
ClaudeCode・NoSQL・Grafana Alloy・Zuora のタグを統合する

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -155,6 +155,10 @@ alias:
   tags/論文解説/: tags/論文紹介/
   tags/SQLLite/: tags/SQLite/ # 誤記の修正
   tags/OpenCensus/: tags/OpenTelemetry/ # OpenCensus は OpenTelemetry に統合された旧規格
+  tags/ClaudeCode/: tags/Claude/
+  tags/NoSQL/: tags/Cassandra/
+  tags/Grafana-Alloy/: tags/Grafana/ # タグ名「Grafana Alloy」のスラッグ
+  tags/Zuora/: tags/サブスクリプション/
 
   # 1記事しかなく、タグ名がタイトルに含まれるため復元が容易なタグ。
   # 一覧のノイズを減らすため廃止し、タグURLは元記事へ転送する。

--- a/source/_posts/2019/20190718-kvs.md
+++ b/source/_posts/2019/20190718-kvs.md
@@ -6,7 +6,6 @@ tags:
   - データモデル
   - KVS
   - Cassandra
-  - NoSQL
 categories:
   - DB
 author: 岩崎祐太

--- a/source/_posts/2020/20200706-zuora-1.md
+++ b/source/_posts/2020/20200706-zuora-1.md
@@ -3,7 +3,6 @@ title: "Zuora連載１：Zuora Central Platform概要"
 date: 2020/07/06 09:01:37
 postid: ""
 tags:
-  - Zuora
   - サブスクリプション
   - データモデル
 categories:

--- a/source/_posts/2020/20200708-zuora-2.md
+++ b/source/_posts/2020/20200708-zuora-2.md
@@ -3,7 +3,6 @@ title: "Zuora連載2：Zuora REST API 利用と開発環境構築"
 date: 2020/07/08 09:56:30
 postid: ""
 tags:
-  - Zuora
   - サブスクリプション
   - Go
   - 環境構築

--- a/source/_posts/2020/20200716-zuora3.md
+++ b/source/_posts/2020/20200716-zuora3.md
@@ -3,7 +3,6 @@ title: "Zuora連載 Vol.3 Notification及びEventTriggerの話"
 date: 2020/07/16 10:49:27
 postid: ""
 tags:
-  - Zuora
   - サブスクリプション
 categories:
   - Infrastructure

--- a/source/_posts/2020/20200720_Zuora連載_Vol.4_Workflowの話.md
+++ b/source/_posts/2020/20200720_Zuora連載_Vol.4_Workflowの話.md
@@ -3,7 +3,6 @@ title: Zuora連載 Vol.4 Workflowの話
 date: 2020/07/20 00:00:00
 postid: ""
 tags:
-  - Zuora
   - ワークフロー
   - サブスクリプション
 categories:

--- a/source/_posts/2021/20210412a_KVSと二年間向き合って得たナレッジを還元する時がきた.md
+++ b/source/_posts/2021/20210412a_KVSと二年間向き合って得たナレッジを還元する時がきた.md
@@ -5,7 +5,6 @@ postid: a
 tags:
   - KVS
   - Cassandra
-  - NoSQL
   - 排他制御
 categories:
   - DB

--- a/source/_posts/2021/20210419b_IT初学者がカラムナデータベースを勉強してみた.md
+++ b/source/_posts/2021/20210419b_IT初学者がカラムナデータベースを勉強してみた.md
@@ -4,7 +4,7 @@ date: 2021/04/19 00:00:01
 postid: b
 tags:
   - 初心者向け
-  - NoSQL
+  - Cassandra
 categories:
   - DB
 series: "春の入門祭り2021"

--- a/source/_posts/2025/20250825b_Grafana_Alloyを使って、EKSクラスタ外部のサーバからメトリクス取得を試してみた.md
+++ b/source/_posts/2025/20250825b_Grafana_Alloyを使って、EKSクラスタ外部のサーバからメトリクス取得を試してみた.md
@@ -4,7 +4,6 @@ date: 2025/08/25 00:00:01
 postid: b
 tags:
   - Grafana
-  - Grafana Alloy
   - EKS
   - 初心者向け
   - Docker

--- a/source/_posts/2025/20250910a_「Grafana_Meetup_Japan_#6｜どうする？Grafanaする！」に登壇しました.md
+++ b/source/_posts/2025/20250910a_「Grafana_Meetup_Japan_#6｜どうする？Grafanaする！」に登壇しました.md
@@ -4,7 +4,6 @@ date: 2025/09/10 00:00:00
 postid: a
 tags:
   - Grafana
-  - Grafana Alloy
   - 登壇レポート
 categories:
   - DevOps

--- a/source/_posts/2026/20260422a_リポジトリ駆動のコンテンツ制作ワークフロー：_GitHub_に素材を集めて、Claude_Code_で成果物に展開する.md
+++ b/source/_posts/2026/20260422a_リポジトリ駆動のコンテンツ制作ワークフロー：_GitHub_に素材を集めて、Claude_Code_で成果物に展開する.md
@@ -3,7 +3,6 @@ title: "リポジトリ駆動のコンテンツ制作ワークフロー: GitHub 
 date: 2026/04/22 00:00:00
 postid: a
 tags:
-  - ClaudeCode
   - Claude
   - GitHub
 categories:

--- a/source/_posts/2026/20260501a_【Claude_Design】インフラ構成のお絵描きからリソース実装までをClaudeで一本化してみた.md
+++ b/source/_posts/2026/20260501a_【Claude_Design】インフラ構成のお絵描きからリソース実装までをClaudeで一本化してみた.md
@@ -3,7 +3,7 @@ title: "【Claude Design】インフラ構成のお絵描きからリソース�
 date: 2026/05/01 00:00:00
 postid: a
 tags:
-  - ClaudeCode
+  - Claude
   - Terraform
   - AWS
 categories:

--- a/source/_posts/2026/20260513a_技術書は「読む」から「呼び出す」へ：ACM経由のO'Reilly_Online_Learning契約とMCP連携の実践.md
+++ b/source/_posts/2026/20260513a_技術書は「読む」から「呼び出す」へ：ACM経由のO'Reilly_Online_Learning契約とMCP連携の実践.md
@@ -4,7 +4,7 @@ date: 2026/05/13 00:00:00
 postid: a
 tags:
   - O'Reilly
-  - ClaudeCode
+  - Claude
   - MCP
 categories:
   - AIDD

--- a/source/_posts/2026/20260525a_AWS_MCP_Server_がGAに_-_Claude_Codeから検証：IAMガードレール設計.md
+++ b/source/_posts/2026/20260525a_AWS_MCP_Server_がGAに_-_Claude_Codeから検証：IAMガードレール設計.md
@@ -4,7 +4,7 @@ date: 2026/05/25 00:00:00
 postid: a
 tags:
   - AWS
-  - ClaudeCode
+  - Claude
   - IAM
   - MCP
 categories:

--- a/source/_posts/2026/20260602a_AI駆動開発は「ツール導入」ではなく「協働チーム設計」である_——_現場で運用して見えてきたこと.md
+++ b/source/_posts/2026/20260602a_AI駆動開発は「ツール導入」ではなく「協働チーム設計」である_——_現場で運用して見えてきたこと.md
@@ -4,7 +4,7 @@ date: 2026/06/02 00:00:00
 postid: a
 tags:
   - ソフトウェア
-  - ClaudeCode
+  - Claude
 categories:
   - AIDD
 thumbnail: /images/2026/20260602a/thumbnail.jpg

--- a/source/_posts/2026/20260615a_テスト連載2026を開始します_AIがテストを書く中であるべき仕様を単体テストで担保する工夫.md
+++ b/source/_posts/2026/20260615a_テスト連載2026を開始します_AIがテストを書く中であるべき仕様を単体テストで担保する工夫.md
@@ -4,7 +4,7 @@ date: 2026/06/15 00:00:00
 postid: a
 tags:
   - テスト
-  - ClaudeCode
+  - Claude
   - インデックス
 categories:
   - AIDD


### PR DESCRIPTION
## 概要

タグメンテの続き。指定された4件を統合します。

| 統合元 | 統合先 | 記事の処理 |
| --- | --- | --- |
| ClaudeCode (6) | Claude | 置換5・両タグ持ちの重複解消1 → Claude 15本 |
| NoSQL (3) | Cassandra | 置換1・重複解消2 → Cassandra 3本 |
| Grafana Alloy (2) | Grafana | 重複解消2（両記事とも Grafana 持ち）→ Grafana 3本 |
| Zuora (4) | サブスクリプション | 重複解消4（全記事が両タグ持ち）→ サブスクリプション 4本 |

- 旧タグ URL は `_config.yml` の alias（同義タグの統合）で転送。「Grafana Alloy」のスラッグは `/tags/Grafana-Alloy/`
- 記事本文中の「NoSQL」の語（20240730a のデータベース分類リスト等）は触っていません

## 動作確認（ローカル）

- /tags/Claude/=15本、/tags/Cassandra/=3本、/tags/Grafana/=3本、/tags/サブスクリプション/=4本
- /tags/ClaudeCode/・/tags/NoSQL/・/tags/Grafana-Alloy/・/tags/Zuora/ が各統合先へ転送

🤖 Generated with [Claude Code](https://claude.com/claude-code)