### PR TITLE
よく読まれている記事の上限を6件にする

### DIFF
--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -21,11 +21,12 @@ hexo.extend.helper.register("get_ga4_pv", url => {
 
 // 推薦の件数は記事数から決める。推薦が全記事の半分を超えると
 // 一覧の並べ替えにしかならず、新着とほぼ同じ顔ぶれになるため、
-// 2件には4本以上、4件には8本以上を要求する (#2173)
+// 2件には4本以上、4件には8本以上、6件には12本以上を要求する (#2173 / #2272)
 function recommendLimit(count) {
   if (count <= 3) return 0;
   if (count <= 7) return 2;
-  return 4;
+  if (count <= 11) return 4;
+  return 6;
 }
 
 // 指定した記事の中から PV の多い順に取り出す。カテゴリ・タグの一覧ページで


### PR DESCRIPTION
## 概要

Close #2272

「よく読まれている記事」（カテゴリ・タグ・著者・年・月・without-go 共通の `popular_posts_in`）の最大件数を4件から**6件**にします。

## 規則

確立済みの一文ルール「**推薦は全記事の半分以下**」（#2173）をそのまま1段階延長します。

| 記事数 | 表示件数 |
| --- | --- |
| 〜3本 | 0（出さない） |
| 4〜7本 | 2 |
| 8〜11本 | 4 |
| **12本以上** | **6** |

カードは2列グリッドなので偶数刻みを保ちます。新しい係数はありません。

## 動作確認（ローカル）

- Programming（337本）・Rust（17本）→ 6件
- Linter（9本）→ 4件
- UUID（2本）→ 非表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)