### PR TITLE
#2292 タグオントロジーの親子構造を /doctor/ にツリー表示する

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -216,3 +216,66 @@ hexo.extend.helper.register('doctor_checks', function() {
 
   return {suggestions, untagged, overTagged, missing, missingTotal, nearDuplicates, categoryDupTags, singleUse};
 });
+
+/**
+ * タグオントロジー（source/_data/tag_ontology.yml）の親子構造を /doctor/ で
+ * 見るためのツリー。複数親のノードはそれぞれの親の下に重複して出す
+ * （DAG を1本の木に潰すと片方の系統から見えなくなる）。
+ */
+hexo.extend.helper.register('doctor_ontology', function() {
+  const ontology = (this.site.data && this.site.data.tag_ontology) || {};
+
+  const tagInfo = new Map(); // タグ名 -> {path, ids}
+  this.site.tags.forEach(tag => {
+    tagInfo.set(tag.name, {path: tag.path, ids: new Set(tag.posts.map(p => p._id))});
+  });
+
+  const children = new Map();
+  const hasParent = new Set();
+  for (const [name, node] of Object.entries(ontology)) {
+    for (const p of (node && node.broader) || []) {
+      if (!children.has(p)) children.set(p, []);
+      children.get(p).push(name);
+      hasParent.add(name);
+    }
+  }
+
+  // 系統（自分＋子孫）のユニーク記事数。複数親経由で同じ記事を
+  // 二重に数えないよう、本数ではなく記事IDの集合で持つ
+  const familyMemo = new Map();
+  const familyIds = (name, trail) => {
+    if (familyMemo.has(name)) return familyMemo.get(name);
+    const acc = new Set(tagInfo.has(name) ? tagInfo.get(name).ids : []);
+    for (const c of children.get(name) || []) {
+      if (trail.has(c)) continue; // 循環は整合性チェック側の担当。ここでは辿らないだけ
+      trail.add(c);
+      for (const id of familyIds(c, trail)) acc.add(id);
+    }
+    familyMemo.set(name, acc);
+    return acc;
+  };
+
+  const build = (name, parentName) => {
+    const info = tagInfo.get(name);
+    return {
+      name,
+      path: info ? info.path : null, // タグとして実在しない概念ノードはリンク先が無い
+      posts: info ? info.ids.size : 0,
+      family: familyIds(name, new Set([name])).size,
+      otherParents: ((ontology[name] || {}).broader || []).filter(p => p !== parentName),
+      children: (children.get(name) || [])
+        .map(c => build(c, name))
+        .sort((a, b) => b.family - a.family || (a.name < b.name ? -1 : 1)),
+    };
+  };
+
+  const roots = Object.keys(ontology).filter(n => !hasParent.has(n));
+  const trees = roots.filter(n => children.has(n))
+    .map(n => build(n, null))
+    .sort((a, b) => b.family - a.family || (a.name < b.name ? -1 : 1));
+  const standalone = roots.filter(n => !children.has(n))
+    .map(n => build(n, null))
+    .sort((a, b) => b.posts - a.posts || (a.name < b.name ? -1 : 1));
+
+  return {trees, standalone, nodeCount: Object.keys(ontology).length};
+});

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1327,6 +1327,35 @@ code {
   color: #6e6e6e;
   font-size: 0.9em;
 }
+/* /doctor/ のオントロジーツリー。系統ごとの小さな木を多段組で敷き詰める */
+.ontology-forest {
+  column-width: 300px;
+  column-gap: 32px;
+  margin: 14px 0;
+}
+.ontology-tree {
+  break-inside: avoid; /* 木の途中で段が割れると親子が追えない */
+  list-style: none;
+  padding-left: 0;
+  margin: 0 0 14px;
+}
+.ontology-tree ul {
+  list-style: none;
+  padding-left: 14px;
+  margin-left: 6px;
+  border-left: 1px solid #d9d9d9; /* 縦罫で階層を示す */
+}
+.ontology-tree li {
+  padding: 2px 0;
+}
+.ontology-concept {
+  color: #6e6e6e;
+}
+.ontology-count {
+  color: #6e6e6e;
+  font-size: 0.85em;
+  margin-left: 5px;
+}
 .author-list {
   padding-inline-start: 0px;
   display: flex;

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -133,6 +133,35 @@
         <% }) %>
       </ul>
 
