### PR TITLE
doctor: カテゴリと同名のタグのチェックを追加

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -180,7 +180,23 @@ hexo.extend.helper.register('doctor_checks', function() {
   }
   nearDuplicates.sort((x, y) => (x.bN - x.aN) - (y.bN - y.aN) || y.aN - x.aN);
 
-  // 5) 1記事タグ。同じ記事に1記事タグ同士が同居している場合は、その記事の
+  // 5) カテゴリと同名のタグ。語彙が重複しているので、タグ側を削除して
+  //    _config.yml の alias でタグURLをカテゴリへ転送する運用（IaC の前例 #2291）。
+  //    大文字小文字違いの表記ゆれも同一視して拾う
+  const categoryDupTags = [];
+  const catByLower = new Map();
+  this.site.categories.forEach(cat => {
+    catByLower.set(cat.name.toLowerCase(), {name: cat.name, path: cat.path, n: cat.length});
+  });
+  this.site.tags.forEach(tag => {
+    const cat = catByLower.get(tag.name.toLowerCase());
+    if (cat) {
+      categoryDupTags.push({name: tag.name, path: tag.path, n: tag.length, cat: cat.name, catPath: cat.path, catN: cat.n});
+    }
+  });
+  categoryDupTags.sort((a, b) => b.n - a.n);
+
+  // 6) 1記事タグ。同じ記事に1記事タグ同士が同居している場合は、その記事の
   //    タグ付けがまとめて薄い可能性が高いので印を付ける
   //    （タグクラウドで * / ** として出していた仕様の移設）
   const singleUse = [];
@@ -198,5 +214,5 @@ hexo.extend.helper.register('doctor_checks', function() {
   }
   singleUse.sort((x, y) => (y.lonelyPair - x.lonelyPair) || (x.name < y.name ? -1 : 1));
 
-  return {suggestions, untagged, overTagged, missing, missingTotal, nearDuplicates, singleUse};
+  return {suggestions, untagged, overTagged, missing, missingTotal, nearDuplicates, categoryDupTags, singleUse};
 });

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -14,6 +14,7 @@
         <li><span class="summary-count"><%= checks.overTagged.length %></span><br><span class="summary-label">タグ付けすぎ</span></li>
         <li><span class="summary-count"><%= checks.missingTotal %></span><br><span class="summary-label">タグ付け漏れ候補</span></li>
         <li><span class="summary-count"><%= checks.nearDuplicates.length %></span><br><span class="summary-label">統合候補のタグ</span></li>
+        <li><span class="summary-count"><%= checks.categoryDupTags.length %></span><br><span class="summary-label">カテゴリと同名のタグ</span></li>
         <li><span class="summary-count"><%= checks.singleUse.length %></span><br><span class="summary-label">1記事タグ</span></li>
       </ul>
 
@@ -63,6 +64,20 @@
         <li>
           <a href="<%- url_for(d.aPath) %>"><%= d.a %></a>（<%= d.aN %>本）<%= d.identical ? ' ＝ ' : ' ⊆ ' %><a href="<%- url_for(d.bPath) %>"><%= d.b %></a>（<%= d.bN %>本）
           <% if (d.identical) { %><span class="doctor-note">記事集合が完全に一致</span><% } %>
+        </li>
+        <% }) %>
+      </ul>
+      <% } else { %>
+      <p>該当なし</p>
+      <% } %>
+
+      <h2 class="bottom-content-header">カテゴリと同名のタグ</h2>
+      ※カテゴリとタグで語彙が重複しています。タグ側を記事から外し、_config.yml の alias でタグURLをカテゴリへ転送してください（大文字小文字違いも同一視して照合）
+      <% if (checks.categoryDupTags.length) { %>
+      <ul class="doctor-list">
+        <% checks.categoryDupTags.forEach(function(d){ %>
+        <li>
+          <a href="<%- url_for(d.path) %>"><%= d.name %></a>（タグ <%= d.n %>本）＝ <a href="<%- url_for(d.catPath) %>"><%= d.cat %></a>（カテゴリ <%= d.catN %>本）
         </li>
         <% }) %>
       </ul>


### PR DESCRIPTION
## 概要

/doctor（記事ドクター）に「カテゴリと同名のタグ」のチェックを追加する。

close #2290

## 変更内容

- `scripts/doctor.js`: 全タグ名をカテゴリ名と照合し、一致したものを列挙する `categoryDupTags` を追加。大文字小文字違いの表記ゆれ（`security` と `Security` 等）も同一視して拾う。タグ本数の多い順に並べる
- `themes/future/layout/doctor.ejs`: サマリータイルと一覧セクションを追加。対処方法（タグ側を外して `_config.yml` の alias で転送）を注記に明記

## 背景

IaC カテゴリ新設の際、同名のタグが16記事に残っていた（#2291 / #2298）。同じ重複が再発しても /doctor を見れば気づけるようにする。

## 確認

- ビルドした `/doctor/` ページで新セクションの表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
