### PR TITLE
#2385 トップの SNS人気 タブを削除する

### DIFF
--- a/scripts/popular_posts.js
+++ b/scripts/popular_posts.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const { getSNSCnt } = require('./lib/sns');
 const { postListItem } = require('./lib/post_list');
 
 const fs = require('fs');
 const gaCache = JSON.parse(fs.readFileSync('ga_cache.json', 'utf-8'));
 
-// ランキング（トレンド・年間人気・SNS人気）の表示件数。
+// ランキング（トレンド・年間人気）の表示件数。
 // 記事が長文化する傾向にあるため、トップページのスクロール量を抑える目的で絞り、
 // 11位以下は details で畳んで25位まで辿れるようにする (#2249)。
 // details ならJSを足さずに済む（参照記事の畳みと同じ作り）
@@ -127,12 +126,4 @@ hexo.extend.helper.register('popular_posts', function (term = 'weekly') {
       ? [RANKING_DISPLAY_COUNT, RANKING_MAX_COUNT, RANKING_YEARLY_MAX_COUNT]
       : [RANKING_DISPLAY_COUNT, RANKING_MAX_COUNT];
   return rankingList(popularPosts, caps);
-});
-
-hexo.extend.helper.register('sns_popular_posts', function () {
-  const allPosts = this.site.posts.data;
-  allPosts.sort((a, b) => getSNSCnt(b.permalink) - getSNSCnt(a.permalink));
-  const popularPost = allPosts.slice(0, RANKING_MAX_COUNT);
-
-  return rankingList(popularPost);
 });

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1928,10 +1928,8 @@ input[name="tab_item"] {
 }
 
 /*選択されているタブのコンテンツのみを表示*/
-#weekly:checked ~ #popular_weekly,
 #monthly:checked ~ #popular_monthly,
-#yearly:checked ~ #popular_yearly,
-#sns:checked ~ #popular_sns {
+#yearly:checked ~ #popular_yearly {
   display: block;
 }
 

--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -11,16 +11,11 @@
         <label tabindex="0" class="tab_item" for="monthly">トレンド</label>
         <input id="yearly" type="radio" name="tab_item">
         <label tabindex="0" class="tab_item" for="yearly">年間人気</label>
-        <input id="sns" type="radio" name="tab_item">
-        <label tabindex="0" class="tab_item" for="sns">SNS人気</label>
         <div class="tab_content" id="popular_monthly">
           <%- popular_posts('monthly') %>
         </div>
         <div class="tab_content" id="popular_yearly">
           <%- popular_posts('yearly') %>
-        </div>
-        <div class="tab_content" id="popular_sns">
-          <%- sns_popular_posts() %>
         </div>
       </div>
   </section>


### PR DESCRIPTION
Closes #2385

## 変更内容

トップ「よく読まれている記事」の3タブから **SNS人気 を削除**し、トレンド / 年間人気 の2タブにする。

- `themes/future/layout/_partial/archive.ejs`: sns のラジオ・ラベル・タブ本体を削除
- `scripts/popular_posts.js`: `sns_popular_posts` ヘルパーと getSNSCnt import を削除
- `theme-styles.styl`: タブ表示セレクタから `#sns` を削除（同じセレクタ列に残っていた**旧 #weekly タブの残骸**も削除）

## 残すもの（スコープ外）

SNS カウントの取得と他の用途はそのまま:

- 著者ページのリアクション集計（author_generator.js）
- 記事ページのシェア数表示（sns_count.js）
- 関連記事のカテゴリ補填の並び（related_posts.js）
- 統計まわり（count_post.js、tags.js）
- 日次の取得ジョブ（update-cache.yml）と sns_count_cache.json

issue 後半の「いいね機能ができたら PV ランキングや関連記事に SNS を加味」は将来の別トラック。

## 確認

フルビルドでトップページのタブが「トレンド / 年間人気」の2つになり、`popular_sns` への参照が生成物から消えることを確認。タブは float 自動幅のため2枚でもレイアウトは崩れない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)