### PR TITLE
#2364 ページング（2ページ目以降）を noindex にする

### DIFF
--- a/themes/future/layout/_partial/head.ejs
+++ b/themes/future/layout/_partial/head.ejs
@@ -142,8 +142,11 @@
       }
     }
 
-    // 現在のページパスがリストに含まれているか判定
-    const isNoindexPage = noindexPaths.includes(page.path);
+    // 現在のページパスがリストに含まれているか判定。
+    // ページング（2ページ目以降）は一覧の続きで内容が薄く、検索の着地先は
+    // 記事本体と各一覧の1ページ目が担うため、種類を問わず noindex にする (#2364)。
+    // follow は維持するのでクロールの回遊経路としては残る
+    const isNoindexPage = noindexPaths.includes(page.path) || (page.current && page.current > 1);
 
     if (isNoindexPage) {
   %>


### PR DESCRIPTION
Close #2364

## 概要

ホーム・タグ・カテゴリ・著者・期間を問わず、ページング（`page/N`、N≥2）に `noindex, follow` を付けます。判定は hexo の `page.current > 1` の1条件で、head.ejs の1行変更です。

- 一覧の続きは内容が薄く記事本体と重複するため、検索の着地先としての価値が低い（記事本体と各一覧の1ページ目が担う）
- `follow` は維持するので、クローラの回遊経路（古い記事への到達）はこれまでどおり
- 各一覧の1ページ目（タグ・カテゴリ個別、/series/ 等）と記事本体は引き続き index される

## 検証（ローカル）

- `/page/2/`・`/categories/Programming/page/2/`・`/tags/Go/page/2/`・`/authors/<著者>/page/2/` すべてに `noindex, follow` が付くこと
- ホーム1ページ目・カテゴリ1ページ目・記事本体には付かないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)