### PR TITLE
MD001 の唯一の残りをインラインコメントで抑止する

### DIFF
--- a/source/_posts/2022/20220615a_Go_で_map_型の_YAML_出力を指定の順序へ変更したい.md
+++ b/source/_posts/2022/20220615a_Go_で_map_型の_YAML_出力を指定の順序へ変更したい.md
@@ -31,6 +31,7 @@ TIG 所属の多賀です。
 Go の map のソート順は不定であることは、よく言われることかなと思います。
 (言語仕様にも明記されています。)
 
+<!-- markdownlint-disable-next-line MD001 -- 引用元（Go 言語仕様書）の見出しレベルをそのまま写している -->
 > #### Map types
 >
 > A map is **an unordered group** of elements of one type, called the element type, indexed by a set of unique keys of another type, called the key type. The value of an uninitialized map is nil.


### PR DESCRIPTION
`source/_posts` の markdownlint 指摘は1件だけ残っていました。**ルールを無効化せず、その場所だけ抑止**します。これで **0件**になります。

```diff
+ <!-- markdownlint-disable-next-line MD001 -- 引用元（Go 言語仕様書）の見出しレベルをそのまま写している -->
  > #### Map types
  >
  > A map is **an unordered group** of elements of one type, called the element type, indexed by a set of unique keys...
  >
  > [The Go Programming Language Specification - Map types](https://go.dev/ref/spec#Map_types)
```

## なぜ直さずに抑止するのか

直前が `## 背景` なので `MD001/heading-increment` は `h3` を期待しますが、この `#### Map types` は **Go 言語仕様書の見出しをそのまま写したもの**です。レベルを変えると引用の改変になります。

`.markdownlint-cli2.jsonc` で `MD001` 自体を切ると、**今後の記事で本当の見出しレベル飛びを検出できなくなります**（#2263 で112記事165箇所を直したばかりのルールです）。1箇所だけ抑止するのが筋です。

理由をコメントに書いているので、次に見た人が「なぜ黙らせているか」を追えます。

## レンダリングへの影響なし

`<!-- -->` はHTMLコメントとして出力され、画面には表示されません。引用の `<h4>` もそのままです。

```html
<p>Go の map のソート順は不定であることは、…</p>
<!-- markdownlint-disable-next-line MD001 -- 引用元（Go 言語仕様書）の見出しレベルをそのまま写している -->
<blockquote> <h4 id="Map-types">…
```

## 検証

| 項目 | 結果 |
| --- | --- |
| `source/_posts` の markdownlint | 1件 → **0件** |
| 生成HTML | 引用ブロックと `<h4>` は変化なし |
| 変更行に載る textlint の指摘 | 0件 |

これで #2245（当初9,939件）が完全に片付きます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
