### PR TITLE
統計を「累計」「直近1年」のパネルで束ねて1行に収める

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1719,6 +1719,29 @@ a.series-nav-item:hover .series-nav-item-title {
   color: #777;
   font-size: 0.9em;
 }
+/* 統計は「累計」「直近1年」の時間軸ごとにパネルで束ねて1行に収める (#2276)。
+   枠は tendency-panel と同じ意匠。時間軸はパネルのラベルが名乗る */
+.summary-panels {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.summary-panel {
+  border: 1px solid #eee;
+  border-radius: card-radius;
+  padding: 6px 16px 2px;
+}
+.summary-panel-label {
+  display: block;
+  margin-bottom: 2px;
+  color: #6e6e6e;
+  font-size: 0.85em;
+}
+.summary-panel .summary-note {
+  margin: 12px 0;
+}
 .bottom-content-header {
   font-weight: bold;
   /* 見出しと直後のコンテンツが近すぎて窮屈に見えていた。

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -9,24 +9,32 @@
   <section id="main" class="margin-top-30">
     <h1 class="list-page"><%- page.author %><span class="list-sub-text">さんのページ</span></h1>
     <% if (page.current === 1) { %>
-    <ul class="summary">
-      <li><span class="summary-count"><%= count_author(page.author) %></span><br><span class="summary-label">投稿</span></li>
-      <li><span class="summary-count"><%= page.authorSNSCnt %></span><br><span class="summary-label">総シェア数</span></li>
-      <li class="summary-sub"><span class="summary-count"><%= page.twitterShare %></span><br><span class="summary-label">X</span></li>
-      <li class="summary-sub"><span class="summary-count"><%= page.facebookShare %></span><br><span class="summary-label">Facebook</span></li>
-      <li class="summary-sub"><span class="summary-count"><%= page.hatebu %></span><br><span class="summary-label">はてブ</span></li>
-      <li class="summary-sub"><span class="summary-count"><%= page.pocket %></span><br><span class="summary-label">Pocket</span></li>
-    </ul>
     <% const as = author_stats(page.author); %>
-    <%# 直近1年（#2082）は全期間の統計と時間軸が違うので、混ぜずに行を分ける。
-        カテゴリ・タグページ (#2084 / #2088) と同じ構成 %>
-    <% if (as.recent > 0) { %>
-    <ul class="summary">
-      <li><span class="summary-count"><%= as.recent %></span><br><span class="summary-label">直近1年の投稿</span></li>
-    </ul>
-    <% } else { %>
-    <p class="summary-note">直近1年間の投稿はありません</p>
-    <% } %>
+    <%# 累計と直近1年（#2082）は時間軸が違うので、パネルで束ねて区別する (#2276)。
+        カテゴリ・タグページと同じ構成 %>
+    <div class="summary-panels">
+      <section class="summary-panel">
+        <span class="summary-panel-label">累計</span>
+        <ul class="summary">
+          <li><span class="summary-count"><%= count_author(page.author) %></span><br><span class="summary-label">投稿</span></li>
+          <li><span class="summary-count"><%= page.authorSNSCnt %></span><br><span class="summary-label">総シェア数</span></li>
+          <li class="summary-sub"><span class="summary-count"><%= page.twitterShare %></span><br><span class="summary-label">X</span></li>
+          <li class="summary-sub"><span class="summary-count"><%= page.facebookShare %></span><br><span class="summary-label">Facebook</span></li>
+          <li class="summary-sub"><span class="summary-count"><%= page.hatebu %></span><br><span class="summary-label">はてブ</span></li>
+          <li class="summary-sub"><span class="summary-count"><%= page.pocket %></span><br><span class="summary-label">Pocket</span></li>
+        </ul>
+      </section>
+      <section class="summary-panel">
+        <span class="summary-panel-label">直近1年</span>
+        <% if (as.recent > 0) { %>
+        <ul class="summary">
+          <li><span class="summary-count"><%= as.recent %></span><br><span class="summary-label">投稿</span></li>
+        </ul>
+        <% } else { %>
+        <p class="summary-note">投稿はありません</p>
+        <% } %>
+      </section>
+    </div>
     <%- get_profile(page.author) %>
     <%# 並びはカテゴリ・タグページの「統計 → よく読まれている記事 → 新着」に
         揃える (#2191)。月別投稿数のグラフは統計の一種とみなして統計の直後に置く %>

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -13,25 +13,34 @@
     <h1 class="list-page"><%- page.category %> <span class="list-sub-text">カテゴリ</span></h1>
     <% if (page.current === 1) { %>
     <% const cs = category_stats(page.category); %>
-    <ul class="summary">
-      <% const summary = summary_category(page.category); %>
-      <li><span class="summary-count"><%= count_category(page.category) %></span><br><span class="summary-label">投稿</span></li>
-      <li><span class="summary-count"><%= summary.authors %></span><br><span class="summary-label">著者数</span></li>
-      <li><span class="summary-count"><%= summary.total %></span><br><span class="summary-label">総シェア数</span></li>
-      <li class="summary-sub"><span class="summary-count"><%= summary.twitter %></span><br><span class="summary-label">X</span></li>
-      <li class="summary-sub"><span class="summary-count"><%= summary.facebook %></span><br><span class="summary-label">Facebook</span></li>
-      <li class="summary-sub"><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
-      <li class="summary-sub"><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
-    </ul>
-    <%# 直近1年（#2084）は全期間の統計と時間軸が違うので、混ぜずに行を分ける %>
-    <% if (cs && cs.recent > 0) { %>
-    <ul class="summary">
-      <li><span class="summary-count"><%= cs.recent %></span><br><span class="summary-label">直近1年の投稿</span></li>
-      <li><span class="summary-count"><%= cs.recentAuthorCount %></span><br><span class="summary-label">直近1年の著者数</span></li>
-    </ul>
-    <% } else if (cs) { %>
-    <p class="summary-note">直近1年間の投稿はありません</p>
-    <% } %>
+    <%# 累計と直近1年（#2084）は時間軸が違うので、パネルで束ねて区別する (#2276)。
+        どちらの数かはパネルのラベルが名乗るので、タイル側では繰り返さない %>
+    <div class="summary-panels">
+      <section class="summary-panel">
+        <span class="summary-panel-label">累計</span>
+        <ul class="summary">
+          <% const summary = summary_category(page.category); %>
+          <li><span class="summary-count"><%= count_category(page.category) %></span><br><span class="summary-label">投稿</span></li>
+          <li><span class="summary-count"><%= summary.authors %></span><br><span class="summary-label">著者数</span></li>
+          <li><span class="summary-count"><%= summary.total %></span><br><span class="summary-label">総シェア数</span></li>
+          <li class="summary-sub"><span class="summary-count"><%= summary.twitter %></span><br><span class="summary-label">X</span></li>
+          <li class="summary-sub"><span class="summary-count"><%= summary.facebook %></span><br><span class="summary-label">Facebook</span></li>
+          <li class="summary-sub"><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
+          <li class="summary-sub"><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
+        </ul>
+      </section>
+      <section class="summary-panel">
+        <span class="summary-panel-label">直近1年</span>
+        <% if (cs && cs.recent > 0) { %>
+        <ul class="summary">
+          <li><span class="summary-count"><%= cs.recent %></span><br><span class="summary-label">投稿</span></li>
+          <li><span class="summary-count"><%= cs.recentAuthorCount %></span><br><span class="summary-label">著者数</span></li>
+        </ul>
+        <% } else { %>
+        <p class="summary-note">投稿はありません</p>
+        <% } %>
+      </section>
+    </div>
     <%# そのカテゴリの中でよく読まれている記事。新着より前に置く。
         絞り込んだ直後の読者がまず知りたいのは「定番はどれか」であって、
         新しさは新着一覧が担う %>

--- a/themes/future/layout/tag.ejs
+++ b/themes/future/layout/tag.ejs
@@ -10,26 +10,34 @@
     <h1 class="list-page"><%- page.tag %> <span class="list-sub-text">タグ</span></h1>
     <% if (page.current === 1) { %>
     <% const summary = summary_tag(page.tag); %>
-    <ul class="summary">
-      <li><span class="summary-count"><%= count_tag(page.tag) %></span><br><span class="summary-label">投稿</span></li>
-      <li><span class="summary-count"><%= summary.authors %></span><br><span class="summary-label">著者数</span></li>
-      <li><span class="summary-count"><%= summary.total %></span><br><span class="summary-label">総シェア数</span></li>
-      <li class="summary-sub"><span class="summary-count"><%= summary.twitter %></span><br><span class="summary-label">X</span></li>
-      <li class="summary-sub"><span class="summary-count"><%= summary.facebook %></span><br><span class="summary-label">Facebook</span></li>
-      <li class="summary-sub"><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
-      <li class="summary-sub"><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
-    </ul>
-    <%# 直近1年（#2088）は全期間の統計と時間軸が違うので、混ぜずに行を分ける。
-        カテゴリページ (#2084) と同じ構成 %>
     <% const ts = tag_stats(page.tag); %>
-    <% if (ts && ts.recent > 0) { %>
-    <ul class="summary">
-      <li><span class="summary-count"><%= ts.recent %></span><br><span class="summary-label">直近1年の投稿</span></li>
-      <li><span class="summary-count"><%= ts.recentAuthorCount %></span><br><span class="summary-label">直近1年の著者数</span></li>
-    </ul>
-    <% } else if (ts) { %>
-    <p class="summary-note">直近1年間の投稿はありません</p>
-    <% } %>
+    <%# 累計と直近1年（#2088）は時間軸が違うので、パネルで束ねて区別する (#2276)。
+        カテゴリページと同じ構成 %>
+    <div class="summary-panels">
+      <section class="summary-panel">
+        <span class="summary-panel-label">累計</span>
+        <ul class="summary">
+          <li><span class="summary-count"><%= count_tag(page.tag) %></span><br><span class="summary-label">投稿</span></li>
+          <li><span class="summary-count"><%= summary.authors %></span><br><span class="summary-label">著者数</span></li>
+          <li><span class="summary-count"><%= summary.total %></span><br><span class="summary-label">総シェア数</span></li>
+          <li class="summary-sub"><span class="summary-count"><%= summary.twitter %></span><br><span class="summary-label">X</span></li>
+          <li class="summary-sub"><span class="summary-count"><%= summary.facebook %></span><br><span class="summary-label">Facebook</span></li>
+          <li class="summary-sub"><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
+          <li class="summary-sub"><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
+        </ul>
+      </section>
+      <section class="summary-panel">
+        <span class="summary-panel-label">直近1年</span>
+        <% if (ts && ts.recent > 0) { %>
+        <ul class="summary">
+          <li><span class="summary-count"><%= ts.recent %></span><br><span class="summary-label">投稿</span></li>
+          <li><span class="summary-count"><%= ts.recentAuthorCount %></span><br><span class="summary-label">著者数</span></li>
+        </ul>
+        <% } else { %>
+        <p class="summary-note">投稿はありません</p>
+        <% } %>
+      </section>
+    </div>
     <% } else { %>
     <%- partial('_partial/pagination-info', {total: count_tag(page.tag)}) %>
     <% } %>


### PR DESCRIPTION
## 概要

Close #2276

カテゴリ・タグ・著者の詳細ページで2段に分かれていた統計（累計の行＋直近1年の行）を、時間軸ごとのパネルで束ねて1行に圧縮します。

```
┌ 累計 ──────────────────────────────┐ ┌ 直近1年 ──────┐
│ 337投稿 72著者数 5,432総シェア数 (X/FB/はてブ/Pocket) │ │ 36投稿 24著者数 │
└──────────────────────────────────┘ └──────────────┘
```

- 時間軸は**パネルのラベルが名乗る**ので、タイル側の「直近1年の投稿」といった接頭辞は「投稿」に簡素化
- 投稿ゼロのとき（例: /tags/OpenCV/）は直近1年パネルの中に「投稿はありません」の注記
- 枠は tendency-panel と同じ意匠（#eee・card-radius）。幅が足りないときは flex-wrap で2段に折り返す
- 期間（年・月）ページは時間軸が1つなのでパネル無しの現状維持（Issue 記載どおり）

## 動作確認（ローカル）

- /categories/Programming/・/tags/Go/・/authors/真野隼記/ で2パネル1行表示
- /tags/OpenCV/（直近1年ゼロ）でパネル内注記

🤖 Generated with [Claude Code](https://claude.com/claude-code)