### PR TITLE
ホームの「ガイドラインから学ぶ」をパネル化し、人気のタグより前に置く

### DIFF
--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -51,6 +51,36 @@
     <p class="more-link"><a href="/series/">すべての連載を見る</a></p>
   </section>
 <% } %>
+  <%# 設計ガイドライン等の外部資産への統一入口 (#2295)。実体は複数サイトに
+      分散しているため、全体一覧は /guidelines/ のポータルが担う。
+      テキスト1行では視線が滑って気づかれないため、連載枠と同じパネルで
+      代表3コンテンツを出し、人気のタグより前に置く (#2343) %>
+  <section class="series-panels">
+    <%- partial('section-heading', {id: 'guidelines', text: 'ガイドラインから学ぶ'}) %>
+    <%
+      const guidelinePanels = [
+        {url: 'https://future-architect.github.io/arch-guidelines/', title: 'Future Architecture Guidelines', image: '/archtecture_guidelines.png', meta: '設計ガイドライン集'},
+        {url: 'https://future-architect.github.io/coding-standards/', title: 'Future Enterprise Coding Standards', image: '/coding_standards.png', meta: 'コーディング規約'},
+        {url: 'https://future-architect.github.io/typescript-guide/', title: '仕事ですぐに使えるTypeScript', image: '/typescript_guidelines.png', meta: '教育コンテンツ'},
+      ];
+    %>
+    <div class="row g-4">
+      <% guidelinePanels.forEach(function(g){ %>
+      <div class="col-12 col-md-4">
+        <div class="article-card series-panel h-100">
+          <a href="<%= g.url %>" title="<%= g.title %>" class="img_wrap panel-thumb" target="_blank" rel="noopener">
+            <img src="<%= g.image %>" alt="" width="200" height="135" loading="lazy">
+          </a>
+          <div class="panel-body">
+            <a href="<%= g.url %>" class="panel-title" target="_blank" rel="noopener"><%= g.title %></a>
+            <div class="panel-meta"><%= g.meta %>（外部サイト）</div>
+          </div>
+        </div>
+      </div>
+      <% }) %>
+    </div>
+    <p class="more-link"><a href="/guidelines/">ガイドライン一覧を見る</a></p>
+  </section>
   <section class="popular-articles">
     <div class="blog-tags margin-bottom-20">
       <%# 実体は list_toppagetags のシェア数順・件数上限ありのリストなので
@@ -62,13 +92,6 @@
           タグに見える・両枠でテイストが揃わないためこちらに寄せた (#2304) %>
       <p class="more-link"><a href="/tags/">すべてのタグを見る</a></p>
     </div>
-  </section>
-  <%# 設計ガイドライン等の外部資産への統一入口 (#2295)。実体は複数サイトに
-      分散しているため、一覧は /guidelines/ のポータルが担い、ここは導線だけ %>
-  <section class="popular-articles">
-    <%- partial('section-heading', {id: 'guidelines', text: 'ガイドラインから学ぶ'}) %>
-    設計ガイドライン・コーディング規約・TypeScript 教材など、フューチャーが無償公開している学習コンテンツの入口です
-    <p class="more-link"><a href="/guidelines/">ガイドライン一覧を見る</a></p>
   </section>
 <% } %>
 <%# 関連タグは1ページ目だけ一覧の前に出す。カテゴリページの


### PR DESCRIPTION
## 概要

ホームの「ガイドラインから学ぶ」枠をパネル化し、「人気のタグから記事を探す」より前に移動する。

close #2343

## 変更内容

- テキスト1行＋リンクだけだった枠を、連載枠と同じ `.series-panels` パネル3枚（設計ガイドライン / コーディング規約 / TypeScript 教材）に変更。画像は旧 We're hiring パネルで使っていた既存の3枚を流用
- 各パネルは外部サイトへ直接リンク（`target="_blank"`、meta 行に「（外部サイト）」明記）。全体一覧への導線「ガイドライン一覧を見る」（/guidelines/）は維持
- セクション順を 連載 → **ガイドライン** → 人気のタグ → 新着 に変更

## 確認

- ビルドしたトップページでセクションの並び順とパネル3枚の出力を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
