### PR TITLE
年別 新規タグ数の推移をカテゴリ別・定着別の積み上げにする

### DIFF
--- a/scripts/tags.js
+++ b/scripts/tags.js
@@ -80,17 +80,61 @@ hexo.extend.helper.register('posts_per_tag', function() {
   return {mean: round1(mean(counts)), median: median(counts)};
 });
 
-// 年ごとに初めて使われたタグの数。タグがどれだけ増えてきたかを示す
+// 年ごとに初めて使われたタグの数。タグがどれだけ増えてきたかを示す。
+// 内訳はタグの首位カテゴリ（最も多く使われているカテゴリ）で積む (#2279)。
+// どの分野が新しいトピックを生んでいるかが色で見える
 hexo.extend.helper.register('new_tags_by_year', function() {
-  const byYear = new Map();
+  const byYearCat = new Map(); // 初出年 -> (カテゴリ -> タグ数)
   this.site.tags.forEach(tag => {
     const first = tag.posts.map(p => p.date.format('YYYY')).sort()[0];
-    byYear.set(first, (byYear.get(first) || 0) + 1);
+    const catCount = new Map();
+    tag.posts.forEach(post => {
+      post.categories.forEach(c => catCount.set(c.name, (catCount.get(c.name) || 0) + 1));
+    });
+    // 同数の決着が無いとビルドごとに割り当てが変わる
+    const top = [...catCount.entries()].sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : 1))[0];
+    const cat = top ? top[0] : '未分類';
+    if (!byYearCat.has(first)) byYearCat.set(first, new Map());
+    const m = byYearCat.get(first);
+    m.set(cat, (m.get(cat) || 0) + 1);
+  });
+  const years = [...byYearCat.keys()].sort();
+  // 並びは他のカテゴリ積み上げと同じサイト累計順で固定 (#2201)
+  const present = new Set();
+  byYearCat.forEach(m => m.forEach((cnt, c) => present.add(c)));
+  const catOrder = this.site.categories.toArray()
+    .sort((a, b) => b.length - a.length || (a.name < b.name ? -1 : 1))
+    .map(c => c.name)
+    .filter(c => present.has(c));
+  const extras = [...present].filter(c => !catOrder.includes(c)).sort();
+  const series = catOrder.concat(extras).map(c => ({
+    name: c,
+    data: years.map(y => byYearCat.get(y).get(c) || 0)
+  }));
+  return JSON.stringify({years, series});
+});
+
+// 年ごとの新規タグを「定着したか」で積む (#2279)。
+// 定着 = 初出から1年以内に2記事目が付いたこと。観察窓を1年に固定するのは、
+// 「その後使われたか」で判定すると新しい年ほど再利用の機会が無く、
+// 年同士を比較できないため。初出から1年未満のタグは判定途中で「定着せず」側に出る
+hexo.extend.helper.register('new_tags_retention', function() {
+  const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+  const byYear = new Map(); // 初出年 -> {settled, unsettled}
+  this.site.tags.forEach(tag => {
+    const dates = tag.posts.map(p => p.date.valueOf()).sort((a, b) => a - b);
+    const year = tag.posts.map(p => p.date.format('YYYY')).sort()[0];
+    const settled = dates.length >= 2 && dates[1] - dates[0] <= YEAR_MS;
+    if (!byYear.has(year)) byYear.set(year, {settled: 0, unsettled: 0});
+    byYear.get(year)[settled ? 'settled' : 'unsettled']++;
   });
   const years = [...byYear.keys()].sort();
   return JSON.stringify({
     years,
-    counts: years.map(y => byYear.get(y))
+    series: [
+      {name: '定着', data: years.map(y => byYear.get(y).settled)},
+      {name: '定着せず', data: years.map(y => byYear.get(y).unsettled)}
+    ]
   });
 });
 

--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -21,18 +21,58 @@
           機会が無いだけで交絡するため、新規数だけを出す %>
       <%# 見出しは他のチャートと同じ「◯別 △の推移」の型 (#2212) %>
       <%- partial('_partial/section-heading', {id: 'newtagstrend', text: '年別 新規タグ数の推移'}) %>
