### PR TITLE
#1955 SVGキャッシュ未生成の mermaid 図をビルド時に警告する

### DIFF
--- a/scripts/mermaid.js
+++ b/scripts/mermaid.js
@@ -42,12 +42,24 @@ function readSvg(hash) {
 hexo.extend.filter.register('before_post_render', (data) => {
   if (ignore(data)) return;
   let matched = false;
+  let missing = 0;
   data.content = data.content.replace(fenceRegExp(), (raw, start, quote, lang, source, endQuote, end) => {
     matched = true;
-    return `${start}<pre class="mermaid" data-mermaid="${hashOf(source)}">${source}</pre>${end}`;
+    const hash = hashOf(source);
+    if (!fs.existsSync(path.join(CACHE_DIR, `${hash}.svg`))) missing++;
+    return `${start}<pre class="mermaid" data-mermaid="${hash}">${source}</pre>${end}`;
   });
   if (matched) {
     data.content += `\n\n${MERMAID_SCRIPT}`;
+  }
+  // SVG化し忘れはフォールバックで表示できてしまい気づけないため、ここで知らせる。
+  // このフィルタは新規・編集した記事のレンダリング時に必ず通る
+  // （db.json にキャッシュ済みの記事では出ないが、書いた本人の環境では必ず出る）
+  if (missing > 0) {
+    hexo.log.warn(
+      'mermaid: %s に SVG キャッシュ未生成の図が %d 件あります。`make mermaid` を実行してコミットしてください（それまではブラウザ描画で表示されます）',
+      data.source, missing
+    );
   }
 }, 9);
 


### PR DESCRIPTION
#1955 の運用を守る仕上げ。

mermaid 図の SVG 化（#2299）は `make mermaid` のし忘れがあってもフォールバックで表示できてしまうため、パフォーマンス改善が黙って失われることに気づけない。そこで記事のレンダリング時（`hexo s` / `hexo g`）に未生成の図を検出して WARN を出す。

```
WARN  mermaid: _posts/2026/20260811z_xxx.md に SVG キャッシュ未生成の図が 1 件あります。`make mermaid` を実行してコミットしてください（それまではブラウザ描画で表示されます）
```

- `before_post_render` での検出なので、新規・編集した記事のレンダリング時に必ず通る（db.json にキャッシュ済みの既存記事では再警告しないが、書いた本人の環境では必ず出る）
- 表示・ビルド結果には一切影響しない（警告のみ）
- テスト記事＋未生成の図で WARN が出ること、該当記事が従来どおりフォールバック表示になることを確認済み

当初は PR にコメントする GitHub Actions を検討したが、ローカルの警告で十分と判断してこの形にした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)