### PR TITLE
publish-qiita スキルを追加（Qiita 記事公開の一気通貫手順）

### DIFF
--- a/.claude/skills/publish-qiita/SKILL.md
+++ b/.claude/skills/publish-qiita/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: publish-qiita
+description: Qiita の下書き URL と著者名を入力に、hexiita 変換 → フロントマター整備 → カテゴリ・タグ見直し → textlint / markdownlint 対応 → mermaid SVG 生成 → 検証 → PR 作成まで行う記事公開手順。「この Qiita 記事を公開して」と頼まれたときに使う。
+---
+
+# Qiita 記事の公開
+
+入力: Qiita 記事 URL（限定共有 `/private/` 可）と著者名（ブログでの表記。Qiita ID ではない）。
+連載に属する場合は連載名も聞く。
+
+## 1. 変換（hexiita）
+
+- `source/_posts/<年>/` で同日の既存記事を確認し、postid（a, b, c…）を決める
+- リポジトリルートで実行する。カレントの `source/` 配下に記事 MD と画像
+  （`source/images/<年>/<記事ID>/`、thumbnail 含む）が出力される
+
+  ```sh
+  hexiita <qiita url> YYYYMMDD
+  ```
+
+- 連載記事は `-series "連載名"`、索引記事はさらに `-index`。
+  フラグは URL より**前**に置く（Go の flag は最初の非フラグ引数で解釈を止める）
+
+## 2. フロントマター整備
+
+- `author:` は Qiita ID のまま出力されるので、指定された著者名に書き換える
+- `lede:` の先頭に `![...]` 画像記法の残骸が混入することがあるので除去する
+- 同日複数投稿なら `date:` の時刻を postid 順にずらす（a=00:00:00、b=00:00:01。#2055）
+- 著者が `_profile.yml` 未登録なら追記する。about は記事冒頭の自己紹介から作り、
+  twitter_id / github_id は確実に分かる場合だけ書く（推測で埋めない）
+
+## 3. カテゴリ・タグ見直し
+
+- カテゴリは CLAUDE.md の既存語彙から。境界ルール（IaC / Infrastructure / DevOps、
+  AIDD / DataScience）に照らして確認する
+- タグは具体タグだけ付ける（抽象への接続はオントロジーが肩代わり）。
+  `source/_data/tag_ontology.yml` に未登録のタグが増えたら **tag-maintenance スキル**の
+  増分追記手順で broader を判断して追記し、`check.mjs` を ERROR ゼロで通す
+
+## 4. lint
+
+```sh
+node_modules/.bin/textlint --fix <path>            # 自動修正
+node_modules/.bin/textlint <path>                  # 残エラー確認。ゼロになるまで
+node_modules/.bin/markdownlint-cli2 --fix "<path>" # 見出し表記ゆれ（heading-vocab）等
+```
+
+- `--fix` の exit 0 は lint クリーンを意味しない。max-ten（読点4つ以上）と
+  no-doubled-joshi（同一助詞の重複）は残り、放置すると reviewdog が PR の全行に
+  コメントする。意味を変えない語順調整で手修正する
+  - max-ten は読点1つの削除か文の分割が安全
+  - 罠: 読点区切りの列挙は助詞重複が許容されるが、読点を `・` に替えると
+    no-doubled-joshi が新たに発火する
+- 誤検知（固有名詞等）は `.textlintrc` の `filters.allowlist.allow` に追加して黙らせる
+
+## 5. mermaid 図（記事にある場合のみ）
+
+```sh
+make mermaid   # Docker 必須
+```
+
+`source/_mermaid/*.svg` が生成されるので、記事とあわせてコミットする。
+
+## 6. 検証
+
+- `hexo generate` を通す（worktree の初回はキャッシュが無くフルビルドで数分かかる）
+- 生成 HTML（`public/articles/<記事ID>/index.html`）で確認する:
+  - mermaid 図がインライン SVG になっているか（`<svg id="mermaid-`）
+  - author・タグ・thumbnail
+  - プロフィールを追記した場合は著者ページ `public/authors/<著者名>/`
+- ユーザーの目視確認用にローカルサーバを起動して URL を伝える。
+  4001〜4004 は並行セッションが使っていることがあるので、`ss -tlnp` で
+  空きポートを確認してから `hexo server -p <port>` する
+
+## 7. PR
+
+- コミット対象: 記事 MD / 画像ディレクトリ / `source/_mermaid/*.svg` /
+  （変更していれば）`_profile.yml` / `tag_ontology.yml`
+- worktree では `gh pr create` に `--head <branch> --base main` を明示する
+  （省略すると push 済みでも "must first push the current branch" で失敗する）。
+  PR 本文は `--body-file` で渡す
+- マージ確認を待ち、レビュー指摘は同じ PR に追いコミットで対応する（force push しない）


### PR DESCRIPTION
## 概要

Qiita 下書きの公開作業（PR #2373 で実施した一連の手順）を `publish-qiita` スキルとして追加する。

## 内容

Qiita URL と著者名を入力に、以下を一気通貫で行う手順書:

1. hexiita 変換（postid 判断、連載フラグの置き場所）
2. フロントマター整備（author 実名化、lede の画像残骸除去、`_profile.yml` 追記）
3. カテゴリ・タグ見直し（境界ルール確認、オントロジー増分追記は tag-maintenance スキルへ委譲）
4. textlint / markdownlint 対応（--fix で直らない max-ten / no-doubled-joshi の手修正指針と罠）
5. mermaid SVG 生成（make mermaid）
6. 生成 HTML での検証とローカルサーバ起動（ポート競合の回避）
7. PR 作成（worktree での gh pr create の注意点）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
