### PR TITLE
#2357 関連タグの並びを共有→系列にする

### DIFF
--- a/scripts/related_tags.js
+++ b/scripts/related_tags.js
@@ -22,7 +22,13 @@
  * ただし共起では「同じ仲間だが同じ記事には付かない」関係が見えない。
  * Go1.26 と Go1.27 の共起は0本で、バージョン違いは排他的に付くため原理的に
  * 検出できない。そこで名前の形（末尾の数字を外した接頭辞が一致する）から
- * 兄弟を拾い、共起の結果より前に置く。
+ * 兄弟を拾い、共起の結果の後ろに置く。
+ *
+ * 並びを共起→兄弟にしているのは、先頭の一等地を非自明な発見に使うため
+ * (#2357)。Terraform → IaC のような共起の関係は見て初めて気づくが、
+ * Go1.26 の隣の Go1.27 は名前だけで関係が自明なので、末尾でも見落とされない。
+ * 逆に先頭へ置くと、兄弟が多いタグ（Go1.xx は11個）で一等地を占拠して
+ * 発見を後ろへ押し出してしまう。
  *
  * 名前の一致は共起と違って決定的な関係なので、件数による裏付けは要らない。
  * 兄弟が1つでも、移動先が1本でも出す。読者にとって Go1.26 の隣に Go1.27 が
@@ -125,7 +131,7 @@ hexo.extend.helper.register('related_tags', function (tagName) {
   const own = total.get(tagName);
   if (!own) return [];
 
-  // 同じ系列のタグ。共起では見えない関係なので、件数で足切りせず先に置く
+  // 同じ系列のタグ。共起では見えない関係なので、件数で足切りせず全部出す
   const stem = family(tagName);
   const siblings = (stem ? families.get(stem) || [] : [])
     .filter((name) => name !== tagName)
@@ -167,5 +173,5 @@ hexo.extend.helper.register('related_tags', function (tagName) {
   // 同点は名前で決める（決着が無いとビルドごとに並びが変わる）
   const score = (r) => r.co * Math.log(1 + r.lift);
   rows.sort((a, b) => score(b) - score(a) || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
-  return siblings.concat(rows.slice(0, MAX_CO_TAGS));
+  return rows.slice(0, MAX_CO_TAGS).concat(siblings);
 });


### PR DESCRIPTION
Close #2357

## あるべき論（設計判断）

**一覧の先頭（一等地）は「非自明な発見」に使う**、を原則にした。

- **共有（共起）タグ**は `Terraform → IaC` のような読者が見て初めて気づく関係で、スコア順（共起数 × log(1+lift)）に強い順で並んでいる。先頭に置く価値が最も高い
- **系列タグ**は `Go1.26 → Go1.27` のように名前だけで関係が自明。視認性が名前に内蔵されているので、末尾でも見落とされない
- 従来の「系列が先頭」には実害があった：**Go1.xx は兄弟11個**あり、Go1.27 のページでは Go1.26〜Go1.16 が11連発した後にやっと共起タグが来る並びになっていた

維持したもの：系列の「新しいバージョン先」ソート、系列は表示上限に数えず全部出す仕様（共起と枠を奪い合う理屈が無い、という既存判断は正しい）。コード先頭の設計コメントも新しい根拠に書き換えた。

## 検証（ローカル）

- `Go1.27`: 「Go: 9本を共有」→ 系列11個（1.26〜1.16、バージョン降順）
- `GoogleCloudNext2025`: 共有4個（GoogleCloudNext・AIエージェント・GoogleCloud・参加レポート）→ 系列2個（2024・2019）

変更は並び替えの1行＋コメント更新のみ（`siblings.concat(rows)` → `rows.concat(siblings)`）。

## 関連

#2355（無印タグ＝GoogleCloudNext の親ページに子系列を出す）は同じファイルの別課題として残っている。無印は共起経由で子ページに出ることは確認済みだが、親ページに子は出ない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)