### PR TITLE
Gems タグを廃止し、MFA ツール記事に CLI タグを付ける

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -191,6 +191,7 @@ alias:
 
   tags/Pマーク/: tags/ISMS/            # 同一記事に重複していたためISMSに寄せる
   tags/Foundationmodel/: articles/20260624a/ # 記事固有のためタグを廃し、記事へ転送
+  tags/Gems/: articles/20250722a/ # Gemini の機能廃止に伴いタグを廃し、記事へ転送
   tags/OJT/: tags/コーチング/          # 社内育成の意味に寄せる
   tags/教育/: tags/コーチング/          # プログラミング教育（産業）と区別する
   tags/Bob/: tags/ORM/

--- a/source/_posts/2021/20210426a_AWS_CLIで用いるMFAをちょっとだけ便利に扱えるツールを公開しました.md
+++ b/source/_posts/2021/20210426a_AWS_CLIで用いるMFAをちょっとだけ便利に扱えるツールを公開しました.md
@@ -7,6 +7,7 @@ tags:
   - IAM
   - OSS
   - Go
+  - CLI
 categories:
   - Security
 thumbnail: /images/2021/20210426a/thumbnail.jpg

--- a/source/_posts/2025/20250722a_生成AIとはじめる、バックオフィス業務改革_～Geminiの有効な使い方～.md
+++ b/source/_posts/2025/20250722a_生成AIとはじめる、バックオフィス業務改革_～Geminiの有効な使い方～.md
@@ -5,7 +5,6 @@ postid: a
 tags:
   - 生成AI
   - Gemini
-  - Gems
 categories:
   - Business
 series: "AI Tips"


### PR DESCRIPTION
## 概要

タグメンテ2件。

- **Gems タグの廃止**: Gemini 側で機能が廃止されるため。1記事タグ（20250722a 生成AIとはじめる、バックオフィス業務改革）なので、タグを外して記事へ転送する既存の流儀（Foundationmodel と同じ）で alias を追加
- **CLI タグの追加**: 「AWS CLIで用いるMFAをちょっとだけ便利に扱えるツールを公開しました」（20210426a）へ

## 動作確認（ローカル）

- /tags/Gems/ → 記事 20250722a へ転送
- /tags/CLI/ → 4本（3本＋今回の1本）

🤖 Generated with [Claude Code](https://claude.com/claude-code)