-      <div id="chart" style="width:100%;min-height:250px"></div>
+      <%# 内訳（カテゴリ・定着）は別の軸で同時に積めないため、タブで切り替える。
+          期間ページの投稿数の推移と同じ chart-tabs (#2171)。
+          タブ名は積み上げの内訳を名乗る (#2222) %>
+      <div class="nav tabs chart-tabs">
+        <input id="tags-tab-category" type="radio" name="tags_chart_tab" checked>
+        <label tabindex="0" class="tab_item" for="tags-tab-category">カテゴリ別</label>
+        <div class="tab_content">
+          ※色は、そのタグが最も多く使われているカテゴリ
+          <div id="chart-tag-category" style="width:100%;min-height:250px"></div>
+        </div>
+        <input id="tags-tab-retention" type="radio" name="tags_chart_tab">
+        <label tabindex="0" class="tab_item" for="tags-tab-retention">定着別</label>
+        <div class="tab_content">
+          ※定着 = 初出から1年以内に2本目の記事が付いたタグ（初出から1年未満のタグは判定途中）
+          <div id="chart-tag-retention" style="width:100%;min-height:250px"></div>
+        </div>
+      </div>
       <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
       <script type="text/javascript">
         const chartData = <%- new_tags_by_year() %>;
-        const myChart = echarts.init(document.getElementById('chart'));
-        myChart.setOption({
+        const catColors = <%- category_colors() %>;
+        echarts.init(document.getElementById('chart-tag-category')).setOption({
           tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
-          grid: { left: 0, right: '2%', containLabel: true },
+          legend: { bottom: 0, type: 'scroll' },
+          grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
           xAxis: { type: 'category', data: chartData.years },
-          yAxis: { type: 'value', min: 0 },
-          color: ['#337ab7'],
-          series: [{ name: '新規タグ', type: 'bar', data: chartData.counts }]
+          yAxis: { type: 'value', min: 0, minInterval: 1 },
+          <%# 色はカテゴリ名で固定 (#2170) %>
+          series: chartData.series.map(s => ({
+            name: s.name,
+            type: 'bar',
+            stack: 'tags',
+            itemStyle: { color: catColors[s.name] },
+            data: s.data
+          }))
+        });
+
+        const retentionData = <%- new_tags_retention() %>;
+        echarts.init(document.getElementById('chart-tag-retention')).setOption({
+          tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+          legend: { bottom: 0 },
+          grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
+          xAxis: { type: 'category', data: retentionData.years },
+          yAxis: { type: 'value', min: 0, minInterval: 1 },
+          <%# 土台が定着、上が定着せず。定着はページャ現在地と同じ #337ab7 %>
+          color: ['#337ab7', '#d2e2ef'],
+          series: retentionData.series.map(s => ({
+            name: s.name,
+            type: 'bar',
+            stack: 'tags',
+            data: s.data
+          }))
         });
       </script>
 


### PR DESCRIPTION
## 概要

Close #2279

/tags/ の「年別 新規タグ数の推移」が単色の棒で、年ごとの本数以上の情報がありませんでした。2つの内訳をタブで切り替えられる積み上げ棒にします（部品は期間ページと同じ chart-tabs #2171、タブ名は内訳を名乗る #2222）。

## カテゴリ別（既定タブ）

新規タグを**首位カテゴリ**（そのタグが最も多く使われているカテゴリ。同数は名前順で決定的）に割り当てて積む。色は CATEGORY_COLORS 固定・並びはサイト累計順（#2201）で、他のカテゴリ積み上げチャートと同じ文法。どの分野が新しいトピックを生んでいるかが見えます。

## 定着別

**定着 = 初出から1年以内に2本目の記事が付いたタグ**。「その後使われたか」で判定すると新しい年ほど再利用の機会が無く年同士を比較できないため、観察窓を1年に固定します（tags.js の旧コメントが指摘していた交絡の解消）。初出から1年未満のタグは判定途中で「定着せず」側に出る旨を注記しています。

色は 定着=#337ab7（従来の棒と同じ青）、定着せず=薄青。現データでは定着率はおおむね5〜6割で推移しています。

## 動作確認（ローカル）

- /tags/ でタブ2枚（カテゴリ別が既定）、それぞれ積み上げ描画とツールチップを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)