### PR TITLE
without-go 監査で確定した6本のカテゴリを付け替える

### DIFF
--- a/source/_posts/2021/20210416a_リモートワーク連載：社用機と私用機に同じモニタ3台を使う話.md
+++ b/source/_posts/2021/20210416a_リモートワーク連載：社用機と私用機に同じモニタ3台を使う話.md
@@ -6,7 +6,7 @@ tags:
   - リモートワーク
   - 環境構築
 categories:
-  - Programming
+  - Infrastructure
 series: "リモートワーク"
 thumbnail: /images/2021/20210416a/thumbnail.JPG
 author: 佐藤尭彰

--- a/source/_posts/2023/20230830a_夏の自由研究連載2023_を始めます.md
+++ b/source/_posts/2023/20230830a_夏の自由研究連載2023_を始めます.md
@@ -6,7 +6,7 @@ tags:
   - インデックス
   - 夏休み自由研究
 categories:
-  - Programming
+  - Culture
 series: "夏の自由研究2023"
 thumbnail: /images/2023/20230830a/thumbnail.JPG
 author: 伊藤太斉

--- a/source/_posts/2023/20231030a_秋のブログ週間2023はじめます.md
+++ b/source/_posts/2023/20231030a_秋のブログ週間2023はじめます.md
@@ -6,7 +6,7 @@ tags:
   - インデックス
   - 秋ブログ週間
 categories:
-  - Infrastructure
+  - Culture
 series: "秋のブログ週間2023"
 thumbnail: /images/2023/20231030a/thumbnail.jpg
 author: admin

--- a/source/_posts/2025/20250825a_夏の自由研究連載_2025.md
+++ b/source/_posts/2025/20250825a_夏の自由研究連載_2025.md
@@ -6,7 +6,7 @@ tags:
   - インデックス
   - 夏休み自由研究
 categories:
-  - DevOps
+  - Culture
 series: "夏の自由研究2025"
 thumbnail: /images/2025/20250825a/thumbnail.png
 author: admin

--- a/source/_posts/2025/20251128b_プロによる本気の攻略本『JavaScript／TypeScript実力強化書』で発表しました.md
+++ b/source/_posts/2025/20251128b_プロによる本気の攻略本『JavaScript／TypeScript実力強化書』で発表しました.md
@@ -7,7 +7,7 @@ tags:
   - TypeScript
   - JavaScript
 categories:
-  - Programming
+  - Frontend
 thumbnail: /images/2025/20251128b/thumbnail.jpg
 author: 澁川喜規
 lede: "プロによる本気の攻略本『JavaScript/TypeScript実力強化書』 - FL#115というForkwellを運営するGroovesさんのイベントで登壇してきました。"

--- a/source/_posts/2026/20260213a_2026年2月版：_Dev_Containersでプチはまり(Node.js_24とPostgreSQL_18とプロキシ).md
+++ b/source/_posts/2026/20260213a_2026年2月版：_Dev_Containersでプチはまり(Node.js_24とPostgreSQL_18とプロキシ).md
@@ -8,7 +8,7 @@ tags:
   - PostgreSQL
   - プロキシ
 categories:
-  - Programming
+  - DevOps
 thumbnail: /images/2026/20260213a/thumbnail.png
 author: 澁川喜規
 lede: "Dev Containers便利ですよね？使っていますか？便利なのですが、久々に新しい環境を作ろうとしてちょっとはまったので解決のメモを書いておきます。"


### PR DESCRIPTION
## 概要

Close #2286

/categories/Programming/without-go/ の127本を監査（leave-one-out のタグ投票＋主題レビュー）し、レビューで確定した6本を付け替えます。

| 記事 | 変更 |
| --- | --- |
| プロによる本気の攻略本『JavaScript/TypeScript実力強化書』で発表しました | Programming → Frontend |
| 夏の自由研究連載2023 を始めます | Programming → Culture |
| リモートワーク連載：社用機と私用機に同じモニタ3台を使う話 | Programming → Infrastructure（環境構築） |
| 2026年2月版: Dev Containersでプチはまり | Programming → DevOps |
| 夏の自由研究連載 2025 | DevOps → Culture |
| 秋のブログ週間2023はじめます | Infrastructure → Culture |

企画インデックスはこれで全年 Culture に揃います。とちぎRuby・OSSフィードバック（Tomcat）・SQLフォーマッタ開発系・アルゴリズム系・書評系・競プロ参戦記はレビューどおり残留です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)