### PR TITLE
一覧カードのサムネイルをOGP比率の枠で切り抜いて大きさを揃える

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -186,6 +186,20 @@ blockquote p {
   max-height: 160px;
   margin : 0 auto;
 }
+/* 一覧カードのサムネは OGP 標準比（1200:630）の枠に固定し、中央で切り抜いて
+   大きさを揃える (#2305)。既存サムネの49%（比率1.75以上）はほぼ無加工で収まる。
+   連載パネル（.panel-thumb は #2271 の 200:135）と We're hiring カードは対象外。
+   アンカーは xs 幅で float が外れて inline になるため display を明示する */
+.card-thumb {
+  display: block;
+  aspect-ratio: unquote('1200 / 630');
+}
+.card-thumb img {
+  width: 100%;
+  height: 100%;
+  max-height: none;
+  object-fit: cover;
+}
 .img_wrap:hover img,
 .img_wrap:focus img {
   opacity: 0.6;

--- a/themes/future/layout/_partial/archive-post.ejs
+++ b/themes/future/layout/_partial/archive-post.ejs
@@ -1,10 +1,8 @@
 <div class="row article-card">
-  <a href="<%- url_for(post.path) %>" title="<%= post.title %>" class="col-sm-4 col-md-4 img_wrap">
-    <% if (post.thumbnail) { %>
-    <img src="<%= post.thumbnail %>" class="img-responsive" alt="" <%= image_size_attribute(post.thumbnail) %> loading="lazy">
-    <% } %>
-  </a>
   <% if (post.thumbnail) { %>
+  <a href="<%- url_for(post.path) %>" title="<%= post.title %>" class="col-sm-4 col-md-4 img_wrap card-thumb">
+    <img src="<%= post.thumbnail %>" class="img-responsive" alt="" <%= image_size_attribute(post.thumbnail) %> loading="lazy">
+  </a>
   <div class="col-sm-8 col-md-8">
   <% } else { %>
   <div class="col-xs-12">


### PR DESCRIPTION
## 概要

一覧カードのサムネイルを OGP 標準比（1200:630 ≒ 1.91）の枠に固定し、`object-fit: cover` の中央切り抜きで大きさを揃える。

close #2305

## 変更内容

- `themes/future/css-src/theme-styles.styl`: 一覧カード専用の `.card-thumb` を追加。`aspect-ratio` 1箇所指定（メディアクエリ無し）+ `object-fit: cover`
- `themes/future/layout/_partial/archive-post.ejs`: サムネアンカーに `card-thumb` を付与。サムネ無し記事で空アンカーが比率枠として表示されないよう、アンカー自体を条件分岐の中に移動

## 設計判断

- 比率はサムネ1,305枚の実測分布（1.75以上が49%、中央値≒1.7）と SNS シェア時の見え方から **1.91（OGP標準）** で合意済み。既存サムネの約半数はほぼ無加工で収まる
- `.img_wrap` は連載パネル（#2271 の 200:135 固定）と We're hiring カードでも共用のため、専用クラスで分離してそれらには影響を与えない
- この部品はトップ・/articles/ のほかカテゴリ・タグ・著者ページの一覧でも共用なので、全一覧が同時に揃う

## 確認

- ビルドした一覧ページで `card-thumb` の付与と CSS の出力（`aspect-ratio: 1200 / 630` が Stylus に演算されず残ること）を確認
- サムネ無し記事のカードで空の比率枠が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
