### PR TITLE
モバイルで /categories/ の統計テキストが見切れるのを直す

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1378,10 +1378,13 @@ code {
 .category-index-head {
   display: flex;
   align-items: baseline;
+  /* メタは nowrap（語の途中で割らない）なので、狭い幅では行ごと折り返して
+     見切れを防ぐ (#2342)。行間は gap の1値目で詰める */
+  flex-wrap: wrap;
   /* 右端寄せ（space-between）にしないのは、枠の無い全幅の行では
      右端が名前から孤立して見えるため。記事メタデータ行（.blog-info）と
      同じ左寄せ + 28px の間隔で「名前の横のメタ情報」として並べる */
-  gap: 28px;
+  gap: 4px 28px;
   /* カテゴリ名の行とタグの行が貼り付かないよう間を空ける */
   margin-bottom: 8px;
 }


### PR DESCRIPTION
## 概要

モバイル幅で /categories/ の各カテゴリ統計（累計・直近1年）が見切れるのを直す。

close #2342

## 原因

`.category-index-head` が `display: flex` + `gap: 28px` で、統計テキスト（`.category-index-meta`）は `flex: none` + `white-space: nowrap`。折り返し（`flex-wrap`）が未指定のため、狭い画面幅では行に収まらずはみ出していた。

## 修正

- `.category-index-head` に `flex-wrap: wrap` を追加。「累計 ◯本・著者◯名」が語の途中で割れない設計意図（nowrap）は保ったまま、狭い幅ではメタが**丸ごと次の行へ折り返す**
- 折り返し時の行間が広がりすぎないよう `gap: 4px 28px`（行 4px / 列 28px）に変更。メディアクエリ無しの1箇所指定で、広い画面の見た目は従来どおり

## 確認

- ビルド後の site.css で `flex-wrap: wrap` と `gap: 4px 28px`（Stylus に潰されていないこと）を確認
- http://localhost:4001/categories/ をモバイル幅で目視確認可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)
