### PR TITLE
#2292 /doctor/ のツリーで versions 未定義でも落ちないようにする

### DIFF
--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -141,7 +141,12 @@
         <li>
           <% if (n.path) { %><a href="<%- url_for(n.path) %>"><%= n.name %></a><% } else { %><span class="ontology-concept"><%= n.name %></span><% } %>
           <span class="ontology-count"><%= n.posts %>本<% if (n.family > n.posts) { %>・系統<%= n.family %>本<% } %><% if (n.otherParents.length) { %>・他の親: <%= n.otherParents.join('、') %><% } %></span>
-          <% if (n.versions.length) { %><span class="ontology-versions">版: <% n.versions.forEach(function(v, i){ %><a href="<%- url_for(v.path) %>"><%= v.name %></a>（<%= v.posts %>）<%= i < n.versions.length - 1 ? '、' : '' %><% }) %></span><% } %>
+          <%# versions が無くても落とさない。scripts/ は再起動まで古いままでテーマだけ
+              watch で再読込されるため、開発サーバでは版ズレでヘルパーが versions を
+              返さないことがある。undefined のまま参照すると未処理例外になり、
+              レスポンスが返らず /doctor/ がハングして見える %>
+          <% const vers = n.versions || []; %>
+          <% if (vers.length) { %><span class="ontology-versions">版: <% vers.forEach(function(v, i){ %><a href="<%- url_for(v.path) %>"><%= v.name %></a>（<%= v.posts %>）<%= i < vers.length - 1 ? '、' : '' %><% }) %></span><% } %>
           <% if (n.children.length) { %>
           <ul>
             <% n.children.forEach(renderNode) %>
@@ -159,7 +164,7 @@
       <ul class="doctor-list">
         <li>
           <span class="doctor-note">親も子も無い根タグ（<%= onto.standalone.length %>件）</span>
-          <% onto.standalone.forEach(function(n, i){ %><a href="<%- url_for(n.path) %>"><%= n.name %></a><span class="ontology-count"><%= n.posts %>本<%= n.versions.length ? '・版' + n.versions.length : '' %></span><%= i < onto.standalone.length - 1 ? '、' : '' %><% }) %>
+          <% onto.standalone.forEach(function(n, i){ %><a href="<%- url_for(n.path) %>"><%= n.name %></a><span class="ontology-count"><%= n.posts %>本<%= (n.versions || []).length ? '・版' + n.versions.length : '' %></span><%= i < onto.standalone.length - 1 ? '、' : '' %><% }) %>
         </li>
       </ul>
 


### PR DESCRIPTION
「/doctor/ が重すぎて開けない」の再発防止。

## 起きていたこと

hexo server はテーマ（doctor.ejs）を watch で自動再読込するが、**scripts/（doctor.js）は起動時にしか読まない**。#2367 マージ後、起動しっぱなしの開発サーバは「新テンプレート＋旧ヘルパー」の版ズレになり、`n.versions.length` が undefined 参照で未処理例外に。**エラーページすら返らずレスポンスが宙吊りになる**ため、/doctor/ だけが無限に開かない状態になる（実測: 他ページは正常応答、/doctor/ は90秒でもタイムアウト。サーバログには `Unhandled rejection TypeError: Cannot read properties of undefined (reading 'length')` の連発）。

本番ビルドはテンプレートとスクリプトが常に同一コミットなので影響なし。影響するのは scripts/ を含む pull を取り込んだ長時間稼働の開発サーバのみ。

## 変更内容

テンプレート側に `n.versions || []` のガードを2箇所。版ズレ時は「版:」の行が出ないだけの退行に収まり、ページ自体は表示される。理由コメント付き。

根本の運用は「scripts/ を含む pull を取り込んだら hexo server を再起動する」——このガードはハングという最悪の見え方を防ぐ保険。

## 確認

フルビルドでエラー0、/doctor/ の版表示（5系統）が従来どおり出力されることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)