### PR TITLE
#2359 検索を汚す定型文と index 漏れの期間ページを整理する

### DIFF
--- a/themes/future/layout/_partial/breadcrumb.ejs
+++ b/themes/future/layout/_partial/breadcrumb.ejs
@@ -17,7 +17,8 @@
  * 置かれていても独立した item として読まれる。
  */
 %>
-<ul class="breadcrumb" itemscope itemtype="https://schema.org/BreadcrumbList">
+<%# data-nosnippet: パンくずの定型文をスニペットに出さない (#2359) %>
+<ul class="breadcrumb" data-nosnippet itemscope itemtype="https://schema.org/BreadcrumbList">
   <% items.forEach(function(item, i){ %>
   <li<%- item.url ? '' : ' class="active"' %> itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
     <% if (item.url) { %><a itemprop="item" href="<%- url_for(item.url) %>"><span itemprop="name"><%= item.label %></span></a><% } else { %><span itemprop="name"><%= item.label %></span><% } %>

--- a/themes/future/layout/_partial/footer.ejs
+++ b/themes/future/layout/_partial/footer.ejs
@@ -1,5 +1,7 @@
 <!-- BEGIN PRE-FOOTER -->
-<footer>
+<%# data-nosnippet: 全ページ共通の定型文が検索結果のスニペットに出ないようにする (#2359)。
+    Google の検索一致そのものは防げない点に注意（要素単位の除外手段が無い） %>
+<footer data-nosnippet>
   <div class="pre-footer">
     <div class="container">
       <div class="row">
@@ -63,9 +65,11 @@
         <div class="col-lg-4 col-md-4 col-sm-4 col-4 pre-footer-col footer-links">
           <h2>Links
           </h2>
+          <%# title に宣伝文を書かない。全ページ共通の文言はサイト内検索の
+              一致を汚す（「Software Design」で「デザイン」が当たる #2359） %>
           <a
             href="https://future.connpass.com/"
-            title="経営とITをデザインするフューチャーの勉強会です"
+            title="フューチャーの勉強会（connpass）"
             target="_blank"
             rel="noopener"
             >connpass</a

--- a/themes/future/layout/_partial/head.ejs
+++ b/themes/future/layout/_partial/head.ejs
@@ -132,8 +132,9 @@
       'doctor/index.html'
     ];
 
-    // 年月日のアーカイブパスを動的に追加
-    for (let year = 2020; year <= new Date().getFullYear(); year++) {
+    // 年月日のアーカイブパスを動的に追加。ブログ開設の2016年から
+    // （以前は2020開始で、2016〜2019年の期間ページだけ index されていた #2359）
+    for (let year = 2016; year <= new Date().getFullYear(); year++) {
       noindexPaths.push(`articles/${year}/index.html`);
       for (let month = 1; month <= 12; month++) {
         const monthStr = month.toString().padStart(2, '0');

--- a/themes/future/layout/_partial/header.ejs
+++ b/themes/future/layout/_partial/header.ejs
@@ -1,5 +1,6 @@
 <!-- BEGIN HEADER -->
-<header class="header">
+<%# data-nosnippet: サイト名の定型文をスニペットに出さない (#2359) %>
+<header class="header" data-nosnippet>
 	<div class="header-overlay">
 		<div class="header-menu"></div>
 		<%# ホームではここがページの見出しそのものなので h1 にする。記事ページは

--- a/themes/future/layout/_partial/related-categories.ejs
+++ b/themes/future/layout/_partial/related-categories.ejs
@@ -6,7 +6,7 @@
 <% const rc = related_categories(page.category); %>
 <% const without = category_without_tag(page.category); %>
 <% if (rc.length || without) { %>
-<aside>
+<aside data-nosnippet>
   <section class="popular-articles margin-bottom-20">
     <% if (rc.length) { %>
     <%- partial('section-heading', {id: 'relatedcategories', text: '関連カテゴリ'}) %>

--- a/themes/future/layout/_partial/related-tags.ejs
+++ b/themes/future/layout/_partial/related-tags.ejs
@@ -3,7 +3,7 @@
     最終ページ = ページャーの下（読み尽くした読者への次の導線）(#2088 / #2213) %>
 <% const related = related_tags(page.tag); %>
 <% if (related.length) { %>
-<aside>
+<aside data-nosnippet>
   <section class="popular-articles margin-bottom-20">
     <%# 見出しは記事ページの「関連記事」に合わせる。あちらも内部ではスコアで
         並べているが強度は名乗っていない。「関連が強いタグ」とすると根拠を

--- a/themes/future/layout/_partial/sidebar.ejs
+++ b/themes/future/layout/_partial/sidebar.ejs
@@ -1,4 +1,7 @@
 <!-- START SIDEBAR  -->
+<%# data-nosnippet: サイドバー（検索窓・目次・カテゴリ・Tech Cast・アドベント
+    カレンダー）は全ページ共通または本文の再掲で、スニペットに出す価値が無い (#2359) %>
+<div data-nosnippet>
 <% if (!is_post()) { %>
 <form id="cse-search-box" action="https://google.com/cse" class="search-wrapper">
   <input type="text" name="q" placeholder="検索" />
@@ -53,4 +56,5 @@
 </section>
 <% } %>
 <% } %>
+</div>
 <!-- END SIDEBAR -->


### PR DESCRIPTION
Close #2359

## 前提（重要）

検索窓は Google CSE で、**Google には「ページ内のこの要素だけ index しない」という手段が無い**。打てる手は3種類に限られる：

1. **文言を変える**（一致そのものを消す）
2. **`data-nosnippet`**（一致は残るが、検索結果のスニペットに定型文が出るのを防ぐ）
3. **ページ単位の noindex**（そのページ自体を検索から外す）

## やったこと

**1. 文言修正**：connpass リンクの `title="経営とITをデザインするフューチャーの勉強会です"` → `"フューチャーの勉強会（connpass）"`。全ページ共通の宣伝文が「Software Design」→「デザイン」の一致源になっていた。

**2. `data-nosnippet` 付与**：ヘッダー・フッター・サイドバー（検索窓・目次・カテゴリ・Tech Cast・アドベントカレンダー）・パンくず・関連タグ・関連カテゴリ。記事末のブロック（連載ナビ・関連記事・被参照記事・We're hiring・シェアボタン）は**既に付与済みだった**。

**3. noindex の漏れ修正**：期間ページの noindex ループが 2020 年開始で、**/articles/2016/〜2019/ とその月ページだけ index されていた**。ブログ開設の 2016 年からに修正（ローカルで 2016 年ページに robots meta が付くことを確認済み）。

## 残る課題（このPRでは対応しない）

- **フッター About の「経営とITをデザインする、フューチャーの技術ブログです。」**（`theme.about`）は全ページの可視テキストで、これも「デザイン」の一致源。ただし企業スローガンなので文言変更は編集判断。変えない限りこの一致は残る
- **ページング（2ページ目以降）は index されている**：ホーム /page/N、タグ・カテゴリ・著者の /page/N。薄い重複ページとして noindex にする価値があるが、影響範囲が広いので別Issueで判断したい
- サイドバーの Tech Cast はエピソード題名（外部コンテンツ）がホーム1ページ目に載るが、既にホーム限定に絞られており実害は小さい

## 検証

- /articles/2016/ に `noindex, follow` が付与されること（2021年と同様）
- connpass title の変更、各ブロックの data-nosnippet 出力をローカルサーバで確認
- サイドバーをラッパー div で包んだことによるレイアウト崩れが無いことをスクリーンショットで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
