### PR TITLE
おかわりの件数表示を「そのクリックで追加表示される数」にする

### DIFF
--- a/scripts/popular_posts.js
+++ b/scripts/popular_posts.js
@@ -34,9 +34,13 @@ const rankingList = (posts, caps = [RANKING_DISPLAY_COUNT, RANKING_MAX_COUNT]) =
   // 2段目は「開いた人がさらに深掘りする」動線なので、1段目の details の中に入れ子にする
   const build = idx => {
     if (idx >= bounds.length || bounds[idx - 1] >= posts.length) return '';
+    // 件数は「このクリックで追加表示される数」を出す（全残数だと開いた数と合わない）。
+    // 入れ子の最終段だけ、それで打ち止めだと分かるよう「残りの」にする
+    const count = bounds[idx] - bounds[idx - 1];
+    const isNestedLast = idx > 1 && idx === bounds.length - 1;
     return `
     <details class="ranking-more">
-      <summary>残り ${posts.length - bounds[idx - 1]}本を表示</summary>
+      <summary>${isNestedLast ? '残りの' : '残り'} ${count}本を表示</summary>
       <ul class="nav featured-post-link">${items(posts.slice(bounds[idx - 1], bounds[idx]), bounds[idx - 1])}</ul>${build(idx + 1)}
     </details>`;
   };


### PR DESCRIPTION
## 概要

ランキングのおかわり件数を「そのクリックで追加表示される数」にする。

#2313 のレビューで指摘をもらい追いコミットしたが、push がマージ（14:31）より後になり本体に入らなかったため、フォローアップとして出し直す。内容は指摘どおり:

- 年間人気の1段目: 「残り 39本を表示」→「残り 15本を表示」
- 年間人気の2段目（入れ子の最終段）: 「残りの 25本を表示」（「残りの」で打ち止めが分かる表記）
- トレンド・SNS人気（1段のみ）は従来どおり「残り 15本を表示」

## 確認

ビルドしたトップページで3ランキングのラベルが上記になることを確認済み（#2313 側で検証したコミットと同一内容の cherry-pick）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
