### PR TITLE
#2404 推薦・パネル系の日付を年月までにする

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -187,12 +187,12 @@ hexo.extend.helper.register('doctor_checks', function () {
  * 見るためのツリー。複数親のノードはそれぞれの親の下に重複して出す
  * （DAG を1本の木に潰すと片方の系統から見えなくなる）。
  */
-hexo.extend.helper.register('doctor_ontology', function() {
+hexo.extend.helper.register('doctor_ontology', function () {
   const ontology = (this.site.data && this.site.data.tag_ontology) || {};
 
   const tagInfo = new Map(); // タグ名 -> {path, ids}
-  this.site.tags.forEach(tag => {
-    tagInfo.set(tag.name, {path: tag.path, ids: new Set(tag.posts.map(p => p._id))});
+  this.site.tags.forEach((tag) => {
+    tagInfo.set(tag.name, { path: tag.path, ids: new Set(tag.posts.map((p) => p._id)) });
   });
 
   const children = new Map();
@@ -207,7 +207,7 @@ hexo.extend.helper.register('doctor_ontology', function() {
 
   // バージョン同義（scripts/version_tags.js と同じ規則）。語幹ノードに「版」として出す
   const VERSIONED = /^(.+?)(\d+(?:\.\d+)+|\d{2,})$/;
-  const stemOf = name => {
+  const stemOf = (name) => {
     const node = ontology[name];
     if (node && node.notVersion) return null;
     if (node && node.versionOf) return node.versionOf;
@@ -245,27 +245,30 @@ hexo.extend.helper.register('doctor_ontology', function() {
       path: info ? info.path : null, // タグとして実在しない概念ノードはリンク先が無い
       posts: info ? info.ids.size : 0,
       family: familyIds(name, new Set([name])).size,
-      otherParents: ((ontology[name] || {}).broader || []).filter(p => p !== parentName),
+      otherParents: ((ontology[name] || {}).broader || []).filter((p) => p !== parentName),
       versions: (versionsByStem.get(name) || [])
         .sort((a, b) => (a < b ? 1 : -1)) // 新しい版を先に（名前の降順で近似）
-        .map(v => ({name: v, path: tagInfo.get(v).path, posts: tagInfo.get(v).ids.size})),
+        .map((v) => ({ name: v, path: tagInfo.get(v).path, posts: tagInfo.get(v).ids.size })),
       children: (children.get(name) || [])
-        .map(c => build(c, name))
+        .map((c) => build(c, name))
         .sort((a, b) => b.family - a.family || (a.name < b.name ? -1 : 1)),
     };
   };
 
   // versionOf ノード（Vue3 等）は語幹の「版」として出すので、木や独立タグには数えない
-  const roots = Object.keys(ontology)
-    .filter(n => !hasParent.has(n) && !(ontology[n] && ontology[n].versionOf));
-  const trees = roots.filter(n => children.has(n))
-    .map(n => build(n, null))
+  const roots = Object.keys(ontology).filter(
+    (n) => !hasParent.has(n) && !(ontology[n] && ontology[n].versionOf),
+  );
+  const trees = roots
+    .filter((n) => children.has(n))
+    .map((n) => build(n, null))
     .sort((a, b) => b.family - a.family || (a.name < b.name ? -1 : 1));
-  const standalone = roots.filter(n => !children.has(n))
-    .map(n => build(n, null))
+  const standalone = roots
+    .filter((n) => !children.has(n))
+    .map((n) => build(n, null))
     .sort((a, b) => b.posts - a.posts || (a.name < b.name ? -1 : 1));
 
-  return {trees, standalone, nodeCount: Object.keys(ontology).length};
+  return { trees, standalone, nodeCount: Object.keys(ontology).length };
 });
 
 /**
@@ -306,7 +309,11 @@ hexo.extend.helper.register('doctor_external_links', function () {
   const layoutDir = path.join(__dirname, '..', 'themes', 'future', 'layout');
   const findings = [];
 
-  const textOf = (inner) => inner.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+  const textOf = (inner) =>
+    inner
+      .replace(/<[^>]*>/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
 
   const scan = (file, content) => {
     // EJS 式は先に落とす。href の式が引用符を含むと属性の切り出しが壊れる

--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -94,7 +94,8 @@ hexo.extend.helper.register('popular_posts_in', function (posts, limit) {
       return (
         `<div class="col-12 col-md-6"><div class="article-card post-panel h-100">${thumb}` +
         `<div class="panel-body"><a href="/${post.path}" class="panel-title">${post.title}</a>` +
-        `<div class="panel-meta">${post.date.format('YYYY.MM.DD')}${snsLabel(post.permalink)}</div>` +
+        // 推薦カードの日付は鮮度の目安なので年月まで (#2404)
+        `<div class="panel-meta">${post.date.format('YYYY.MM')}${snsLabel(post.permalink)}</div>` +
         `</div></div></div>`
       );
     })

--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -28,21 +28,23 @@ hexo.extend.helper.register('get_ga4_pv', (url) => {
 hexo.extend.helper.register('recent_popular_tags', function (limit = 10, minRecent = 3) {
   const YEAR = 365 * 24 * 60 * 60 * 1000;
   const now = Date.now();
-  return this.site.tags
-    .map((tag) => {
-      const recent = tag.posts.toArray().filter((p) => now - p.date.valueOf() <= YEAR);
-      return {
-        name: tag.name,
-        path: tag.path,
-        count: tag.length,
-        recent: recent.length,
-        pv: recent.reduce((sum, p) => sum + getGA4PV('/' + p.path), 0),
-      };
-    })
-    .filter((t) => t.recent >= minRecent && t.pv > 0)
-    // 同点は名前で決める（決着が無いとビルドごとに並びが変わる）
-    .sort((a, b) => b.pv - a.pv || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
-    .slice(0, limit);
+  return (
+    this.site.tags
+      .map((tag) => {
+        const recent = tag.posts.toArray().filter((p) => now - p.date.valueOf() <= YEAR);
+        return {
+          name: tag.name,
+          path: tag.path,
+          count: tag.length,
+          recent: recent.length,
+          pv: recent.reduce((sum, p) => sum + getGA4PV('/' + p.path), 0),
+        };
+      })
+      .filter((t) => t.recent >= minRecent && t.pv > 0)
+      // 同点は名前で決める（決着が無いとビルドごとに並びが変わる）
+      .sort((a, b) => b.pv - a.pv || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+      .slice(0, limit)
+  );
 });
 
 // 推薦の件数は記事数から決める。推薦が全記事の半分を超えると

--- a/scripts/lib/post_list.js
+++ b/scripts/lib/post_list.js
@@ -39,7 +39,9 @@ const postListItem = (post, itemClass, titleAttr, withThumb = false, rank = null
   const body =
     `<a href="/${post.path}" title="${attr}">${post.title}</a>` +
     `${newLabel(post.date)}` +
-    `<span class="post-meta"><span class="post-meta-date">${post.date.format('YYYY.MM.DD')}</span>${snsLabel(post.permalink)}</span>`;
+    // 関連記事・ランキングの日付は鮮度の目安なので年月まで (#2404)。
+    // 日まで出すのは、日付が並びの座標になる時系列リストと記事自身だけ
+    `<span class="post-meta"><span class="post-meta-date">${post.date.format('YYYY.MM')}</span>${snsLabel(post.permalink)}</span>`;
   if (!withThumb) {
     return `<li class="${itemClass}">${rankLabel}${body}</li>`;
   }

--- a/scripts/version_tags.js
+++ b/scripts/version_tags.js
@@ -21,13 +21,13 @@
 
 const VERSIONED = /^(.+?)(\d+(?:\.\d+)+|\d{2,})$/;
 
-hexo.extend.filter.register('before_generate', async function() {
+hexo.extend.filter.register('before_generate', async function () {
   const data = this.locals.get('data') || {};
   const ontology = data.tag_ontology || {};
 
-  const tagNames = new Set(this.model('Tag').map(t => t.name));
+  const tagNames = new Set(this.model('Tag').map((t) => t.name));
 
-  const stemOf = name => {
+  const stemOf = (name) => {
     const node = ontology[name];
     if (node && node.notVersion) return null;
     if (node && node.versionOf) return node.versionOf;
@@ -38,7 +38,7 @@ hexo.extend.filter.register('before_generate', async function() {
   };
 
   for (const post of this.model('Post').toArray()) {
-    const names = post.tags.map(t => t.name);
+    const names = post.tags.map((t) => t.name);
     const add = new Set();
     for (const n of names) {
       const stem = stemOf(n);

--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -36,7 +36,8 @@
           </a>
           <div class="panel-body">
             <a href="<%- url_for(s.index.path) %>" class="panel-title"><%= s.name %></a>
-            <div class="panel-meta">全<%= s.total %>本・<%= date(s.latest, 'YYYY.MM.DD') %> 更新</div>
+            <%# 更新の日付は鮮度の目安なので年月まで (#2404)。/series/ の期間表記とも揃う %>
+            <div class="panel-meta">全<%= s.total %>本・<%= date(s.latest, 'YYYY.MM') %> 更新</div>
           </div>
         </div>
       </div>

--- a/themes/future/layout/_partial/post-panel-grid.ejs
+++ b/themes/future/layout/_partial/post-panel-grid.ejs
@@ -15,7 +15,8 @@
       <% } %>
       <div class="panel-body">
         <a href="<%- url_for(p.path) %>" class="panel-title"><%= p.title %></a>
-        <div class="panel-meta"><%= date(p.date, 'YYYY.MM.DD') %></div>
+        <%# 推薦パネルの日付は鮮度の目安なので年月まで (#2404) %>
+        <div class="panel-meta"><%= date(p.date, 'YYYY.MM') %></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Close #2404

## ルール（1文）

**日付が並びの座標になっている場所は日まで、鮮度の目安として添えるだけの場所は年月まで。**

## 変更（年月 YYYY.MM に短縮 — 推薦・パネル系4カ所）

| 箇所 | 例 |
| --- | --- |
| 関連記事・ランキングの行（post_list.js） | `2026.04` |
| よく読まれている記事カード（ga4_pv.js） | `2025.11` |
| 特設ページのパネル（post-panel-grid: guidelines / HTTF） | `2026.07` |
| トップ連載パネルの「更新」 | `全9本・2026.08 更新`（/series/ の期間表記とも揃う） |

読者が推薦系の日付から読み取るのは「新しいか古いか」だけで、日は判断を変えないため。

## 維持（YYYY.MM.DD のまま — 時系列リストと記事自身3カ所）

- 記事ページのメタ（発行日は引用・言及の基準。出版の慣行どおり）
- 一覧の記事行（archive-post）・すべての記事リスト（archive-all）：時系列リストでは日付が並びの座標。**月ページでは全行が同じ年月**になり、日を消すと日付欄が無情報になる

## 検証（ローカル）

7カ所すべてをページ実出力で確認：短縮4カ所が `YYYY.MM`、維持3カ所が `YYYY.MM.DD` のまま。

🤖 Generated with [Claude Code](https://claude.com/claude-code)