### PR TITLE
パネルのサムネを88×59の枠に固定して切り抜く

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -371,9 +371,13 @@ body.page-header-fixed .header {
   flex: 0 0 88px;
   line-height: 0;
 }
+/* パネルの大きさが正で、画像はそこに収める (#2271)。標準サムネ（200×135）と
+   同じ比率の枠に固定し、縦長・正方形のサムネは中央で切り抜く。
+   height: auto だと画像側がカードの高さを引き伸ばしてしまう */
 .panel-thumb img {
   width: 88px;
-  height: auto;
+  height: 59px;
+  object-fit: cover;
   border-radius: 4px;
 }
 .panel-body {


### PR DESCRIPTION
## 概要

Close #2271

タグ・カテゴリ・著者・年ページの「よく読まれている記事」（と、同じ部品を使うホームの「連載から探す」）で、縦長・正方形のサムネイルがカードの高さを引き伸ばしていました。

## 原因と対応

`.panel-thumb img` が `width: 88px; height: auto` で、画像のアスペクト比がそのままカードに効いていました。**パネルの大きさを正**とし、画像は 88×59（標準サムネ 200×135 と同じ比率）の枠に固定して `object-fit: cover` で中央切り抜きにします。

- 標準比率（200:135）のサムネは見た目が変わりません
- 縦長・正方形のサムネだけが枠に収まるようになります
- ランキングの小サムネ（48×32 + cover #2246）と同じ方式です

## 動作確認（ローカル）

- 生成 CSS に枠固定が入ることを確認。標準サムネのカードは変化なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)