### PR TITLE
#2302 mermaid 図のラベルが途中で切られるのを直す

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2001,6 +2001,15 @@ pre.mermaid,
   color: #424242;
 }
 
+/* ラベルは foreignObject に計測時のサイズで固定embedされるが、計測時のフォント
+   （ビルド側は Noto CJK）と読者環境のフォント（游ゴシック等）は一致させようがなく、
+   読者側が大きいと既定の overflow: hidden で文字が途中で切られる（#2302）。
+   切り捨てをやめ、はみ出しても描画する。SVG内の要素なので大文字小文字は区別される */
+.article-entry pre.mermaid foreignObject,
+.article-entry .mermaid-svg foreignObject {
+  overflow: visible;
+}
+
 /* ::: note tip 対応 */
 .tip {
   background: #8E96AA24;


### PR DESCRIPTION
Close #2302

## 調査結果（Issueの当たりとの差分）

| Issueの当たり | 実際 |
| --- | --- |
| SVG の font-family が空 | **空ではない**。全SVGとも `"trebuchet ms",verdana,arial,sans-serif` が明示されている |
| Docker イメージに CJK フォントを入れる | **既に入っている**。`yuzutech/kroki-mermaid:0.32.0` は Noto Sans CJK JP を同梱しており、計測は正しい（全角1字=1em） |
| フォント計測と描画の不一致 | **これは正しい**。ただし不一致そのものではなく、不一致時の「切り捨て」が症状の正体 |

ラベルは `foreignObject` に**計測時のサイズで固定**で埋め込まれ、foreignObject の既定は `overflow: hidden`。計測フォント（Noto CJK）より読者環境のフォント（游ゴシック・メイリオ等）が広い・縦に大きいと、はみ出した分が**切り捨てられて**「途中で途切れる」になる。クライアント描画時代も構造は同じ（mermaid.js も foreignObject を生成する）なので、#1955 以前から発生していたことと整合する。

## 修正

読者のフォントはこちらから揃えようがない（Webフォントは入れない方針、`fontFamily` を明示しても読者がそのフォントを持っていなければ同じ）ため、**切り捨てをやめて、はみ出しても描画する**:

```css
.article-entry pre.mermaid foreignObject,
.article-entry .mermaid-svg foreignObject {
  overflow: visible;
}
```

- **SVG の再生成は不要**（47枚そのまま）。CI・生成フローも無変更
- フォールバック（`pre.mermaid` でのブラウザ描画）にも同時に効く
- はみ出しが大きい場合はノードの枠から文字がわずかに溢れるが、「切れて読めない」よりは常に良い。`htmlLabels: false`（ネイティブ `<text>`）案も溢れ方は同じで、全SVG再生成が必要になるぶん不利なので採らない

## 検証（kroki-mermaid コンテナ内の Chromium でスクリーンショット比較）

1. **計測と同一フォント環境（Noto CJK）では途切れが再現しない** → 図の組版自体は正しい
2. ラベルを 17.5px に拡大して「読者フォントが計測より大きい」状況を模擬 → **Issueどおりの途切れが再現**（「バリューチェー：」「統合デー」等）
3. 同じ模擬環境に本修正を適用 → **全ラベルが完全に描画される**ことを、ビルド後の実 `site.css` で確認

再現・検証はコンテナ内 Chromium で行った（`docker run --entrypoint chromium yuzutech/kroki-mermaid:0.32.0 --headless=new --screenshot ...`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
