### PR TITLE
note記法のインデント対応regexが後続ブロックまで飲み込むのを直す（23記事の描画崩れ）

### DIFF
--- a/scripts/note_container.js
+++ b/scripts/note_container.js
@@ -12,10 +12,12 @@
  * :::
  */
 hexo.extend.filter.register('before_post_render', function (data) {
-  // インデントに対応するよう正規表現を修正
-  // ^(\s*): 行頭のインデント（スペース）をキャプチャ(group 1)
-  // \1:::  : 開始タグと同じインデントを持つ終了タグにマッチ
-  const regex = /^(\s*):::\s+note(?:\s+(\w+))?\n([\s\S]+?)\n\1:::$/gm;
+  // ^([ \t]*): 行頭のインデントをキャプチャし、同じインデントの終了タグ（\1:::）と対にする。
+  // 水平空白に限るのが要点で、\s にすると改行まで飲み、直前の空行から
+  // マッチが始まって \1 に「\n」が入る。すると閉じ側に「空行＋:::」を要求してしまい、
+  // 直後の ::: を素通りして後続ブロックの :::（表の後の空行付き等）まで
+  // 1つの note に飲み込む。この取り違えで23記事の描画が壊れていた
+  const regex = /^([ \t]*):::[ \t]+note(?:[ \t]+(\w+))?\n([\s\S]+?)\n\1:::$/gm;
 
   data.content = data.content.replace(regex, (match, indent, specifiedClass, content) => {
     let className = 'info'; // デフォルトのクラス名


### PR DESCRIPTION
報告のあった [20250512b](https://future-architect.github.io/articles/20250512b/) のレンダリング崩れの修正。調査の結果、**2026-07-22 から本番の23記事で note 記法の描画が壊れていた**サイト全体の退行だった。

## 原因

`scripts/note_container.js` のインデント対応（ae500eb4、2026-07-22）で入った正規表現:

```js
/^(\s*):::\s+note(?:\s+(\w+))?\n([\s\S]+?)\n\1:::$/gm
```

`^(\s*)` の `\s` は**改行にもマッチ**するため、note の直前に空行があるとそこからマッチが始まり、インデントのキャプチャ `\1` に「\n」が入る。すると閉じ側が「空行＋:::」を要求する形になり、直後の `:::` を素通りして、後続ブロックの空行付き `:::`（表の後など）まで**1つの note に飲み込む**。

20250512b では冒頭の warn note が「はじめに」〜Logic Apps比較表まで約4,800文字を飲み込み、その中に2つ目の `::: note info` がリテラル表示されていた。

## 修正

インデントを水平空白に限定する: `^([ \t]*):::[ \t]+note(?:[ \t]+(\w+))?`（インデント対応の意図はそのまま）。

## 影響と検証

- `::: note` を使う111記事のうち、現行regexで壊れていたのは**23記事**（20230221a、20230922a、20240722a、20250325a、20250509a、20250512b、20250723a、20250725a、20250801a、20250827a、20250828a、20251010a、20251020a、20251028b、20260202a、20260323a、20260511a、20260601a、20260602a、20260603a、20260605a、20260608a、20260730a）
- 修正後、全111記事で開きタグ数とregexマッチ数の一致を検算
- クリーンビルドで、生の「::: note」が残るページが全1,468記事中**0件**になることを確認（20250512b は warn / info の2つの note-container が正しく分離）
- 注意: `before_post_render` の結果は db.json にキャッシュされるため、**ローカル検証は `hexo clean` が必要**。CI のデプロイは毎回クリーンビルドなのでマージすれば反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)