+      <h2 class="bottom-content-header">タグの親子関係（オントロジー）</h2>
+      ※<code>source/_data/tag_ontology.yml</code> の broader の可視化。関連記事の計算が辿る辺で、「子タグの記事に親タグを打つのは冗長」という自明な包含だけを登録しています（#2292）。灰色はタグとして実在しない概念ノード。「系統」は自分＋子孫のユニーク記事数
+      <% const onto = doctor_ontology(); %>
+      <%
+        function renderNode(n) { %>
+        <li>
+          <% if (n.path) { %><a href="<%- url_for(n.path) %>"><%= n.name %></a><% } else { %><span class="ontology-concept"><%= n.name %></span><% } %>
+          <span class="ontology-count"><%= n.posts %>本<% if (n.family > n.posts) { %>・系統<%= n.family %>本<% } %><% if (n.otherParents.length) { %>・他の親: <%= n.otherParents.join('、') %><% } %></span>
+          <% if (n.children.length) { %>
+          <ul>
+            <% n.children.forEach(renderNode) %>
+          </ul>
+          <% } %>
+        </li>
+      <% } %>
+      <div class="ontology-forest">
+        <% onto.trees.forEach(function(t){ %>
+        <ul class="ontology-tree">
+          <% renderNode(t) %>
+        </ul>
+        <% }) %>
+      </div>
+      <ul class="doctor-list">
+        <li>
+          <span class="doctor-note">親も子も無い根タグ（<%= onto.standalone.length %>件）</span>
+          <% onto.standalone.forEach(function(n, i){ %><a href="<%- url_for(n.path) %>"><%= n.name %></a><span class="ontology-count"><%= n.posts %>本</span><%= i < onto.standalone.length - 1 ? '、' : '' %><% }) %>
+        </li>
+      </ul>
+
       <h2 class="bottom-content-header">タイトルにタグ名を含むのに、そのタグが付いていない記事</h2>
       ※英数3文字・和文4文字未満のタグ名は一般語に当たりやすいので照合していません
       <ul class="doctor-list">


### PR DESCRIPTION
タグオントロジー（#2317 でマージ済みの `source/_data/tag_ontology.yml`）の構造を、運営向けの /doctor/ ページで確認できるようにする。

## 表示内容

「1記事にしか使われていないタグ」の後、「タイトルにタグ名を含むのに〜」の前にセクションを追加。

- **親子を持つ25系統をツリーで表示**（`column-width` の多段組で敷き詰め、木の途中で段が割れないよう `break-inside: avoid`）
- 各ノードに **タグ単体の記事数** と **系統**（自分＋子孫のユニーク記事数。複数親経由の重複は記事ID集合で排除）を併記
  - 例: `AI 23本・系統130本 → 生成AI 24本・系統67本 → LLM 23本・系統48本 → Claude 15本`
- **複数親のノード**（DynamoDB → AWS / NoSQL 等）は各親の下に重複して出し「他の親: 〜」で相互参照。DAG を1本の木に潰すと片方の系統から見えなくなるため
- **概念ノード**（イベント / OS 等、タグとして実在しない9件）は灰色・リンク無し
- **親も子も無い根タグ43件**は木にせず、既存の1記事タグ一覧と同じインライン形式で1行にまとめる

## 実装

- `scripts/doctor.js` に `doctor_ontology` ヘルパーを追加（site.data.tag_ontology から children マップと系統集計を構築。循環は整合性チェック側の担当なので、ここでは辿らないだけの防御に留める）
- `themes/future/layout/doctor.ejs` に再帰レンダラとセクションを追加
- `theme-styles.styl` に既存の doctor スタイル群の隣へツリー用スタイルを追加（フォントサイズは相対値1箇所のみ）

## 確認

フルビルドで /doctor/ の生成HTMLを確認。25系統・概念ノード9件・独立タグ43件が期待どおり出力され、DynamoDB / Lambda の複数親相互参照も両方の木に出ている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)