### PR TITLE
#2304 連載の一覧ページ /series/ を新設する

### DIFF
--- a/scripts/lib/series.js
+++ b/scripts/lib/series.js
@@ -125,6 +125,7 @@ function build(site) {
       name,
       total: posts.length,
       index: index || posts[0],
+      first: posts[0].date,
       latest: posts[posts.length - 1].date
     };
   })};

--- a/scripts/list_tags.js
+++ b/scripts/list_tags.js
@@ -60,14 +60,9 @@ function listTopPageTags(tags, options) {
       result += '</li>';
     });
 
-    if (minCount > 1) {
-        result += `<li>`
-        result += `<a href="/tags" style="color:#424242;">`;
-        result += "タグ一覧へ";
-        result += '</a>';
-        result += '</li>';
-    }
-
+    // 「タグ一覧へ」チップはここに居たが、タグに見えるうえ連載枠の
+    // 「すべての連載を見る」とテイストが揃わないため、ホーム側の
+    // 枠下リンク（すべてのタグを見る）に移した (#2304)
     result += '</ul>';
   } else {
     tags.forEach((tag, i) => {

--- a/scripts/series.js
+++ b/scripts/series.js
@@ -15,3 +15,16 @@ hexo.extend.helper.register('recent_series', function(limit = 4, minPosts = 3) {
     .filter(s => s.total >= minPosts && s.index.thumbnail)
     .slice(0, limit);
 });
+
+// /series/ 一覧ページ（#2304）。更新が新しい順の全連載
+hexo.extend.helper.register('all_series', function() {
+  return allSeries(this.site);
+});
+
+hexo.extend.generator.register('series-list', function(locals) {
+  // ページ生成に1件必要なだけのダミー。categories.js と同じ流儀
+  const pagination = require('hexo-pagination');
+  return pagination('series', locals.posts.sort('-date').slice(0, 1), {
+    layout: ['series', 'archive', 'index'],
+  });
+});

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1974,6 +1974,13 @@ input[name="tab_item"] {
   color: #5f6d7b;
 }
 
+/* トップ「連載から探す」の全件リンク（#2304）。統計ラベルと同じ 12px */
+.series-more {
+  text-align: right;
+  font-size: 12px;
+  margin-top: 8px;
+}
+
 /* カテゴリページの見出し行（#2294）。RSS購読アイコンを見出しの右端に置く */
 .list-page-header {
   display: flex;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1974,11 +1974,33 @@ input[name="tab_item"] {
   color: #5f6d7b;
 }
 
-/* トップ「連載から探す」の全件リンク（#2304）。統計ラベルと同じ 12px */
-.series-more {
+/* トップの「すべての◯◯を見る」リンク（#2304）。連載・タグの枠で共用。
+   統計ラベルと同じ 12px */
+.more-link {
   text-align: right;
   font-size: 12px;
   margin-top: 8px;
+}
+
+/* 節見出し直下の注記。row の負のマージンが食い込まないよう余白を明示する */
+.section-note {
+  margin-bottom: 16px;
+}
+
+/* /series/ の年ごとの枠。ラベルと枠線は summary-panel を継ぎ、
+   カードが収まるよう下側の padding だけ広げる */
+.series-year {
+  padding-bottom: 16px;
+  margin-bottom: 24px;
+}
+
+/* サムネの無い連載の空き枠。.panel-thumb img と同じ寸法 */
+.panel-thumb-empty {
+  display: block;
+  width: 88px;
+  height: 59px;
+  background: #eee;
+  border-radius: 4px;
 }
 
 /* カテゴリページの見出し行（#2294）。RSS購読アイコンを見出しの右端に置く */

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1993,6 +1993,11 @@ input[name="tab_item"] {
   padding-bottom: 16px;
   margin-bottom: 24px;
 }
+/* row(g-4) の負のトップマージンが年ラベルに食い込むため枠内では無効化する。
+   ラベルとカードの間隔がカード同士の間隔（24px）と同じになる */
+.series-year .series-panels {
+  margin-top: 0;
+}
 
 /* サムネの無い連載の空き枠。.panel-thumb img と同じ寸法 */
 .panel-thumb-empty {

--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -48,7 +48,7 @@
       <% }) %>
     </div>
     <%# 全連載は /series/ が持つ (#2304)。トップの枠は直近4件のまま増やさない %>
-    <p class="series-more"><a href="/series/">すべての連載を見る</a></p>
+    <p class="more-link"><a href="/series/">すべての連載を見る</a></p>
   </section>
 <% } %>
   <section class="popular-articles">
@@ -57,6 +57,10 @@
           「人気のタグ」。/tags/ の同名セクションと表記を揃える (#2052) %>
       <%- partial('section-heading', {id: 'searchbytag', text: '人気のタグから記事を探す'}) %>
       <%- partial('../_widget/tag.ejs') %>
+      <%# 連載枠の「すべての連載を見る」と同じ形の全件導線。
+          以前はタグクラウド末尾の「タグ一覧へ」チップだったが、
+          タグに見える・両枠でテイストが揃わないためこちらに寄せた (#2304) %>
+      <p class="more-link"><a href="/tags/">すべてのタグを見る</a></p>
     </div>
   </section>
 <% } %>

--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -47,6 +47,8 @@
       </div>
       <% }) %>
     </div>
+    <%# 全連載は /series/ が持つ (#2304)。トップの枠は直近4件のまま増やさない %>
+    <p class="series-more"><a href="/series/">すべての連載を見る</a></p>
   </section>
 <% } %>
   <section class="popular-articles">

--- a/themes/future/layout/_partial/head.ejs
+++ b/themes/future/layout/_partial/head.ejs
@@ -52,6 +52,9 @@
     } else if (page.path === 'tags/index.html') {
       title = 'タグ一覧';
       description = 'タグ一覧 | ' + config.description;
+    } else if (page.path === 'series/index.html') {
+      title = '連載一覧';
+      description = '連載一覧 | ' + config.description;
     } else if (page.author && path.indexOf('authors/') === 0) {
       title = page.author + 'さんのページ';
       description = page.author + ' が執筆した記事一覧 | ' + config.description

--- a/themes/future/layout/series.ejs
+++ b/themes/future/layout/series.ejs
@@ -1,0 +1,41 @@
+<div class="container">
+  <%- partial('_partial/breadcrumb', {items: [
+        {label: 'ホーム', url: '/'},
+        {label: '連載'}
+      ]}) %>
+
+  <section id="main" class="margin-top-30">
+
+    <h1 class="list-page margin-bottom-20">連載一覧</h1>
+
+    <%# 統計は h1 直下。/tags/・/categories/ と同じ流儀 (#2211) %>
+    <% const series = all_series(); %>
+    <ul class="summary">
+      <li><span class="summary-count"><%= series.length %></span><br><span class="summary-label">連載数</span></li>
+      <li><span class="summary-count"><%= series.reduce((sum, s) => sum + s.total, 0) %></span><br><span class="summary-label">投稿</span></li>
+    </ul>
+
+    <%# h1「連載一覧」と重ならない語にする（categories.ejs の流儀） %>
+    <%- partial('_partial/section-heading', {id: 'series', text: 'すべての連載'}) %>
+    ※更新が新しい順。リンク先は各連載の索引記事です
+    <%# .series-panels がパネルの横並びレイアウトを持つ（トップの「連載から探す」と同じ部品） %>
+    <div class="series-panels row g-4 footer-gap">
+      <% series.forEach(function(s){ %>
+      <div class="col-12 col-md-6 col-lg-4">
+        <div class="article-card series-panel h-100">
+          <a href="<%- url_for(s.index.path) %>" title="<%= s.name %>" class="img_wrap panel-thumb">
+            <img src="<%= s.index.thumbnail %>" alt="" width="200" height="135" loading="lazy">
+          </a>
+          <div class="panel-body">
+            <a href="<%- url_for(s.index.path) %>" class="panel-title"><%= s.name %></a>
+            <%# 期間は連載の活動期間（初回〜最新）。単月で終わった連載は1つだけ名乗る %>
+            <% const first = date(s.first, 'YYYY.MM'); const latest = date(s.latest, 'YYYY.MM'); %>
+            <div class="panel-meta">全<%= s.total %>本・<%= first === latest ? first : first + ' 〜 ' + latest %></div>
+          </div>
+        </div>
+      </div>
+      <% }) %>
+    </div>
+
+  </section>
+</div>

--- a/themes/future/layout/series.ejs
+++ b/themes/future/layout/series.ejs
@@ -17,25 +17,44 @@
 
     <%# h1「連載一覧」と重ならない語にする（categories.ejs の流儀） %>
     <%- partial('_partial/section-heading', {id: 'series', text: 'すべての連載'}) %>
-    ※更新が新しい順。リンク先は各連載の索引記事です
-    <%# .series-panels がパネルの横並びレイアウトを持つ（トップの「連載から探す」と同じ部品） %>
-    <div class="series-panels row g-4 footer-gap">
-      <% series.forEach(function(s){ %>
-      <div class="col-12 col-md-6 col-lg-4">
-        <div class="article-card series-panel h-100">
-          <a href="<%- url_for(s.index.path) %>" title="<%= s.name %>" class="img_wrap panel-thumb">
-            <img src="<%= s.index.thumbnail %>" alt="" width="200" height="135" loading="lazy">
-          </a>
-          <div class="panel-body">
-            <a href="<%- url_for(s.index.path) %>" class="panel-title"><%= s.name %></a>
-            <%# 期間は連載の活動期間（初回〜最新）。単月で終わった連載は1つだけ名乗る %>
-            <% const first = date(s.first, 'YYYY.MM'); const latest = date(s.latest, 'YYYY.MM'); %>
-            <div class="panel-meta">全<%= s.total %>本・<%= first === latest ? first : first + ' 〜 ' + latest %></div>
+    <p class="section-note">※最終更新の年ごとに、更新が新しい順。リンク先は各連載の索引記事です</p>
+    <%# 最終更新の年ごとに枠で束ねる。枠と小ラベルは詳細ページの
+        「累計/直近1年」パネル（summary-panel）と同じ見た目に揃える %>
+    <% const byYear = new Map(); %>
+    <% series.forEach(function(s){
+         const y = date(s.latest, 'YYYY');
+         if (!byYear.has(y)) byYear.set(y, []);
+         byYear.get(y).push(s);
+       }); %>
+    <% const years = [...byYear.keys()]; %>
+    <% years.forEach(function(year, yi){ %>
+    <section class="summary-panel series-year <%= yi === years.length - 1 ? 'footer-gap' : '' %>">
+      <span class="summary-panel-label"><%= year %>年</span>
+      <%# .series-panels がパネルの横並びレイアウトを持つ（トップの「連載から探す」と同じ部品） %>
+      <div class="series-panels row g-4">
+        <% byYear.get(year).forEach(function(s){ %>
+        <div class="col-12 col-md-6 col-lg-4">
+          <div class="article-card series-panel h-100">
+            <% if (s.index.thumbnail) { %>
+            <a href="<%- url_for(s.index.path) %>" title="<%= s.name %>" class="img_wrap panel-thumb">
+              <img src="<%= s.index.thumbnail %>" alt="" width="200" height="135" loading="lazy">
+            </a>
+            <% } else { %>
+            <%# サムネの無い連載は同じ大きさの空き枠で行頭を揃える（post_list.js と同じ流儀） %>
+            <span class="panel-thumb panel-thumb-empty"></span>
+            <% } %>
+            <div class="panel-body">
+              <a href="<%- url_for(s.index.path) %>" class="panel-title"><%= s.name %></a>
+              <%# 期間は連載の活動期間（初回〜最新）。単月で終わった連載は1つだけ名乗る %>
+              <% const first = date(s.first, 'YYYY.MM'); const latest = date(s.latest, 'YYYY.MM'); %>
+              <div class="panel-meta">全<%= s.total %>本・<%= first === latest ? first : first + ' 〜 ' + latest %></div>
+            </div>
           </div>
         </div>
+        <% }) %>
       </div>
-      <% }) %>
-    </div>
+    </section>
+    <% }) %>
 
   </section>
 </div>


### PR DESCRIPTION
Close #2304

## 概要

連載の一覧ページ `/series/` を新設します。全73連載（投稿630本）を見渡す場所がサイトに無く（トップの「連載から探す」は直近更新4件のみ）、タグ・カテゴリ・著者には一覧ページがあるのに連載だけが欠けていました。

## ページ構成（確定構成に準拠）

- h1「連載一覧」→ 統計タイル（連載数 73・投稿 630）→ 節見出し「すべての連載」→ パネル一覧
- 並びは**更新が新しい順**（`allSeries()` の既存仕様のまま）
- パネルはトップの「連載から探す」と同じ部品（`.series-panels` の横並びカード）を再利用。連載名・**全N本・期間（初回〜最新の年月、単月連載は1つだけ表示）**を名乗り、索引記事へリンクする
- 索引記事が無い2連載は第1回記事へのフォールバック（`lib/series.js` の既存実装）
- タブ表示（title要素）は h1 と同じ「連載一覧」（#2218 の流儀）

## トップページ

「連載から探す」の枠の下に「**すべての連載を見る**」リンク（右寄せ12px）を追加。

## 「人気のシリーズ」枠は追加しない（Issue の議論結果）

- トップには既に #2039 の「連載から探す」枠（直近更新4件）があり、役割が重複する。同種の枠を2つ置くと確定構成の探索ゾーンが肥大化する
- 「人気」を PV 合計で定義すると古い大型連載（春の入門祭り2020 等）が上位に固定され、鮮度が死ぬ。技術ブログでは既存の「直近更新順」が合理的
- 「人気を見たい」需要は今後 `/series/` ページ側のソート追加で吸収できる

## 検証

- ローカルサーバで 73 パネル・統計・リンク先・単月/複数月の期間表示（例: CI/CD は7本すべて2025年6月＝単月表示が正しいことを実データで確認）をスクリーンショット確認
- `hexo generate` エラーなし、`public/series/index.html` 生成を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

