### PR TITLE
カテゴリ一覧の明細に節見出しを立て、著者の数え方を揃える

### DIFF
--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -51,16 +51,16 @@
         カテゴリ名は広い言葉なので、代表タグと直近1年の投稿数を添えて
         中身の見当と活発さが分かるようにする (#2056) %>
     <%- partial('_partial/section-heading', {id: 'categories', text: 'すべてのカテゴリ'}) %>
-    ※各カテゴリに、記事数と寄稿した執筆者数（累計・直近1年）、よく使われるタグを添えています
+    ※各カテゴリに、記事数と著者数（累計・直近1年）、よく使われるタグを添えています
     <ul class="category-index footer-gap">
       <% category_index().forEach(function(c){ %>
       <li class="category-index-item">
         <div class="category-index-head">
           <a class="category-index-name" href="<%- url_for(c.path) %>"><%= c.name %></a>
-          <%# 累計と直近1年を「本数・名数」の同じ形の対にする。
-              名数の意味（寄稿した執筆者数）は上の注記が説明する %>
-          <span class="category-index-meta">累計 <%= c.count %>本・<%= c.authorCount %>名</span>
-          <span class="category-index-meta">直近1年 <%= c.recent %>本・<%= c.recentAuthorCount %>名</span>
+          <%# 累計と直近1年を「本数・著者数」の同じ形の対にする。
+              「著者n名」と行自身が名乗り、注記を読まなくても意味が分かるようにする %>
+          <span class="category-index-meta">累計 <%= c.count %>本・著者<%= c.authorCount %>名</span>
+          <span class="category-index-meta">直近1年 <%= c.recent %>本・著者<%= c.recentAuthorCount %>名</span>
         </div>
         <%# チップの右肩の件数は「タグ総数」の意味で使う (#2129)。ここに出せる
             のはカテゴリ内の本数で意味が違うため出さない（title には残す）。

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -46,8 +46,11 @@
       myChart.setOption(option);
     </script>
 
-    <%# カテゴリ名は広い言葉なので、代表タグと直近1年の投稿数を添えて
+    <%# 一覧にも節見出しを立てて、グラフとの境界を節間の余白で分ける (#2281)。
+        h1「カテゴリ一覧」と重ならない語にする。
+        カテゴリ名は広い言葉なので、代表タグと直近1年の投稿数を添えて
         中身の見当と活発さが分かるようにする (#2056) %>
+    <%- partial('_partial/section-heading', {id: 'categories', text: 'すべてのカテゴリ'}) %>
     ※各カテゴリに、記事数と寄稿した執筆者数（累計・直近1年）、よく使われるタグを添えています
     <ul class="category-index footer-gap">
       <% category_index().forEach(function(c){ %>


### PR DESCRIPTION
## 概要

Close #2281

/categories/ の明細まわりの視認性と表記を整えます。

## 節見出し（#2281）

「カテゴリ別 投稿数の推移」のグラフ直後に、注記と明細リストが節見出し無しで続いており境界が無く詰まって見えていました（#2211 の並び替えで顕在化）。明細の前に h2「**すべてのカテゴリ**」（section-heading 部品）を立て、節見出しの標準余白で分離します。語は h1「カテゴリ一覧」と重ねず、「すべての記事」と同じ語彙です。

## 著者の数え方（レビュー指摘）

- 行の「累計 335本・71名」→「累計 335本・**著者**71名」。「名」の意味が注記を読まないと分からなかったのを、行自身が名乗る形に。タイルのラベル「著者数」とも語彙が繋がる
- ※注記の「寄稿した**執筆者**数」→「**著者**数」。サイトの語彙（著者一覧・著者数・著者ページ）はすべて「著者」で、ここだけ執筆者だった

なお「本」は #2209 で統一した正規の単位、タイルの「投稿」は単位ではなく項目名なので、この2系統は揺れではなくそのままです。

## 動作確認（ローカル）

- /categories/ で グラフ → h2 すべてのカテゴリ → 注記 → 明細（累計 335本・著者71名）の順を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)