### PR TITLE
hexo-server-live でローカルサーバにライブリロードを付ける

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ lede: "Go 1.27 で標準ライブラリに追加されたuuidパッケージを�
 ## コマンド
 
 ```sh
-make s      # ローカルサーバ（http://localhost:4000）
+make s      # ローカルサーバ（http://localhost:4000、ライブリロード付き。hexo-server-live）
 make g      # 静的ファイル生成（public/）
 make clean  # キャッシュ・生成物の削除
 make fix    # textlint --fix（source/_posts 配下）

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "rss-parser": "^3.13.0"
       },
       "devDependencies": {
+        "hexo-server-live": "^0.2.12",
         "lint-staged": "^15.2.7",
         "markdownlint-cli2": "^0.22.1",
         "prettier": "^3.9.6",
@@ -4028,6 +4029,13 @@
       "engines": {
         "node": ">=12.13.0"
       }
+    },
+    "node_modules/hexo-server-live": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/hexo-server-live/-/hexo-server-live-0.2.12.tgz",
+      "integrity": "sha512-F3tQFzdzztKouXKsxUG2TtgWlmKW8dS/QzXDCOB9Sme+++5iy0gQ0BdJBF9SEkIyiK074oDPoOMgxavKoxM1Uw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hexo-util": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "rss-parser": "^3.13.0"
   },
   "devDependencies": {
+    "hexo-server-live": "^0.2.12",
     "lint-staged": "^15.2.7",
     "markdownlint-cli2": "^0.22.1",
     "prettier": "^3.9.6",


### PR DESCRIPTION
## 概要

`hexo server` にライブリロードを付ける。ファイルを保存するとブラウザが自動リロードされる。

close #2337

## 選定

| 候補 | 判断 |
| --- | --- |
| **hexo-server-live**（採用） | 2024年更新・**依存パッケージゼロ**・SSE 方式。入れるだけで `hexo server` に効く |
| hexo-browsersync | 2017年で更新停止、古い browser-sync を抱え込む |
| hexo-livereload | 2015年で更新停止 |

## 本番混入の検証（Issue の必須条件）

- クライアントスクリプトの注入は hexo injector 経由だが、**`hexo generate` の生成物には混入しない**ことを確認（public/ を grep して live-reload / EventSource とも0件）。deploy.yml はそのまま安全
- `hexo server` ではファイル変更で `Reloading due to changes...` が発火し、SSE（/live-reload）でブラウザに通知されることを確認

## 変更内容

- `package.json` に devDependency として追加（設定はデフォルトのまま。`live_reload:` で delay 等の調整も可能）
- CLAUDE.md の `make s` の説明を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)