### PR TITLE
#2358 /tags/ の「人気のタグ」を直近1年/累計の2列で出す

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2036,6 +2036,17 @@ input[name="tab_item"] {
   margin-bottom: 16px;
 }
 
+/* /tags/ の「人気のタグ」2列パネル（直近1年/累計 #2358）。
+   summary-panel の枠と小ラベルを継ぎ、チップが収まるよう下側だけ広げる。
+   row の負のトップマージンはカラム自身のガターと相殺するため対策不要 */
+.tag-pool-panel {
+  padding-bottom: 12px;
+}
+/* 既定の 2px はタイル数値用の詰め。チップ相手だとラベルが貼り付いて見える */
+.tag-pool-panel .summary-panel-label {
+  margin-bottom: 10px;
+}
+
 /* /series/ の年ごとの枠。ラベルと枠線は summary-panel を継ぎ、
    カードが収まるよう下側の padding だけ広げる */
 .series-year {

--- a/themes/future/layout/_widget/tag.ejs
+++ b/themes/future/layout/_widget/tag.ejs
@@ -1,7 +1,8 @@
-<%# トップの「人気のタグ」(#2358)。直近1年に公開された記事の PV 合計で選ぶ
+<%# 「人気のタグ」(#2358)。直近1年に公開された記事の PV 合計で選ぶ
     （recent_popular_tags）。チップ右肩の件数は「タグ総数」の意味のみ (#2129)。
-    直近の内訳は title 属性が名乗る %>
-<% const tags = recent_popular_tags(theme.tag_display_max_count); %>
+    直近の内訳は title 属性が名乗る。
+    件数は呼び出し側が limit で渡せる（トップ=既定10、/tags/ のタブ=30） %>
+<% const tags = recent_popular_tags(typeof limit !== 'undefined' ? limit : theme.tag_display_max_count); %>
 <% if (tags.length){ %>
 <div class="widget">
   <ul class="tag-list" itemprop="keywords">

--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -82,7 +82,27 @@
           「〜から記事を探す」を繰り返さない体言止めにする（ホーム側は
           文脈が混在するため説明的な「人気のタグから記事を探す」のまま） %>
       <%- partial('_partial/section-heading', {id: 'populartags', text: '人気のタグ'}) %>
-      <%- ranking_tags() %>
+      <%# 直近1年（公開1年以内の記事のPV合計）と累計（全期間のシェア効率）を
+          2列で並べて両方見せる (#2358)。タブ切り替えは上のグラフのタブと
+          見た目が重複するためやめた。枠と小ラベルは詳細ページの統計パネル
+          （累計/直近1年 #2276）と同じ部品。並びだけは鮮度が主目的の
+          セクションなので直近1年を左にする %>
+      <div class="row g-4 tag-pool-panels">
+        <div class="col-12 col-md-6">
+          <section class="summary-panel tag-pool-panel h-100">
+            <span class="summary-panel-label">直近1年</span>
+            <div class="blog-tags">
+              <%- partial('_widget/tag.ejs', {limit: 30}) %>
+            </div>
+          </section>
+        </div>
+        <div class="col-12 col-md-6">
+          <section class="summary-panel tag-pool-panel h-100">
+            <span class="summary-panel-label">累計</span>
+            <%- ranking_tags() %>
+          </section>
+        </div>
+      </div>
       <%# 「今年初出」ではなく件数固定の新着。トップページの「新着記事」と同じ語彙 %>
       <%- partial('_partial/section-heading', {id: 'newtags', text: '新着タグ'}) %>
       <%# マークアップは「関連タグ」（archive.ejs）や _widget/tag.ejs と揃える。


### PR DESCRIPTION
#2358 の追加対応（トップ側は #2375 で対応済み）。

## 概要

/tags/ の「人気のタグ」を2列パネルにし、**直近1年**（トップと同じ、公開1年以内の記事のPV合計・30件）と**累計**（従来のシェア効率スコア・30件）を並置します。

## 設計判断

- **タブ切り替え案は実装後に取り下げ**：同ページ上部の「年別 新規タグ数の推移」のタブと見た目が重複した。2列なら両方同時に見えて比較もしやすい
- 枠と小ラベルは詳細ページの統計パネル（累計/直近1年 #2276）と同じ部品・同じ語彙。**鮮度が主目的のセクションなので直近1年を左**に置く（統計パネルの累計先頭とは意図的に逆）
- チップ部品（`_widget/tag.ejs`）に `limit` を渡せるようにして、トップ（10件）と /tags/（30件）で共用
- ラベルとチップの間隔は 10px に調整（`summary-panel-label` 既定の 2px は統計タイル用の詰めのため）

## 検証

ローカルで両パネル30件ずつの表示・モバイル幅での縦積み・ラベル間隔をスクリーンショット確認。ビルドエラーなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)