### PR TITLE
#2356 関連記事に「残り N本を表示」の畳みを付ける

### DIFF
--- a/scripts/related_posts.js
+++ b/scripts/related_posts.js
@@ -1,8 +1,14 @@
 'use strict';
 
-// 関連記事の最大表示件数
-// 記事が長文化する傾向にあるため、記事末尾のスクロール量を抑える目的で絞っている
-const maxCount = 3;
+// 関連記事の件数 (#2356)。
+// 記事が長文化する傾向にあるため、常に見せるのは3件に絞り、
+// 続きは details で畳んでクリックで開けるようにする（参照記事と同じ作り）。
+// 畳む側の候補はタグ由来（スコア有り）だけ。実測では4位以下に
+// カテゴリ補填（同カテゴリのSNS人気順で、関連の根拠が無い）や
+// 汎用タグの同点帯のノイズが混ざり、スコアの絶対値では切れなかったため、
+// しきい値ではなく出所で絞る
+const DISPLAY_COUNT = 3;
+const MORE_COUNT = 5;
 const { getSNSCnt } = require('./lib/sns');
 const { postListItem } = require('./lib/post_list');
 const { navLinkedPaths } = require('./lib/series');
@@ -66,54 +72,72 @@ function buildTokenIndex(site) {
 }
 
 /**
- * 上位から maxCount 本選ぶ。ただし同じ連載の記事で全部は埋めない。
+ * 上位から表示分＋畳み分を選ぶ。ただし同じ連載の記事で埋めない。
  *
- * 3枠すべてが同じ連載になると、連載ナビと索引で辿れる範囲しか出ず、
- * 関連記事の枠から得られる導線がゼロになる。少なくとも1枠は連載の外から取る。
+ * 同じ連載は索引・前後ナビで辿れるため、関連記事の枠を使う価値が低い。
+ * 全体で2枠まで（畳み分を増やす前の「3枠中最低1枠は連載の外」の実質値を、
+ * 総数を増やしても変えない）。
  *
- * 逆に締め出しはしない。テーマが自由な連載（春の入門祭りなど）では、
+ * 締め出しはしない。テーマが自由な連載（春の入門祭りなど）では、
  * 同じ連載でも独立した記事なので、関連が強ければ出す価値がある。
  */
 function pickRelatedPosts(posts, series) {
-  if (!series) return posts.slice(0, maxCount);
+  const total = DISPLAY_COUNT + MORE_COUNT;
+  if (!series) return posts.slice(0, total);
 
+  const SAME_SERIES_MAX = 2;
   const picked = [];
   const deferred = [];
   for (const p of posts) {
-    if (picked.length >= maxCount) break;
+    if (picked.length >= total) break;
     const sameSeries = p.series === series;
-    if (sameSeries && picked.filter((x) => x.series === series).length >= maxCount - 1) {
+    if (sameSeries && picked.filter((x) => x.series === series).length >= SAME_SERIES_MAX) {
       deferred.push(p);
       continue;
     }
     picked.push(p);
   }
   // 連載の外から埋まらなかったときは、抑えた分を戻す
-  return picked.concat(deferred).slice(0, maxCount);
+  return picked.concat(deferred).slice(0, total);
 }
 
 // HTMLを生成するロジックを共通関数として外に切り出す
 function generateRelatedPostsHtml(posts, series) {
   posts = pickRelatedPosts(posts, series);
-  const count = Math.min(maxCount, posts.length);
-  if (count === 0) {
+
+  let visible = posts.slice(0, DISPLAY_COUNT);
+  // 畳み分はタグ由来（スコア有り）だけ。カテゴリ補填は表の3件を埋める保険で、
+  // 開いてまで見せる関連の根拠が無い
+  let more = posts.slice(DISPLAY_COUNT).filter((p) => p.score);
+  // 残り1件なら畳む意味がない（参照記事の畳みと同じ扱い）
+  if (more.length === 1) {
+    visible = visible.concat(more);
+    more = [];
+  }
+
+  if (visible.length === 0) {
     return `<p class="related-posts-none">No related post.</p>`;
   }
 
-  let result = '';
-  for (let i = 0; i < count; i++) {
-    const related = posts[i];
-    if (related) {
-      const scoreText = related.score ? `スコア: ${related.score.toFixed(4)}` : '';
-      const titleAttr = `${related.lede} ${scoreText}`.trim();
-      // マークアップは lib/post_list.js に集約している
-      result += postListItem(related, 'related-posts-item', titleAttr, true);
-    }
-  }
+  // マークアップは lib/post_list.js に集約している
+  const item = (related) => {
+    const scoreText = related.score ? `スコア: ${related.score.toFixed(4)}` : '';
+    const titleAttr = `${related.lede} ${scoreText}`.trim();
+    return postListItem(related, 'related-posts-item', titleAttr, true);
+  };
+
+  // 語彙と作りはランキング・参照記事の畳みに揃える (#2249)
+  const moreHtml = more.length
+    ? `
+    <details class="related-posts-more">
+      <summary>残り ${more.length}本を表示</summary>
+      <ul class="related-post-link">${more.map(item).join('')}</ul>
+    </details>`
+    : '';
 
   return `
     <div class="widget">
-      <ul class="related-post-link">${result}</ul>
+      <ul class="related-post-link">${visible.map(item).join('')}</ul>${moreHtml}
     </div>`;
 }
 
@@ -254,8 +278,8 @@ hexo.extend.helper.register('list_related_posts', function () {
       (a.path < b.path ? -1 : a.path > b.path ? 1 : 0),
   );
 
-  // 4. 記事数がmaxCountに満たない場合はカテゴリから補填
-  if (relatedPosts.length < maxCount) {
+  // 4. 表示分（3件）に満たない場合はカテゴリから補填。畳み分は補填しない
+  if (relatedPosts.length < DISPLAY_COUNT) {
     const postsToFill = getCategoryRelatedPosts(this, post, isExcluded);
     postsToFill.forEach((p) => {
       if (relatedPosts.findIndex((rp) => rp._id === p._id) === -1) {

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1695,10 +1695,12 @@ a.series-nav-item:hover .series-nav-item-title {
    全件を並べると記事末尾が長くなりすぎるが、件数で打ち切ると
    参照された事実そのものが隠れてしまうため、開けば全部見える形にする。
    JS は使わない */
-.reference-post-more {
+.reference-post-more,
+.related-posts-more {
   padding: 0 0.8em 0.6em;
 }
 .reference-post-more > summary,
+.related-posts-more > summary,
 .ranking-more > summary {
   padding: 0.5em 0;
   border-top: 1px solid #ecebeb;
@@ -1707,15 +1709,18 @@ a.series-nav-item:hover .series-nav-item-title {
   cursor: pointer;
 }
 .reference-post-more > summary:hover,
+.related-posts-more > summary:hover,
 .ranking-more > summary:hover {
   color: #424242;
 }
 /* 畳んだ側の ul は details 側で余白を持つので、二重に付けない */
-.reference-post-more .reference-post-link {
+.reference-post-more .reference-post-link,
+.related-posts-more .related-post-link {
   padding: 0;
 }
 /* 直前の ul の最終行は、summary の上線と重なって二重線になる */
 .reference-post-link:has(+ .reference-post-more) .reference-posts-item:last-child,
+.related-post-link:has(+ .related-posts-more) .related-posts-item:last-child,
 .featured-post-link:has(+ .ranking-more) .featured-posts-item:last-child {
   border-bottom: none;
 }


### PR DESCRIPTION
Close #2356

## 概要

記事末の関連記事に details の畳み「残り N本を表示」を追加します。常に見せる3件は変えず、**4位以下を最大5件（計8件）**畳んで出します。JSは足しません（ランキング #2249・参照記事の畳みと同じ作り・同じ語彙・同じ見た目）。

## 件数と質の判断（Issueの「目視確認してから決める」への回答）

一時的に10件表示にして6記事（Goリリース連載・データモデリング・AWS合格記・OJT・ブログ運営・Spring Boot）の4〜10位を目視した結果：

- **当たり**：AWS合格記の4位以下は他の合格体験記が並び読者ニーズに合致。データ系記事もdbt/BigQuery系で妥当
- **ハズレの混入源は2つ**：
  1. **カテゴリ補填**（タグ関連が3件未満のときのSNS人気順補填）— 関連の根拠が無く、RedmineのEVM記事が3本並ぶ等
  2. **汎用タグの同点帯** — Go連載記事の同点4.52点に「アルバイト生から見たTIGユニット」が混入
- **スコアの絶対値では切れない**：同じ4.5点に妥当な連載回と無関係記事が同居し、逆にSpring記事では2.7点でも妥当

そこで「+7で計10」ではなく **+5で計8** を採り、さらに**畳み分はタグ由来（スコア有り）だけ**に絞りました。ノイズの主要源であるカテゴリ補填を構造的に排除します（表の3件の補填は従来どおり＝空欄よりまし、の既存意図を維持）。汎用タグ同点帯のノイズは僅かに残りますが、畳みの中＝読者が自分で開く場所なので許容範囲と判断しました。

## 挙動の実測

| 記事 | 表示 | 畳み |
| --- | --- | --- |
| AWS Security合格記 | 3 | 5（他の合格体験記） |
| Go1.27ポスト量子暗号 | 3 | 5（Go連載・GC解説） |
| Spring Boot Flyway | 3 | 2（Spring系のみ。補填は畳まれない） |
| OJTをいつ終えるか（タグ関連1件） | 3 | 0（**details自体が出ない**） |

- 残り1件のときは畳まず表に出す（参照記事と同じ扱い）
- 同一連載の上限は従来の実質値（2枠）を総数を増やしても維持（連載内は索引で辿れるため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
