### PR TITLE
検索ボックスをヘッダー右上に昇格する

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2021,33 +2021,51 @@ input[name="tab_item"] {
   line-height: 1.6;
   vertical-align: middle;
 }
-.search-wrapper {
-  margin: 45px auto 50px auto;
+/* ヘッダー右上のサイト内検索 (#2399)。サイドバーから昇格し、全ページで同じ位置に出す。
+   .header は position: relative 指定済み。狭い幅では中央タイトルと重なるため、
+   通常フローに落としてタイトルの上に右寄せで出す */
+.header-search {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  display: flex;
 }
-.search-wrapper input {
-  width: 80%;
-  height: 40px;
-  padding: 10px 15px;
-  font: normal 16px 'Arial', 'Tahoma';
-  border: 1px solid #ccc;
-  border-radius: 8px 0 0 8px;
+.header-search input {
+  width: 200px;
+  height: 34px;
+  padding: 6px 12px;
+  font-size: 16px; /* 16px 未満だと iOS がフォーカス時に画面をズームする */
+  border: 0;
+  border-radius: 6px 0 0 6px;
+  background: rgba(255,255,255,0.92);
 }
-.search-wrapper button {
-  width: 20%;
-  height: 40px;
-  float: right;
+.header-search button {
+  display: flex;
+  align-items: center;
+  height: 34px;
+  padding: 0 10px;
   border: 0;
   cursor: pointer;
-  font: bold 18px 'Arial', 'Tahoma';
-  background: #c1c1c1;
-  border-radius: 0 8px 8px 0;
+  font-size: 16px; /* アイコン（.svg-icon = 1em）の実寸を決める */
+  color: #424242;
+  background: rgba(255,255,255,0.92);
+  border-radius: 0 6px 6px 0;
 }
-.search-wrapper button:hover,
-  .search-wrapper button:active,
-  .search-wrapper button:focus {
+.header-search button .svg-icon {
+  margin-right: 0;
+}
+.header-search button:hover,
+.header-search button:focus {
+  color: #fff;
   background: #1b95e0;
   transition: all 0.1s linear;
-  border: 0;
+}
+@media (max-width: 558px) {
+  .header-search {
+    position: static;
+    justify-content: flex-end;
+    padding: 8px 12px 0 0;
+  }
 }
 .blog-news {
   padding-top: 20px;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2057,14 +2057,26 @@ input[name="tab_item"] {
 .header-search button:hover,
 .header-search button:focus {
   color: #fff;
-  background: #1b95e0;
+  /* 青はページャーの選択色と同じ値に揃える */
+  background: #337ab7;
   transition: all 0.1s linear;
 }
 @media (max-width: 558px) {
   .header-search {
     position: static;
     justify-content: flex-end;
-    padding: 8px 12px 0 0;
+    padding: 6px 10px 0 0;
+  }
+  /* モバイルはヘッダーを圧迫しないよう小型化する。
+     font-size は 16px を割ると iOS がフォーカス時にズームするため維持 */
+  .header-search input {
+    width: 150px;
+    height: 30px;
+    padding: 4px 10px;
+  }
+  .header-search button {
+    height: 30px;
+    padding: 0 8px;
   }
 }
 .blog-news {

--- a/themes/future/layout/_partial/header.ejs
+++ b/themes/future/layout/_partial/header.ejs
@@ -3,6 +3,14 @@
 <header class="header" data-nosnippet>
 	<div class="header-overlay">
 		<div class="header-menu"></div>
+		<%# サイト内検索 (#2399)。全ページで使えるようサイドバーから昇格した。
+		    素の CSE フォームなので JS は増えない %>
+		<form action="https://google.com/cse" class="header-search">
+			<input type="text" name="q" placeholder="検索" aria-label="サイト内検索キーワード" />
+			<button type="submit" formtarget="_blank" name="sa" value="検索" aria-label="サイト内検索"><%- partial('svg-icon', {icon: 'search'}) %></button>
+			<input type="hidden" name="cx" value="7f77887fafdb7bb62" />
+			<input type="hidden" name="ie" value="UTF-8" />
+		</form>
 		<%# ホームではここがページの見出しそのものなので h1 にする。記事ページは
 		    記事タイトルが h1 なので div のまま。見た目は同じ %>
 		<% if (is_home()) { %>

--- a/themes/future/layout/_partial/sidebar.ejs
+++ b/themes/future/layout/_partial/sidebar.ejs
@@ -6,16 +6,7 @@
     レイアウトから specialsToc（[{id, text}]）を受け取って目次を組む (#2345)。
     目次を出すページではページ内移動が主なので、カテゴリ一覧は出さない %>
 <% const sToc = (typeof specialsToc === 'undefined') ? null : specialsToc; %>
-<% if (!is_post()) { %>
-<form id="cse-search-box" action="https://google.com/cse" class="search-wrapper">
-  <input type="text" name="q" placeholder="検索" />
-  <button type="submit" formtarget="_blank" name="sa" value="検索" aria-label="サイト内検索">
-    <span></span>
-  </button>
-  <input type="hidden" name="cx" value="7f77887fafdb7bb62" />
-  <input type="hidden" name="ie" value="UTF-8" />
-</form>
-<% } %>
+<%# 検索はヘッダー右上に昇格した (#2399)。二重の導線は置かない %>
 <% if (is_post()) { %>
 <section class="toc-section">
   <h2 class="margin-top-30">目次</h2>

--- a/themes/future/layout/_partial/svg-icon.ejs
+++ b/themes/future/layout/_partial/svg-icon.ejs
@@ -26,6 +26,7 @@ const SVG_ICON_PATHS = {
   'tag': ['M7.5 7.5m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0', 'M3 6v5.172a2 2 0 0 0 .586 1.414l7.71 7.71a2.41 2.41 0 0 0 3.408 0l5.592 -5.592a2.41 2.41 0 0 0 0 -3.408l-7.71 -7.71a2 2 0 0 0 -1.414 -.586h-5.172a3 3 0 0 0 -3 3z'],
   'calendar-stats': ['M11.795 21h-6.795a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v4', 'M18 14v4h4', 'M18 18m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0', 'M15 3v4', 'M7 3v4', 'M3 11h16'],
   'user': ['M8 7a4 4 0 1 0 8 0a4 4 0 0 0 -8 0', 'M6 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2'],
+  'search': ['M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0', 'M21 21l-6 -6'],
 };
 const svgPaths = SVG_ICON_PATHS[icon];
 %><% if (svgPaths) { %><svg class="svg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><% svgPaths.forEach(function(d){ %><path d="<%= d %>"/><% }) %></svg><% } %>


### PR DESCRIPTION
## 概要

検索ボックスをサイドバーからヘッダー右上に昇格し、記事ページを含む全ページで使えるようにする。

close #2399

## 背景

従来の検索はサイドバーにあり、しかも記事ページには出ていなかった（読者が最も長く滞在する場所に検索が無い）。ヘッダーは全ページ共通なので、右上常設で「どこでも検索」を満たす。

## 変更内容

- `header.ejs`: CSE フォーム（素の HTML form、JS 追加なし）をヘッダーに追加。虫眼鏡アイコンは svg-icon 辞書に `search` を追加して利用
- `sidebar.ejs`: 検索フォームを撤去（導線の二重化を避ける）
- CSS: 絶対配置で右上、狭い幅（≤558px）ではタイトルとの重なりを避けて通常フローの右寄せに落とす。入力は16pxにして iOS のフォーカスズームを回避。旧 `.search-wrapper` のスタイルは削除

## 確認

- トップ・記事ページ両方でヘッダー検索が出力され、サイドバーから消えていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)