### PR TITLE
/authors/ に Best Blogger of the Year の受賞者一覧を出し、表彰の見せ方を揃える

### DIFF
--- a/scripts/awards.js
+++ b/scripts/awards.js
@@ -26,24 +26,34 @@ hexo.extend.helper.register('author_awards', function (author) {
 // /authors/ の表彰一覧 (#2409)。受賞バッジは著者ページにしか出ないため、
 // 顔ぶれを一覧で見る場所をここで作る。新人賞などの部門が増えたら
 // awards.yml に kind フィールドを足して拡張する。
-// nth はその年時点の累計受賞回数。2回目以降を括弧で強調し、
-// 殿堂入り（3回目）に達した年にだけ称号を添える
+//
+// 返すのは2つ。hall は殿堂入り（3回受賞）で、年1回の表彰の主役なので
+// 一覧では大きく扱う。years は年ごとの受賞者で、殿堂入りの人も
+// その年の記録として含める（記録から人を抜くと年の顔ぶれが嘘になる）。
+// nth はその年時点の累計受賞回数
 hexo.extend.helper.register('awards_list', function () {
   const rows = (this.site.data && this.site.data.awards) || [];
-  const nth = new Map(); // `${year}\t${author}` -> その年時点の回数
-  const wins = new Map();
+  const yearsByAuthor = new Map();
   for (const r of rows.slice().sort((a, b) => a.year - b.year)) {
-    const n = (wins.get(r.author) || 0) + 1;
-    wins.set(r.author, n);
-    nth.set(r.year + '\t' + r.author, n);
+    if (!yearsByAuthor.has(r.author)) yearsByAuthor.set(r.author, []);
+    yearsByAuthor.get(r.author).push(r.year);
   }
+
   const byYear = new Map();
   for (const r of rows) {
     if (!byYear.has(r.year)) byYear.set(r.year, []);
-    const n = nth.get(r.year + '\t' + r.author);
-    byYear.get(r.year).push({ name: r.author, nth: n, hall: n === HALL_OF_FAME_WINS });
+    const nth = yearsByAuthor.get(r.author).indexOf(r.year) + 1;
+    byYear.get(r.year).push({ name: r.author, nth });
   }
-  return [...byYear.entries()]
+  const years = [...byYear.entries()]
     .sort((a, b) => b[0] - a[0])
     .map(([year, authors]) => ({ year, authors }));
+
+  const hall = [...yearsByAuthor.entries()]
+    .filter(([, ys]) => ys.length >= HALL_OF_FAME_WINS)
+    // 到達が早い順（同数なら名前）に並べる
+    .sort((a, b) => a[1][HALL_OF_FAME_WINS - 1] - b[1][HALL_OF_FAME_WINS - 1])
+    .map(([author, ys]) => ({ author, years: ys, wins: ys.length }));
+
+  return { hall, years };
 });

--- a/scripts/awards.js
+++ b/scripts/awards.js
@@ -22,3 +22,24 @@ hexo.extend.helper.register('author_awards', function (author) {
   if (years.length === 0) return null;
   return { years, hallOfFame: years.length >= HALL_OF_FAME_WINS };
 });
+
+// /authors/ の表彰一覧 (#2409)。受賞バッジは著者ページにしか出ないため、
+// 顔ぶれを一覧で見る場所をここで作る。新人賞などの部門が増えたら
+// awards.yml に kind フィールドを足して拡張する
+hexo.extend.helper.register('awards_list', function () {
+  const rows = (this.site.data && this.site.data.awards) || [];
+  const byYear = new Map();
+  const wins = new Map();
+  for (const r of rows) {
+    if (!byYear.has(r.year)) byYear.set(r.year, []);
+    byYear.get(r.year).push(r.author);
+    wins.set(r.author, (wins.get(r.author) || 0) + 1);
+  }
+  const years = [...byYear.entries()]
+    .sort((a, b) => b[0] - a[0])
+    .map(([year, authors]) => ({ year, authors }));
+  const hallOfFame = [...wins.entries()]
+    .filter(([, n]) => n >= HALL_OF_FAME_WINS)
+    .map(([author, n]) => ({ author, wins: n }));
+  return { years, hallOfFame };
+});

--- a/scripts/awards.js
+++ b/scripts/awards.js
@@ -25,21 +25,25 @@ hexo.extend.helper.register('author_awards', function (author) {
 
 // /authors/ の表彰一覧 (#2409)。受賞バッジは著者ページにしか出ないため、
 // 顔ぶれを一覧で見る場所をここで作る。新人賞などの部門が増えたら
-// awards.yml に kind フィールドを足して拡張する
+// awards.yml に kind フィールドを足して拡張する。
+// nth はその年時点の累計受賞回数。2回目以降を括弧で強調し、
+// 殿堂入り（3回目）に達した年にだけ称号を添える
 hexo.extend.helper.register('awards_list', function () {
   const rows = (this.site.data && this.site.data.awards) || [];
-  const byYear = new Map();
+  const nth = new Map(); // `${year}\t${author}` -> その年時点の回数
   const wins = new Map();
+  for (const r of rows.slice().sort((a, b) => a.year - b.year)) {
+    const n = (wins.get(r.author) || 0) + 1;
+    wins.set(r.author, n);
+    nth.set(r.year + '\t' + r.author, n);
+  }
+  const byYear = new Map();
   for (const r of rows) {
     if (!byYear.has(r.year)) byYear.set(r.year, []);
-    byYear.get(r.year).push(r.author);
-    wins.set(r.author, (wins.get(r.author) || 0) + 1);
+    const n = nth.get(r.year + '\t' + r.author);
+    byYear.get(r.year).push({ name: r.author, nth: n, hall: n === HALL_OF_FAME_WINS });
   }
-  const years = [...byYear.entries()]
+  return [...byYear.entries()]
     .sort((a, b) => b[0] - a[0])
     .map(([year, authors]) => ({ year, authors }));
-  const hallOfFame = [...wins.entries()]
-    .filter(([, n]) => n >= HALL_OF_FAME_WINS)
-    .map(([author, n]) => ({ author, wins: n }));
-  return { years, hallOfFame };
 });

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1850,6 +1850,21 @@ a.series-nav-item:hover .series-nav-item-title {
   padding: 0;
   list-style: none;
 }
+/* /authors/ の表彰一覧 (#2409)。年ラベル + 受賞者リンクの行 */
+.award-years {
+  margin: 12px 0 0;
+  padding-left: 0;
+  list-style: none;
+}
+.award-years li {
+  padding: 4px 0;
+  font-size: 1.2em; /* 本文相当。.article-entry 外なので明示 */
+}
+.award-years .award-year {
+  display: inline-block;
+  min-width: 5em;
+  color: #777;
+}
 /* 受賞年のバッジはグレースケール。金は殿堂入りだけに使い、称号の格を色で分ける
    （灰アイコン#6e6e6e: 対 淡灰#f5f5f5 4.68。AA充足） */
 .award-badge {

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1850,25 +1850,154 @@ a.series-nav-item:hover .series-nav-item-title {
   padding: 0;
   list-style: none;
 }
-/* /authors/ の表彰一覧 (#2409)。年ラベル + 受賞者リンクの行 */
+/* /authors/ の表彰一覧 (#2409)。
+   金は #7a5f16 を使う。既存バッジの #8a6d1a は淡金の地（#f7edcf）に対して
+   4.19 で AA を割るため、この面では一段濃い金にする（対 #f7edcf 5.17、対白 6.04）。
+   Webフォントも画像も足さず、色と余白と既存アイコンだけで祝いの場を作る */
+.awards-hall {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin: 20px 0 28px;
+}
+.awards-hall-card {
+  flex: 1 1 260px;
+  max-width: 400px;
+  padding: 18px 22px;
+  border: 1px solid #e8dcb0;
+  border-radius: 10px;
+  /* 淡い金のグラデーション。単色より奥行きが出て、賞状の紙の質感に寄る */
+  background: linear-gradient(135deg, #fdf9ec, #f7edcf);
+  box-shadow: 0 2px 10px rgba(122,95,22,0.12);
+}
+.awards-hall-label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 1em;
+  font-weight: bold;
+  color: #7a5f16;
+  /* 称号は字間を開けて記章らしく見せる */
+  letter-spacing: 0.12em;
+}
+.awards-hall-label .svg-icon {
+  width: 1.25em;
+  height: 1.25em;
+  margin-right: 0;
+}
+.awards-hall-name {
+  display: block;
+  margin: 8px 0 12px;
+  font-size: 1.9em;
+  font-weight: bold;
+  color: #3d3d3d;
+  text-decoration: none;
+}
+.awards-hall-name:hover,
+.awards-hall-name:focus {
+  color: #3d3d3d;
+  text-decoration: underline;
+}
+/* 受賞年は「メダル＋年」を並べる。回数が視覚的な量として伝わる */
+.awards-hall-years {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.awards-hall-medal {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px 10px 3px 8px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.75);
+  font-size: 0.95em;
+  font-weight: bold;
+  color: #7a5f16;
+}
+.awards-hall-medal .svg-icon {
+  width: 1.1em;
+  height: 1.1em;
+  margin-right: 0;
+}
+/* メダルの色は回数で決まる。規則は .award-medal（部品側）が1箇所で持つ */
+/* 各年の記録。左に年、右に受賞者チップ */
 .award-years {
-  margin: 12px 0 0;
+  margin: 0;
   padding-left: 0;
   list-style: none;
 }
 .award-years li {
-  padding: 4px 0;
-  font-size: 1.2em; /* 本文相当。.article-entry 外なので明示 */
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  padding: 8px 0;
+  border-top: 1px solid #ecebeb;
+}
+.award-years li:last-child {
+  border-bottom: 1px solid #ecebeb;
 }
 .award-years .award-year {
-  display: inline-block;
-  min-width: 5em;
-  color: #777;
+  flex: none;
+  min-width: 3.2em;
+  font-size: 1.5em;
+  font-weight: bold;
+  color: #9b9b9b;
+  letter-spacing: -0.01em;
 }
-/* 受賞回数の注釈は補足情報なので、名前より一段小さく淡くする */
-.award-years .award-note {
-  font-size: 0.85em;
-  color: #777;
+.award-years .award-winners {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+/* チップは著者ページの受賞バッジ（.award-badge）と同じ形。ページをまたいで
+   同じものが同じ見た目になるようにする */
+.award-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 12px;
+  border: 1px solid #ddd;
+  border-radius: 999px;
+  background: #f5f5f5;
+  font-size: 1.15em;
+  color: #424242;
+  text-decoration: none;
+}
+/* メダルの円の中に受賞回数が入る（award-medal.ejs）。
+   数字が読める大きさが必要なので、他のアイコンより一段大きくする。
+   メダルだけ金にして名前の文字色と分ける。表彰の場なので徽章に色を持たせる
+   （#8a6d1a 対 灰地 #f5f5f5 は 4.50。文字基準でも AA を満たす） */
+/* チップの地は回数によらず灰のまま。回数はメダルの色だけで表す
+   （地の色まで変えると一覧が賑やかになりすぎ、記録として読みにくい）。
+   メダルの数字が読める大きさが要るので、他のアイコンより一段大きくする */
+.award-chip .svg-icon {
+  width: 1.35em;
+  height: 1.35em;
+  margin-right: 0;
+}
+/* 受賞メダルの色は「何回目の受賞か」で決まる (#2409)。/authors/ の一覧でも
+   著者ページのバッジでも同じ規則が効くよう、部品のクラスに持たせる。
+   淡金の地（殿堂カード #f7edcf）と灰地（チップ #f5f5f5）の両方で AA を満たす値:
+   灰 #666 4.91 / 銅 #a05a2b 4.50 / 金 #7a5f16 5.17（いずれも淡金地での比）。
+   金は彩度が低く線の細さのままだと隣の銅に負けるので、線だけ太くして
+   目方で勝たせる（塗ると質感が浮いて他のメダルと別物に見える） */
+.award-medal {
+  color: #666;
+}
+.award-medal-2 {
+  color: #a05a2b;
+}
+.award-medal-3 {
+  color: #7a5f16;
+  stroke-width: 2.6;
+}
+.award-chip:hover,
+.award-chip:focus {
+  border-color: #c9c9c9;
+  background: #ececec;
+  color: #424242;
+  text-decoration: none;
 }
 /* 受賞年のバッジはグレースケール。金は殿堂入りだけに使い、称号の格を色で分ける
    （灰アイコン#6e6e6e: 対 淡灰#f5f5f5 4.68。AA充足） */
@@ -1883,8 +2012,14 @@ a.series-nav-item:hover .series-nav-item-title {
   font-weight: bold;
 }
 .award-badge svg {
-  color: #6e6e6e;
   flex: none;
+}
+/* アイコンは共有部品（.svg-icon）。バッジは gap で間隔を取るので、
+   部品側の右マージンは打ち消す */
+.award-badge .svg-icon {
+  width: 1.15em;
+  height: 1.15em;
+  margin-right: 0;
 }
 /* 殿堂入り（3回受賞）だけ金（#8a6d1a: 対 白文字 4.90。AA充足） */
 .award-badge-hall {

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1865,6 +1865,11 @@ a.series-nav-item:hover .series-nav-item-title {
   min-width: 5em;
   color: #777;
 }
+/* 受賞回数の注釈は補足情報なので、名前より一段小さく淡くする */
+.award-years .award-note {
+  font-size: 0.85em;
+  color: #777;
+}
 /* 受賞年のバッジはグレースケール。金は殿堂入りだけに使い、称号の格を色で分ける
    （灰アイコン#6e6e6e: 対 淡灰#f5f5f5 4.68。AA充足） */
 .award-badge {

--- a/themes/future/layout/_partial/award-medal.ejs
+++ b/themes/future/layout/_partial/award-medal.ejs
@@ -1,0 +1,14 @@
+<%# 受賞メダル (#2409)。nth を渡すとメダルの円の中にその数字を描く。
+    「2回目」と文字で添えるとノイズになるため、回数はメダル自体に持たせる。
+    ベースは Tabler Icons の award（MIT）。円は中心 (12,9)・半径6なので、
+    数字はその中心に置く。svg-icon.ejs は辞書式でテキストを持てないため別部品 %>
+<%# 色は回数で決まる（灰→銅→金）。クラスに持たせて、置き場所（一覧・著者ページ）が
+    変わっても同じ規則が効くようにする %>
+<svg class="svg-icon award-medal<%= (typeof nth !== 'undefined' && nth >= 2) ? ' award-medal-' + Math.min(nth, 3) : '' %>" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+  <path d="M12 9m-6 0a6 6 0 1 0 12 0a6 6 0 1 0 -12 0"/>
+  <path d="M12 15l3.4 5.89l1.598 -3.233l3.598 .232l-3.4 -5.889"/>
+  <path d="M6.802 12l-3.4 5.89l3.598 -.233l1.598 3.232l3.4 -5.889"/>
+  <% if (typeof nth !== 'undefined' && nth) { %>
+  <text x="12" y="9" text-anchor="middle" dominant-baseline="central" font-size="9" font-weight="bold" fill="currentColor" stroke="none"><%= nth %></text>
+  <% } %>
+</svg>

--- a/themes/future/layout/_partial/svg-icon.ejs
+++ b/themes/future/layout/_partial/svg-icon.ejs
@@ -27,6 +27,12 @@ const SVG_ICON_PATHS = {
   'calendar-stats': ['M11.795 21h-6.795a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v4', 'M18 14v4h4', 'M18 18m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0', 'M15 3v4', 'M7 3v4', 'M3 11h16'],
   'user': ['M8 7a4 4 0 1 0 8 0a4 4 0 0 0 -8 0', 'M6 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2'],
   'search': ['M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0', 'M21 21l-6 -6'],
+  'crown': ['M12 6l4 6l5 -4l-2 10h-14l-2 -10l5 4z'],
+  'award': [
+    'M12 9m-6 0a6 6 0 1 0 12 0a6 6 0 1 0 -12 0',
+    'M12 15l3.4 5.89l1.598 -3.233l3.598 .232l-3.4 -5.889',
+    'M6.802 12l-3.4 5.89l3.598 -.233l1.598 3.232l3.4 -5.889',
+  ],
 };
 const svgPaths = SVG_ICON_PATHS[icon];
 %><% if (svgPaths) { %><svg class="svg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><% svgPaths.forEach(function(d){ %><path d="<%= d %>"/><% }) %></svg><% } %>

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -37,20 +37,23 @@
       <%# 表彰の記録 (#2149)。受賞者のページにだけパネルが出る。
           機械算出のバッジは付けない方針（理由は scripts/awards.js）。
           受賞年を1つずつメダルのバッジで出し、殿堂入り（3回受賞）は
-          濃い金の別バッジで格を分ける %>
+          濃い金の別バッジで格を分ける。
+          アイコンは /authors/ の表彰一覧と同じ部品を使い、殿堂入りは王冠、
+          受賞年はメダルで揃える (#2409) %>
       <% const awards = author_awards(page.author); %>
       <% if (awards) { %>
-      <% const medal = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="8" r="7"/><path d="M8.21 13.89 7 23l5-3 5 3-1.21-9.11"/></svg>'; %>
       <section class="summary-panel">
         <span class="summary-panel-label">表彰</span>
         <p class="award-name">Best Blogger of the Year</p>
         <%# 殿堂入り（最上位の称号）を先頭に、受賞年は新しい順 %>
         <ul class="award-badges">
           <% if (awards.hallOfFame) { %>
-          <li class="award-badge award-badge-hall"><%- medal %>殿堂入り</li>
+          <li class="award-badge award-badge-hall"><%- partial('_partial/svg-icon', {icon: 'crown'}) %>殿堂入り</li>
           <% } %>
-          <% awards.years.forEach(function(y){ %>
-          <li class="award-badge"><%- medal %><%= y %></li>
+          <%# years は新しい順。メダルの色・数字は「何回目の受賞か」で決まるので、
+              古い方から数え直して渡す %>
+          <% awards.years.forEach(function(y, i){ %>
+          <li class="award-badge"><%- partial('_partial/award-medal', {nth: awards.years.length - i}) %><%= y %></li>
           <% }) %>
         </ul>
       </section>

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -90,14 +90,11 @@
           顔ぶれを一覧で見る場所がなかった。データは awards.yml 一元。
           並びは確定構成の「定番」枠に相当する位置（グラフの後・一覧の前） %>
       <%- partial('_partial/section-heading', {id: 'awards', text: 'Best Blogger of the Year'}) %>
-      ※社外に影響を与えた記事を執筆した著者を年1回表彰する取り組み（2020年〜）。累計3回の受賞で殿堂入り
-      <% const awards = awards_list(); %>
+      <%# .specials-text は名前こそ特設ページ由来だが実体は「本文サイズの地の文」 %>
+      <p class="specials-text">Best Blogger of the Year は、社外に影響を与えた記事を執筆した著者を年1回表彰する取り組みです。累計3回の受賞で殿堂入りします。</p>
       <ul class="award-years">
-        <% if (awards.hallOfFame.length) { %>
-        <li><span class="award-year">殿堂入り</span><% awards.hallOfFame.forEach(function(h, i){ %><a href="<%- url_for('authors/' + h.author + '/') %>"><%= h.author %></a>（<%= h.wins %>回）<%= i < awards.hallOfFame.length - 1 ? '・' : '' %><% }) %></li>
-        <% } %>
-        <% awards.years.forEach(function(y){ %>
-        <li><span class="award-year"><%= y.year %>年</span><% y.authors.forEach(function(a, i){ %><a href="<%- url_for('authors/' + a + '/') %>"><%= a %></a><%= i < y.authors.length - 1 ? '・' : '' %><% }) %></li>
+        <% awards_list().forEach(function(y){ %>
+        <li><span class="award-year"><%= y.year %>年</span><% y.authors.forEach(function(a, i){ %><a href="<%- url_for('authors/' + a.name + '/') %>"><%= a.name %></a><% if (a.nth >= 2) { %><strong>（<%= a.nth %>回目<%= a.hall ? ': 殿堂入り' : '' %>）</strong><% } %><%= i < y.authors.length - 1 ? '・' : '' %><% }) %></li>
         <% }) %>
       </ul>
 

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -94,7 +94,7 @@
       <p class="specials-text">Best Blogger of the Year は、社外に影響を与えた記事を執筆した著者を年1回表彰する取り組みです。累計3回の受賞で殿堂入りします。</p>
       <ul class="award-years">
         <% awards_list().forEach(function(y){ %>
-        <li><span class="award-year"><%= y.year %>年</span><% y.authors.forEach(function(a, i){ %><a href="<%- url_for('authors/' + a.name + '/') %>"><%= a.name %></a><% if (a.nth >= 2) { %><strong>（<%= a.nth %>回目<%= a.hall ? ': 殿堂入り' : '' %>）</strong><% } %><%= i < y.authors.length - 1 ? '・' : '' %><% }) %></li>
+        <li><span class="award-year"><%= y.year %>年</span><% y.authors.forEach(function(a, i){ %><a href="<%- url_for('authors/' + a.name + '/') %>"><%= a.name %></a><% if (a.nth >= 2) { %>（<%= a.nth %>回目<%= a.hall ? ': 殿堂入り' : '' %>）<% } %><%= i < y.authors.length - 1 ? '・' : '' %><% }) %></li>
         <% }) %>
       </ul>
 

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -94,7 +94,7 @@
       <p class="specials-text">Best Blogger of the Year は、社外に影響を与えた記事を執筆した著者を年1回表彰する取り組みです。累計3回の受賞で殿堂入りします。</p>
       <ul class="award-years">
         <% awards_list().forEach(function(y){ %>
-        <li><span class="award-year"><%= y.year %>年</span><% y.authors.forEach(function(a, i){ %><a href="<%- url_for('authors/' + a.name + '/') %>"><%= a.name %></a><% if (a.nth >= 2) { %>（<%= a.nth %>回目<%= a.hall ? ': 殿堂入り' : '' %>）<% } %><%= i < y.authors.length - 1 ? '・' : '' %><% }) %></li>
+        <li><span class="award-year"><%= y.year %>年</span><% y.authors.forEach(function(a, i){ %><a href="<%- url_for('authors/' + a.name + '/') %>"><%= a.name %></a><% if (a.nth >= 2) { %><span class="award-note">（<%= a.nth %>回目<%= a.hall ? ': 殿堂入り' : '' %>）</span><% } %><%= i < y.authors.length - 1 ? '・' : '' %><% }) %></li>
         <% }) %>
       </ul>
 

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -92,9 +92,31 @@
       <%- partial('_partial/section-heading', {id: 'awards', text: 'Best Blogger of the Year'}) %>
       <%# .specials-text は名前こそ特設ページ由来だが実体は「本文サイズの地の文」 %>
       <p class="specials-text">Best Blogger of the Year は、社外に影響を与えた記事を執筆した著者を年1回表彰する取り組みです。累計3回の受賞で殿堂入りします。</p>
+      <% const awards = awards_list(); %>
+      <%# 殿堂入りは年1回の表彰の主役なので、金のカードで大きく称える。
+          各年の受賞者は著者ページのバッジと同じチップで淡々と並べ、
+          主役と記録の役割を分ける %>
+      <% if (awards.hall.length) { %>
+      <div class="awards-hall">
+        <% awards.hall.forEach(function(h){ %>
+        <div class="awards-hall-card">
+          <span class="awards-hall-label"><%- partial('_partial/svg-icon', {icon: 'crown'}) %>殿堂入り</span>
+          <a class="awards-hall-name" href="<%- url_for('authors/' + h.author + '/') %>"><%= h.author %></a>
+          <span class="awards-hall-years"><% h.years.forEach(function(y, i){ %><span class="awards-hall-medal"><%- partial('_partial/award-medal', {nth: i + 1}) %><%= y %></span><% }) %></span>
+        </div>
+        <% }) %>
+      </div>
+      <% } %>
       <ul class="award-years">
-        <% awards_list().forEach(function(y){ %>
-        <li><span class="award-year"><%= y.year %>年</span><% y.authors.forEach(function(a, i){ %><a href="<%- url_for('authors/' + a.name + '/') %>"><%= a.name %></a><% if (a.nth >= 2) { %><span class="award-note">（<%= a.nth %>回目<%= a.hall ? ': 殿堂入り' : '' %>）</span><% } %><%= i < y.authors.length - 1 ? '・' : '' %><% }) %></li>
+        <% awards.years.forEach(function(y){ %>
+        <li>
+          <span class="award-year"><%= y.year %></span>
+          <span class="award-winners">
+            <% y.authors.forEach(function(a){ %>
+            <a class="award-chip<%= a.nth >= 3 ? ' award-chip-hall' : (a.nth === 2 ? ' award-chip-repeat' : '') %>" href="<%- url_for('authors/' + a.name + '/') %>" title="<%= a.name %>（<%= a.nth %>回目の受賞）"><%- partial('_partial/award-medal', {nth: a.nth >= 2 ? a.nth : null}) %><%= a.name %></a>
+            <% }) %>
+          </span>
+        </li>
         <% }) %>
       </ul>
 

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -86,6 +86,21 @@
         myChart.setOption(option);
       </script>
 
+      <%# 表彰の一覧 (#2409)。受賞バッジは著者ページ (#2149) にしか出ず、
+          顔ぶれを一覧で見る場所がなかった。データは awards.yml 一元。
+          並びは確定構成の「定番」枠に相当する位置（グラフの後・一覧の前） %>
+      <%- partial('_partial/section-heading', {id: 'awards', text: 'Best Blogger of the Year'}) %>
+      ※社外に影響を与えた記事を執筆した著者を年1回表彰する取り組み（2020年〜）。累計3回の受賞で殿堂入り
+      <% const awards = awards_list(); %>
+      <ul class="award-years">
+        <% if (awards.hallOfFame.length) { %>
+        <li><span class="award-year">殿堂入り</span><% awards.hallOfFame.forEach(function(h, i){ %><a href="<%- url_for('authors/' + h.author + '/') %>"><%= h.author %></a>（<%= h.wins %>回）<%= i < awards.hallOfFame.length - 1 ? '・' : '' %><% }) %></li>
+        <% } %>
+        <% awards.years.forEach(function(y){ %>
+        <li><span class="award-year"><%= y.year %>年</span><% y.authors.forEach(function(a, i){ %><a href="<%- url_for('authors/' + a + '/') %>"><%= a %></a><%= i < y.authors.length - 1 ? '・' : '' %><% }) %></li>
+        <% }) %>
+      </ul>
+
       <%# 全年を縦に並べると16セクションになるが、普段見るのは今年だけなので
           タブで切り替える。既定は今年 (#2073)。ランキングと同じ radio + label 方式 %>
       <div class="nav tabs year-tabs">


### PR DESCRIPTION
## 概要

Best Blogger of the Year の受賞者の顔ぶれを /authors/（著者一覧）で見られるようにする。あわせて表彰の見せ方を作り直し、著者ページと規則を揃える。

close #2409

## 変更内容

### /authors/ に表彰セクションを新設

- **殿堂入り**（3回受賞）は金のカードで大きく称える。受賞年をメダル付きで並べ、積み上がりが見えるようにした
- **各年の記録**は年表形式。受賞者は著者ページと同じ形のチップで並べる（殿堂入りの人もその年の記録として含める）
- ヘルパー `awards_list` を追加。データは awards.yml 一元のまま

### 受賞回数の表し方

- メダルの円の中に回数の数字を描き、色で段階を出す（1回目=灰 / 2回目=銅 / 3回目=金）。「2回目」と文字で添える案・チップの地を塗り分ける案はノイズが多く見送り
- 金は彩度が低く線が細いままだと銅に負けるため、線幅だけ太くして格を出す（塗りつぶしは質感が浮くため不採用）
- 色は淡金地・灰地の両方で AA を満たす値: 灰 #666 4.91 / 銅 #a05a2b 4.50 / 金 #7a5f16 5.17

### 部品の共通化

- メダルを `_partial/award-medal.ejs` に切り出し、**色の規則も部品側の1箇所**に集約。一覧・殿堂カード・著者ページのどこに置いても同じ規則が効く
- 著者ページの殿堂入りバッジをメダル→**王冠**に変更し、一覧と揃えた。author.ejs にあったインラインSVGの重複も解消
- svg-icon 辞書に crown / award を追加

Webフォント・外部JS・画像の追加なし。新人賞など部門が増える場合は awards.yml に `kind` を足して拡張する前提。

## 確認

- /authors/ と著者ページ（澁川喜規・原木翔）で、殿堂カード・年表チップ・バッジの表示とメダルの色分けを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)