### PR TITLE
モバイルの検索を虫眼鏡アイコンに畳み、タップで展開する

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2061,22 +2061,46 @@ input[name="tab_item"] {
   background: #337ab7;
   transition: all 0.1s linear;
 }
+/* モバイル展開用の虫眼鏡ラベル。PC では入力欄が常時出ているので使わない */
+.header-search-open {
+  display: none;
+}
 @media (max-width: 558px) {
   .header-search {
     position: static;
     justify-content: flex-end;
+    align-items: center;
     padding: 6px 10px 0 0;
   }
-  /* モバイルはヘッダーを圧迫しないよう小型化する。
-     font-size は 16px を割ると iOS がフォーカス時にズームするため維持 */
+  /* モバイルは虫眼鏡アイコンだけを出し、タップ（label→input フォーカス）で
+     :focus-within により入力欄が展開する。JS は使わない。
+     送信はキーボードの検索キーが担うため、送信ボタンは出さない
+     （タップでの送信は Safari が button にフォーカスを与えず、
+     blur で先に閉じてしまうため成立しない） */
+  .header-search-open {
+    display: flex;
+    align-items: center;
+    margin: 0;
+    padding: 4px;
+    font-size: 20px;
+    color: #fff;
+    cursor: pointer;
+    filter: drop-shadow(0 1px 2px rgba(0,0,0,0.6));
+  }
   .header-search input {
-    width: 150px;
+    width: 0;
     height: 30px;
+    padding: 0;
+    opacity: 0;
+    transition: width 0.15s ease, opacity 0.15s ease;
+  }
+  .header-search:focus-within input {
+    width: 150px;
     padding: 4px 10px;
+    opacity: 1;
   }
   .header-search button {
-    height: 30px;
-    padding: 0 8px;
+    display: none;
   }
 }
 .blog-news {

--- a/themes/future/layout/_partial/header.ejs
+++ b/themes/future/layout/_partial/header.ejs
@@ -4,10 +4,13 @@
 	<div class="header-overlay">
 		<div class="header-menu"></div>
 		<%# サイト内検索 (#2399)。全ページで使えるようサイドバーから昇格した。
-		    素の CSE フォームなので JS は増えない %>
-		<form action="https://google.com/cse" class="header-search">
-			<input type="text" name="q" placeholder="検索" aria-label="サイト内検索キーワード" />
-			<button type="submit" formtarget="_blank" name="sa" value="検索" aria-label="サイト内検索"><%- partial('svg-icon', {icon: 'search'}) %></button>
+		    素の CSE フォームなので JS は増えない。
+		    モバイルは虫眼鏡だけ出し、label タップで入力欄にフォーカスして
+		    :focus-within で展開する（CSSのみ）。送信はキーボードの検索キーが担う %>
+		<form action="https://google.com/cse" target="_blank" class="header-search">
+			<label for="header-search-q" class="header-search-open" aria-label="検索を開く"><%- partial('svg-icon', {icon: 'search'}) %></label>
+			<input type="text" id="header-search-q" name="q" placeholder="検索" aria-label="サイト内検索キーワード" />
+			<button type="submit" aria-label="サイト内検索"><%- partial('svg-icon', {icon: 'search'}) %></button>
 			<input type="hidden" name="cx" value="7f77887fafdb7bb62" />
 			<input type="hidden" name="ie" value="UTF-8" />
 		</form>


### PR DESCRIPTION
## 概要

#2401 のレビュー続き（マージと追いコミットが行き違ったためフォローアップ）。モバイルのヘッダー検索を虫眼鏡アイコンだけに畳み、タップで入力欄が展開するようにする。

## 変更内容

- モバイル（≤558px）: 虫眼鏡ラベルのみ表示 → タップ（`label` → input フォーカス）→ `:focus-within` で入力欄が 150px にスライド展開（0.15s）。フォーカスが外れると畳まれる
- 送信はモバイルキーボードの検索キー（`target="_blank"` を form に移設）。Safari は button にフォーカスを与えず blur で先に閉じてしまうため、モバイルでは送信ボタンを出さない（コードコメントに記録）
- PC は従来どおり入力欄＋ボタン常設。JS は使わない

## 確認

- 開発サーバーで、モバイル幅のタップ展開 → 検索キー送信、PC 幅の従来動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)