### PR TITLE
#2413 著者一覧で、その年が初投稿の著者に NEW を付ける

### DIFF
--- a/scripts/author_generator.js
+++ b/scripts/author_generator.js
@@ -139,10 +139,14 @@ hexo.extend.helper.register('list_authors', function (year = 'all') {
         </li>`;
     };
   } else {
-    // 年指定の場合のロジック (従来通り)
+    // 年指定: その年が初投稿の著者に NEW を付ける (#2413)。
+    // 「1本目を踏み出してくれた新しい寄稿者数/年」という運営のキーメトリクスと
+    // 同じ定義。マークは記事一覧の NEW（.newitem）と同じ表現
+    const yearNum = Number(year);
+    const isNewIn = (author) => Math.min(...yearsByAuthor.get(author)) === yearNum;
     authorMapper = (author) => `
       <li class="author-list-item">
-        <a class="author-list-link" href="/authors/${author_to_url.call(this, author)}">${author}</a>
+        <a class="author-list-link" href="/authors/${author_to_url.call(this, author)}">${author}</a>${isNewIn(author) ? '<span class="newitem">NEW</span>' : ''}
         <span class="author-list-count">${count_posts(author)} 件</span>
       </li>`;
   }
@@ -162,6 +166,19 @@ hexo.extend.helper.register('count_authors', function (year = 'all') {
       ? this.site.posts
       : this.site.posts.filter((post) => post.date.format('YYYY') === year);
   return posts.map((post) => post.author).unique().length;
+});
+
+// その年が初投稿の著者数 (#2413)。振り返り記事で毎年数えている
+// 「1本目を踏み出してくれた新しい寄稿者数」と同じ定義
+hexo.extend.helper.register('count_new_authors', function (year) {
+  const yearNum = Number(year);
+  const firstYear = new Map();
+  this.site.posts.forEach((post) => {
+    const y = post.date.year();
+    const prev = firstYear.get(post.author);
+    if (prev === undefined || y < prev) firstYear.set(post.author, y);
+  });
+  return [...firstYear.values()].filter((y) => y === yearNum).length;
 });
 
 // 著者ページの傾向表示用 (#2082)。よく投稿するカテゴリ（上位3）と

--- a/scripts/author_generator.js
+++ b/scripts/author_generator.js
@@ -144,9 +144,11 @@ hexo.extend.helper.register('list_authors', function (year = 'all') {
     // 同じ定義。マークは記事一覧の NEW（.newitem）と同じ表現
     const yearNum = Number(year);
     const isNewIn = (author) => Math.min(...yearsByAuthor.get(author)) === yearNum;
+    // NEW は名前と同じ行（アンカー内の名前直後）に置く。リンクの外に置くと
+    // 2行目の件数の隣に折り返され、「件数が新しい」ように読めてしまう
     authorMapper = (author) => `
       <li class="author-list-item">
-        <a class="author-list-link" href="/authors/${author_to_url.call(this, author)}">${author}</a>${isNewIn(author) ? '<span class="newitem">NEW</span>' : ''}
+        <a class="author-list-link" href="/authors/${author_to_url.call(this, author)}">${author}${isNewIn(author) ? '<span class="newitem">NEW</span>' : ''}</a>
         <span class="author-list-count">${count_posts(author)} 件</span>
       </li>`;
   }

--- a/source/_posts/2026/20260319a_クラウド世代のITコンサルタントが『Data_Center』で物理インフラを体験してみた.md
+++ b/source/_posts/2026/20260319a_クラウド世代のITコンサルタントが『Data_Center』で物理インフラを体験してみた.md
@@ -9,7 +9,7 @@ tags:
 categories:
   - Infrastructure
 thumbnail: /images/2026/20260319a/thumbnail.png
-author: 片岡 久人
+author: 片岡久人
 lede: "今回は『Data Center』というゲームがリリースされ、一部界隈で話題になっていたので、プレイした感想をお話できればと思います。"
 ---
 ## 1. はじめに

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -98,6 +98,8 @@
         <div class="tab_content">
           <ul class="summary">
             <li><span class="summary-count"><%= count_authors(year.toString()) %></span><br><span class="summary-label">著者数</span></li>
+            <%# その年が初投稿の著者。一覧の NEW マークと同じ定義 (#2413) %>
+            <li><span class="summary-count"><%= count_new_authors(year.toString()) %></span><br><span class="summary-label">新規著者</span></li>
             <li><span class="summary-count"><%= count_articles_year(year.toString()) %></span><br><span class="summary-label">投稿</span></li>
           </ul>
           <%- list_authors(year.toString()) %>


### PR DESCRIPTION
Close #2413

## 概要

著者一覧（/authors/）の年タブで、**その年が初投稿の著者**に NEW マークを付ける。あわせて統計タイルに「新規著者」の人数を追加する。

## 設計判断

- **「新規」の定義＝初投稿の年**。同ページの「年別 著者数の推移」グラフの注記（※新規=初投稿）と同じ定義で、振り返り記事で毎年数えている「1本目を踏み出してくれた新しい寄稿者数」のキーメトリクスとも一致する
- マークは記事一覧の NEW と同じ部品（`.newitem`、枠線だけの控えめな表現）を再利用。新規CSSなし
- 過去の年タブでも「その年に新規だった人」が分かる（履歴としても一貫）
- **全期間タブには付けない**（全員がいつかは新規で、意味を持たない）
- タイル数とマーク数が全年で一致することを機械検証済み（2026: 16名 / 2025: 43名 / 2024: 30名 …）

## ついでの修正

NEW マークの検証中に著者名の表記ゆれを発見：**「片岡 久人」（空白入り・1記事）と「片岡久人」（2記事）が別著者として分裂**していたため、空白無しに統一した。

## 報告（このPRでは触っていない）

`author: admin` の記事が3本ある（Java連載2024・CNCF連載2025・Vue.js連載2025 の開始アナウンス）。運営名義として意図的なら現状維持で良いが、著者一覧に「admin（2件）」と出るのは見え方として微妙なので、方針があれば別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)