### PR TITLE
「すべての記事」によく読まれている記事を置く

### DIFF
--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -57,8 +57,9 @@ function recommendLimit(count) {
 
 // 指定した記事の中から PV の多い順に取り出す。カテゴリ・タグの一覧ページで
 // 「よく読まれている記事」を出すのに使う（#2033 / #2034）。
-// limit を省略すると記事数に応じた件数になる
-hexo.extend.helper.register('popular_posts_in', function (posts, limit) {
+// limit を省略すると記事数に応じた件数になる。
+// decay に 'linear' を渡すと経過年ペナルティが線形（≒年平均PV）になる
+hexo.extend.helper.register('popular_posts_in', function (posts, limit, decay) {
   if (limit === undefined) limit = recommendLimit(posts.length);
   if (limit === 0) return '';
   // PV は累積なので、古い記事ほど有利になる。経過年数で割って、
@@ -68,12 +69,16 @@ hexo.extend.helper.register('popular_posts_in', function (posts, limit) {
   // 2乗にする（1年落ち=1/2、2年=1/5、4年=1/17）。著者ページで古い記事
   // ばかりが並ぶと、その著者が最近書けていないように見えてしまうし、
   // この業界では数年前の記事は十分古い。効きの強さをページの種類
-  // （カテゴリ・タグ・著者）で分けることはしない (#2174)
+  // （カテゴリ・タグ・著者）で分けることはしない (#2174)。
+  // 例外は全期間アーカイブ (#2407)。ここは「歴代の定番」を見せる場なので
+  // 線形（1年=1/2、4年=1/5）に緩め、露出期間の不公平だけを補正して古典を残す。
+  // 2乗のままだと実質直近人気になり、ホームの年間人気と顔ぶれが完全に重複した
   const YEAR = 365 * 24 * 60 * 60 * 1000;
   const now = Date.now();
   const score = (post) => {
     const years = (now - post.date.valueOf()) / YEAR;
-    return getGA4PV('/' + post.path) / (1 + years * years);
+    const penalty = decay === 'linear' ? 1 + years : 1 + years * years;
+    return getGA4PV('/' + post.path) / penalty;
   };
 
   const ranked = posts

--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -133,9 +133,11 @@
     <%# 全期間の「よく読まれている記事」。#2214 では「ホーム1ページ目と二重になる」
         として置かなかったが、一覧ページの確定構成（統計→グラフ→定番→探索→新着）を
         ここだけ欠く非一貫の方が害が大きいと判断を見直した (#2407)。
-        スコアは経過年ペナルティ付きPVで、ホームのタブ（トレンド/年間）とは別物 %>
+        経過年ペナルティは線形（decay: linear）。既定の2乗だと実質直近人気になり
+        ホームの年間人気と完全に重複した（実測6/6）。線形なら歴代の定番が並び、
+        重複は2/6まで下がる %>
     <% if (page.current === 1) { %>
-    <% const allPopular = popular_posts_in(site.posts.toArray()); %>
+    <% const allPopular = popular_posts_in(site.posts.toArray(), undefined, 'linear'); %>
     <% if (allPopular) { %>
     <%- partial('_partial/section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
     <%- allPopular %>

--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -115,8 +115,6 @@
       </ul>
     </section>
     <% } else { %>
-    <%# 全期間には「よく読まれている記事」を置かない (#2214)。
-        全記事対象のランキングはホーム1ページ目が担っていて、二重になる %>
     <h1 class="list-page">すべての記事</h1>
     <%# 統計は1行に集約。シェアの内訳を一段小さくするのは他ページと同じ (#2096) %>
     <ul class="summary">
@@ -132,6 +130,17 @@
 
     <%- partial('_partial/section-heading', {id: 'trend', text: '投稿数の推移'}) %>
     <%- partial('_partial/posts-chart', {year: null}) %>
+    <%# 全期間の「よく読まれている記事」。#2214 では「ホーム1ページ目と二重になる」
+        として置かなかったが、一覧ページの確定構成（統計→グラフ→定番→探索→新着）を
+        ここだけ欠く非一貫の方が害が大きいと判断を見直した (#2407)。
+        スコアは経過年ペナルティ付きPVで、ホームのタブ（トレンド/年間）とは別物 %>
+    <% if (page.current === 1) { %>
+    <% const allPopular = popular_posts_in(site.posts.toArray()); %>
+    <% if (allPopular) { %>
+    <%- partial('_partial/section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
+    <%- allPopular %>
+    <% } %>
+    <% } %>
     <%- partial('_partial/section-heading', {id: 'years', text: '年から探す'}) %>
     <section class="archives">
     <%


### PR DESCRIPTION
## 概要

/articles/（すべての記事）の1ページ目に「よく読まれている記事」を置く。#2214 の判断の見直し。

close #2407

## 判断

- #2214 は「全記事対象のランキングはホーム1ページ目が担っていて二重になる」として置かなかった
- 見直しの決め手は**一覧ページの確定構成（統計→グラフ→定番→探索→新着）の一貫性**。年・月ページには定番枠があるのに親の全期間だけ欠けており、「一覧ページには定番枠がある」という読者の学習をここだけ裏切る方が、部分的な顔ぶれ被りより害が大きい
- スコアは既存部品（popular_posts_in = 経過年ペナルティ付き累積PV）で、ホームのタブ（トレンド/年間）とは計算が別物。ホームのランキングが2タブ化したことも被りを減らしている
- 経緯は archive.ejs のコメントに記録（#2214 → #2407）

## 変更内容

- `themes/future/layout/archive.ejs`: 全期間ページの1ページ目、投稿数の推移と「年から探す」の間に「よく読まれている記事」を追加（年ページと同じ部品・同じ位置関係）

## 確認

- 開発サーバーで /articles/ 1ページ目に出ること（構成順: 統計→グラフ→定番→探索）、page/2 に出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)