### PR TITLE
#2307 prettier --check を PR の CI に追加する

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,0 +1,38 @@
+# prettier の整形漏れを PR で検出する (#2307)。
+# 対象は JS（scripts/**/*.js とルートの *.mjs）だけ。記事 Markdown・EJS・Stylus は
+# .prettierignore で除外している。lint-staged（make lint）は手動実行のため
+# 通し忘れが起き、導入から数日で3ファイル漏れた実績がある。
+# paths フィルタにより、記事だけの PR ではこのジョブ自体が走らない。
+name: prettier
+
+on:
+  pull_request:
+    paths:
+      - "scripts/**"
+      - "*.mjs"
+      - ".prettierrc"
+      - ".prettierignore"
+      - "package.json"
+      - ".github/workflows/prettier.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run prettier --check
+        run: npx --no-install prettier --check "scripts/**/*.js" "*.mjs"


### PR DESCRIPTION
#2307 のフォローアップ。lint-staged（`make lint`）は手動実行のため通し忘れが起き、導入から数日で3ファイルの整形漏れが出た（#2411 で整形済み）。PR の CI で機械的に検出する。

## 記事編集で困らないことの確認

- **対象は JS（`scripts/**/*.js` とルートの `*.mjs`）だけ**。記事 Markdown は #2307 の判断で、EJS / Stylus は公式サポートが無いため、いずれも `.prettierignore` で除外済み
- さらに **paths フィルタで JS が変わった PR でしか走らない**。記事だけの PR では CI 実行時間も増えない
- 引っかかったときの直し方は `make fmt`（または `node_modules/.bin/prettier --write <file>`）

## 検証

- 現在の main 全ファイルが `prettier --check` を通過することを確認済み（初回から赤にならない）
- 次に scripts/ を触る PR でワークフローの実走が確認される

## 補足（環境）

リモートURL埋め込みのPATに `workflow` スコープが無く、ワークフローファイルのpushには gh CLI の認証（workflowスコープあり）を使った。今後もワークフロー編集時は同様の手当てが要る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)