### PR TITLE
#2292 バージョン同義を /doctor/ のオントロジーツリーに表示する

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -268,6 +268,24 @@ hexo.extend.helper.register('doctor_ontology', function() {
     }
   }
 
+  // バージョン同義（scripts/version_tags.js と同じ規則）。語幹ノードに「版」として出す
+  const VERSIONED = /^(.+?)(\d+(?:\.\d+)+|\d{2,})$/;
+  const stemOf = name => {
+    const node = ontology[name];
+    if (node && node.notVersion) return null;
+    if (node && node.versionOf) return node.versionOf;
+    const m = VERSIONED.exec(name);
+    if (!m) return null;
+    return tagInfo.has(m[1]) ? m[1] : null;
+  };
+  const versionsByStem = new Map();
+  for (const name of tagInfo.keys()) {
+    const stem = stemOf(name);
+    if (!stem || stem === name) continue;
+    if (!versionsByStem.has(stem)) versionsByStem.set(stem, []);
+    versionsByStem.get(stem).push(name);
+  }
+
   // 系統（自分＋子孫）のユニーク記事数。複数親経由で同じ記事を
   // 二重に数えないよう、本数ではなく記事IDの集合で持つ
   const familyMemo = new Map();
@@ -291,13 +309,18 @@ hexo.extend.helper.register('doctor_ontology', function() {
       posts: info ? info.ids.size : 0,
       family: familyIds(name, new Set([name])).size,
       otherParents: ((ontology[name] || {}).broader || []).filter(p => p !== parentName),
+      versions: (versionsByStem.get(name) || [])
+        .sort((a, b) => (a < b ? 1 : -1)) // 新しい版を先に（名前の降順で近似）
+        .map(v => ({name: v, path: tagInfo.get(v).path, posts: tagInfo.get(v).ids.size})),
       children: (children.get(name) || [])
         .map(c => build(c, name))
         .sort((a, b) => b.family - a.family || (a.name < b.name ? -1 : 1)),
     };
   };
 
-  const roots = Object.keys(ontology).filter(n => !hasParent.has(n));
+  // versionOf ノード（Vue3 等）は語幹の「版」として出すので、木や独立タグには数えない
+  const roots = Object.keys(ontology)
+    .filter(n => !hasParent.has(n) && !(ontology[n] && ontology[n].versionOf));
   const trees = roots.filter(n => children.has(n))
     .map(n => build(n, null))
     .sort((a, b) => b.family - a.family || (a.name < b.name ? -1 : 1));

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1360,6 +1360,11 @@ code {
   font-size: 0.85em;
   margin-left: 5px;
 }
+.ontology-versions {
+  display: block; /* Go は版が12個並ぶので、名前と同じ行に置くと折り返して階層が崩れる */
+  color: #6e6e6e;
+  font-size: 0.85em;
+}
 .author-list {
   padding-inline-start: 0px;
   display: flex;

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -134,13 +134,14 @@
       </ul>
 
       <h2 class="bottom-content-header">タグの親子関係（オントロジー）</h2>
-      ※<code>source/_data/tag_ontology.yml</code> の broader の可視化。関連記事の計算が辿る辺で、「子タグの記事に親タグを打つのは冗長」という自明な包含だけを登録しています（#2292）。灰色はタグとして実在しない概念ノード。「系統」は自分＋子孫のユニーク記事数
+      ※<code>source/_data/tag_ontology.yml</code> の broader の可視化。関連記事の計算が辿る辺で、「子タグの記事に親タグを打つのは冗長」という自明な包含だけを登録しています（#2292）。灰色はタグとして実在しない概念ノード。「系統」は自分＋子孫のユニーク記事数。「版」はバージョン同義（Go1.27 は Go を書いたのと同じ扱い。<code>scripts/version_tags.js</code>）で語幹に吸収されるタグ
       <% const onto = doctor_ontology(); %>
       <%
         function renderNode(n) { %>
         <li>
           <% if (n.path) { %><a href="<%- url_for(n.path) %>"><%= n.name %></a><% } else { %><span class="ontology-concept"><%= n.name %></span><% } %>
           <span class="ontology-count"><%= n.posts %>本<% if (n.family > n.posts) { %>・系統<%= n.family %>本<% } %><% if (n.otherParents.length) { %>・他の親: <%= n.otherParents.join('、') %><% } %></span>
+          <% if (n.versions.length) { %><span class="ontology-versions">版: <% n.versions.forEach(function(v, i){ %><a href="<%- url_for(v.path) %>"><%= v.name %></a>（<%= v.posts %>）<%= i < n.versions.length - 1 ? '、' : '' %><% }) %></span><% } %>
           <% if (n.children.length) { %>
           <ul>
             <% n.children.forEach(renderNode) %>
@@ -158,7 +159,7 @@
       <ul class="doctor-list">
         <li>
           <span class="doctor-note">親も子も無い根タグ（<%= onto.standalone.length %>件）</span>
-          <% onto.standalone.forEach(function(n, i){ %><a href="<%- url_for(n.path) %>"><%= n.name %></a><span class="ontology-count"><%= n.posts %>本</span><%= i < onto.standalone.length - 1 ? '、' : '' %><% }) %>
+          <% onto.standalone.forEach(function(n, i){ %><a href="<%- url_for(n.path) %>"><%= n.name %></a><span class="ontology-count"><%= n.posts %>本<%= n.versions.length ? '・版' + n.versions.length : '' %></span><%= i < onto.standalone.length - 1 ? '、' : '' %><% }) %>
         </li>
       </ul>
 


### PR DESCRIPTION
#2331（オントロジーツリー）と #2363（バージョン同義）のマージ後の磨き込み。ツリーが versionOf を知らず、`Vue3` / `JDK23` が「親も子も無い根タグ」に紛れ込んでいたのを直す。

## 変更内容

- 版タグ（名前規則 + versionOf。`scripts/version_tags.js` と同じ導出）を語幹ノードの下に **「版: Go1.27（8）、Go1.26（7）、…」** として表示する。新しい版が先。Go は12個並ぶので名前と同じ行に置かず、専用の行にする
- versionOf ノードは木・独立タグ一覧には数えない（語幹の「版」として出すため）
- 独立タグ側は「インターン 26本・版6」のように件数だけ添える

## 確認

フルビルドで /doctor/ を確認: Go の版12個・Vue.js 配下に Vue3・独立タグ一覧から Vue3 消滅・インターンに「版6」を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)