### PR TITLE
本文の冒頭画像が別の画像を指していたのを直す

### DIFF
--- a/source/_posts/2024/20240528a_Cloudflare_D1を触ってみる.md
+++ b/source/_posts/2024/20240528a_Cloudflare_D1を触ってみる.md
@@ -13,7 +13,7 @@ author: 真野隼記
 lede: "Cloudflare D1を触ってみました。"
 ---
 
-<img src="/images/2024/20240528a/image.png" alt="" width="1200" height="404" loading="lazy">
+<img src="/images/2024/20240528a/top.png" alt="" width="1200" height="404" loading="lazy">
 
 [Cloudflare連載](/articles/20240527a/)の2日目です。
 

--- a/source/_posts/2025/20250922b_JDK24.md
+++ b/source/_posts/2025/20250922b_JDK24.md
@@ -13,7 +13,7 @@ author: 前川喜洋
 lede: "JDK 25のリリースを受けてバージョン24,25の変更点を紹介する連載企画の1本目の記事です。今回はJDK 24でのアップデート内容から以下についてピックアップしてご紹介します。"
 ---
 
-<img src="/images/2025/20250922b/thumbnail.jpg" alt="" width="600" height="395">
+<img src="/images/2025/20250922b/top.jpg" alt="" width="600" height="395">
 
 ## はじめに
 

--- a/source/_posts/2025/20250924a_Java_24_&_25_連載：_Java_24におけるパフォーマンス周りのアップデート.md
+++ b/source/_posts/2025/20250924a_Java_24_&_25_連載：_Java_24におけるパフォーマンス周りのアップデート.md
@@ -13,7 +13,7 @@ author: 武田大輝
 lede: "Java 24&25 リリース連載第 2 弾の記事です。第 1 弾の記事 に引き続き本記事では Java 24 のアップデートを取り上げます。"
 ---
 
-<img src="/images/2025/20250924a/thumbnail.jpg" alt="" width="600" height="395">
+<img src="/images/2025/20250924a/top.jpg" alt="" width="600" height="395">
 
 ## はじめに
 


### PR DESCRIPTION
#2223（参照されていない画像の削除）に着手する前に、**「`top.jpg` が使われていないのは、本文が誤って `thumbnail.jpg` を参照しているからではないか」**という指摘を受けて調べたところ、**そのとおりでした**。同じミスが**3記事**で見つかりました。

```diff
- <img src="/images/2025/20250922b/thumbnail.jpg" alt="" width="600" height="395">
+ <img src="/images/2025/20250922b/top.jpg" alt="" width="600" height="395">
```

## 判定の根拠は「宣言サイズ」

`<img>` が宣言している `width` / `height` が、**読み込んでいる画像ではなく、使われていない画像の実寸と一致**していました。差し替え漏れの動かぬ証拠です。

| 記事 | 本文が読んでいた画像 | その実寸 | 宣言サイズ | 一致する画像 |
| --- | --- | --- | --- | --- |
| `20250922b_JDK24` | `thumbnail.jpg` | 300x197 | **600x395** | `top.jpg` |
| `20250924a_Java_24_&_25_連載…` | `thumbnail.jpg` | 300x197 | **600x395** | `top.jpg` |
| `20240528a_Cloudflare_D1を触ってみる` | `image.png` | 1200x643 | **1200x404** | `top.png` |

Java の2記事は**半分のサイズの画像を2倍に引き伸ばして表示**していました。同じテンプレートからのコピペミスと見られます。

`20240528a` は、同じ `image.png` が本文中（253行目）では `1200x643` と実寸どおりに使われており、**冒頭だけ差し替えを忘れた**形です。

## 調べ方

孤立画像（どこからも参照されていない画像）**226枚**それぞれについて、「同じディレクトリの**参照されている画像**が、この孤立画像の実寸を宣言していないか」を調べました。一致すれば差し替え漏れです。

この3件は #2223 の削除候補に入っていました。**消していたら、画像がぼやけている原因ごと消えていました。** issue #2223 の「確認済みの例」として挙がっている `2025/20250924a/top.jpg` が、まさにこのケースです。

## 副産物: 縦横比が崩れている画像が52枚

同じ観点で全記事の `<img>` **3,597枚**を突き合わせたところ、**52枚で縦横比が崩れていました**。#2326 に切り出しています。

```
20230725a_フューチャーのSwagger…   top.png   宣言 409x11    実 409x118    ← 高さ11px
20210320_CKA合格記               *.jpg     宣言 929x1200  実 1200x929   ← 縦横が逆（9枚）
```

なお、宣言サイズが実寸より小さいだけのもの（`宣言 1200x675 / 実 1920x1080` など約70枚）は、大きな画像を縮小表示しているだけで**正常**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)