### PR TITLE
コードの置き場所の方針を CLAUDE.md に書く

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,12 @@ Hexo 7.3 製の静的サイトで、GitHub Pages にホスティングされて�
 | `themes/future/_config.yml` | テーマ設定（メニュー、GA4 プロパティ、SNSリンク） |
 | `_profile.yml` | 著者プロフィール（about / twitter_id / github_id） |
 
+コードの置き場所は **URL ではなく部品の種別**で決める。
+`layout/` 直下＝ページ種、`_partial/`＝共有部品、`_widget/`＝サイドバー、`scripts/`＝機能単位＋`lib/`。
+URL は読者向け、コード配置は保守者向けの分類なので、鏡合わせにすると URL を変えるたびにコード移動が要る。
+`/specials/` のような名前空間を切っても `layout/specials/` は作らない。
+同じ系統のレイアウトが3〜4本に増えて見通しが悪くなったら、そのとき分ける（#2369）。
+
 ## 記事の書き方
 
 ファイル名は `source/_posts/<年>/YYYYMMDD<postid>_<タイトル>.md`。


### PR DESCRIPTION
Closes #2369

#2369 は「specials 系レイアウトが3〜4本に増えたら `layout/specials/` を切るか再検討する」という**運用方針を issue に置いた**ものでした。

> 問題になった場合に起票すべき。
> 運用方針であれば、README.md やCLAUDE.mdに記載すべきである。

というご指摘のとおりなので、CLAUDE.md に移して issue は閉じます。

## 追記した内容

```md
コードの置き場所は **URL ではなく部品の種別**で決める。
`layout/` 直下＝ページ種、`_partial/`＝共有部品、`_widget/`＝サイドバー、`scripts/`＝機能単位＋`lib/`。
URL は読者向け、コード配置は保守者向けの分類なので、鏡合わせにすると URL を変えるたびにコード移動が要る。
`/specials/` のような名前空間を切っても `layout/specials/` は作らない。
同じ系統のレイアウトが3〜4本に増えて見通しが悪くなったら、そのとき分ける（#2369）。
```

`## 構成` の表の直後に置いています。表がパスと役割の対応を示しているので、その分類軸の説明として続く形です。

## 現状（参考）

条件にはまだ達していません。

| 項目 | 現状 |
| --- | --- |
| specials 系レイアウト | `guidelines.ejs` の**1本のみ** |
| `layout/` 直下の `.ejs` | 16本 |
| `/specials/` 配下のページ | `/specials/`（`layout: page`）と `/specials/guidelines/` |

`httf.ejs`（#2345）はこれから作るものです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
