### PR TITLE
ja-no-redundant-expression の dict3 / dict4 を無効化する

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -42,6 +42,12 @@
       "max-kanji-continuous-len": {
         "max": 10
       },
+      "ja-no-redundant-expression": {
+        "dictOptions": {
+          "dict3": { "disabled": true },
+          "dict4": { "disabled": true }
+        }
+      },
       "ja-no-successive-word": {
         "allow": [
           "/^[^\\p{L}\\p{N}]+$/u",


### PR DESCRIPTION
#2381 の一部です。`ja-no-redundant-expression` を**残して直す**方針にあたり、**筆者の留保まで削らせない**ための設定です。

```jsonc
"ja-no-redundant-expression": {
  "dictOptions": {
    "dict3": { "disabled": true },
    "dict4": { "disabled": true }
  }
}
```

## なぜ無効化するか

この2つの辞書は、以下を冗長表現として**削除**しようとします。

| 辞書 | 対象 | 修正案 |
| --- | --- | --- |
| `dict3` | `であると言えます` | `である` |
| `dict4` | `であると考えている` / `と考えています` | `である` |

```diff
- 重要な要素であると考えています。
+ 重要な要素である。
```

**「と考えています」は冗長表現ではなく筆者の留保**です。断定に変えると書き手の意図が変わります。

## 実際に壊れることを確認しました

`--fix` を全記事に当てて検証したところ、この2辞書が原因で**筆者の見解が断定に変わる修正が10行**入りました。

```diff
- 社会全体への貢献をしたいという思いがあると考えています。
+ 社会全体への貢献をしたいという思いがある。
```

なお `--fix` は他にも**文を壊す**ことが分かったので、このルールの修正は手作業で進めます（別PR）。

```diff
- フォーマットプロセスの改善のみで新規構文をサポート
+ フォーマットプロセスの改善できるこののみで新規構文をサポート

- - **工数削減と迅速化**
+ - できる工数削減と迅速化**
```

## 影響は12件のみ

`ja-no-redundant-expression` 1,791件の辞書別内訳です。

| 辞書 | 件数 | 例 | 扱い |
| --- | --- | --- | --- |
| `dict5` | 1,206 | `調査を行う` → `調査する` | 直す |
| `dict2` | 293 | `することはできず` → `できず` | 直す |
| `dict1` | 235 | `することが可能です` → `できます` | 直す |
| `dict6` | 45 | `検索を実行` → `検索する` | 直す |
| **`dict3`** | **6** | `であると言えます` | **本PRで無効化** |
| **`dict4`** | **6** | `であると考えている` | **本PRで無効化** |

対象は 1,791件 → **1,779件**になります。

## 検証

dict3/dict4 が出ていた11記事で再検査し、**0件**になることを確認しました。

## 次

残る1,779件を**年ごとのPR**で直します（2016年13件 〜 2021年348件）。最多は `〜を行う` → `〜する`（1,206件・68%）で、文字数削減に直結します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
