### PR TITLE
ホームのガイドライン枠を /guidelines/ を紹介する1枚パネルにする

### DIFF
--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -65,7 +65,7 @@
           </a>
           <div class="panel-body">
             <a href="/guidelines/" class="panel-title">フューチャーのガイドライン</a>
-            <div class="panel-meta">設計ガイドライン・コーディング規約・TypeScript 教材の入口</div>
+            <div class="panel-meta">設計ガイドライン・コーディング規約・TypeScript 教材の入口です。</div>
           </div>
         </div>
       </div>

--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -51,35 +51,25 @@
     <p class="more-link"><a href="/series/">すべての連載を見る</a></p>
   </section>
 <% } %>
-  <%# 設計ガイドライン等の外部資産への統一入口 (#2295)。実体は複数サイトに
-      分散しているため、全体一覧は /guidelines/ のポータルが担う。
-      テキスト1行では視線が滑って気づかれないため、連載枠と同じパネルで
-      代表3コンテンツを出し、人気のタグより前に置く (#2343) %>
+  <%# 設計ガイドライン等の外部資産への統一入口 (#2295)。テキスト1行では視線が
+      滑るためパネルにする (#2343)。外部サイトへ直接飛ばす3枚構成はやめ、
+      サイト内の /guidelines/ ポータルを紹介する1枚に絞る。一覧の説明と
+      外部サイトへの分岐はポータル側が担う %>
   <section class="series-panels">
     <%- partial('section-heading', {id: 'guidelines', text: 'ガイドラインから学ぶ'}) %>
-    <%
-      const guidelinePanels = [
-        {url: 'https://future-architect.github.io/arch-guidelines/', title: 'Future Architecture Guidelines', image: '/archtecture_guidelines.png', meta: '設計ガイドライン集'},
-        {url: 'https://future-architect.github.io/coding-standards/', title: 'Future Enterprise Coding Standards', image: '/coding_standards.png', meta: 'コーディング規約'},
-        {url: 'https://future-architect.github.io/typescript-guide/', title: '仕事ですぐに使えるTypeScript', image: '/typescript_guidelines.png', meta: '教育コンテンツ'},
-      ];
-    %>
     <div class="row g-4">
-      <% guidelinePanels.forEach(function(g){ %>
-      <div class="col-12 col-md-4">
+      <div class="col-12 col-md-6">
         <div class="article-card series-panel h-100">
-          <a href="<%= g.url %>" title="<%= g.title %>" class="img_wrap panel-thumb" target="_blank" rel="noopener">
-            <img src="<%= g.image %>" alt="" width="200" height="135" loading="lazy">
+          <a href="/guidelines/" title="フューチャーのガイドライン" class="img_wrap panel-thumb">
+            <img src="/archtecture_guidelines.png" alt="" width="200" height="135" loading="lazy">
           </a>
           <div class="panel-body">
-            <a href="<%= g.url %>" class="panel-title" target="_blank" rel="noopener"><%= g.title %></a>
-            <div class="panel-meta"><%= g.meta %>（外部サイト）</div>
+            <a href="/guidelines/" class="panel-title">フューチャーのガイドライン</a>
+            <div class="panel-meta">設計ガイドライン・コーディング規約・TypeScript 教材の入口</div>
           </div>
         </div>
       </div>
-      <% }) %>
     </div>
-    <p class="more-link"><a href="/guidelines/">ガイドライン一覧を見る</a></p>
   </section>
   <section class="popular-articles">
     <div class="blog-tags margin-bottom-20">


### PR DESCRIPTION
## 概要

ホームの「ガイドラインから学ぶ」パネル（#2343 / #2352）が3枚とも外部サイトへの直リンクだったのを、サイト内の /guidelines/ ポータルを紹介する1枚パネルに変更する。外部サイトへの分岐と説明はポータル側が担う。

## 変更内容

- パネルを1枚（タイトル: フューチャーのガイドライン、リンク先: /guidelines/）に変更
- パネル自体が一覧への導線になったため、重複する「ガイドライン一覧を見る」の more-link を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)