### PR TITLE
ホームの特設ページ枠に HACK TO THE FUTURE を追加する

### DIFF
--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -47,12 +47,13 @@
     <p class="more-link"><a href="/series/">すべての連載を見る</a></p>
   </section>
 <% } %>
-  <%# 設計ガイドライン等の外部資産への統一入口 (#2295)。テキスト1行では視線が
-      滑るためパネルにする (#2343)。外部サイトへ直接飛ばす3枚構成はやめ、
-      サイト内の /specials/guidelines/ ポータルを紹介する1枚に絞る。一覧の説明と
-      外部サイトへの分岐はポータル側が担う %>
+  <%# 特設ページへの入口 (#2295 / #2421)。テキスト1行では視線が滑るため
+      パネルにする (#2343)。外部サイトへ直接飛ばさず、サイト内のポータルを
+      紹介する（説明と外部サイトへの分岐はポータル側が担う）。
+      ページが増えたらここに列を足す。3枚を超えたら /specials/ への
+      導線1本にまとめる %>
   <section class="series-panels">
-    <%- partial('section-heading', {id: 'guidelines', text: 'ガイドラインから学ぶ'}) %>
+    <%- partial('section-heading', {id: 'specials', text: '特設ページ'}) %>
     <div class="row g-4">
       <div class="col-12 col-md-6">
         <div class="article-card series-panel h-100">
@@ -62,6 +63,18 @@
           <div class="panel-body">
             <a href="/specials/guidelines/" class="panel-title">フューチャーのガイドライン</a>
             <div class="panel-meta">設計ガイドライン・コーディング規約・TypeScript 教材の入口です。</div>
+          </div>
+        </div>
+      </div>
+      <div class="col-12 col-md-6">
+        <div class="article-card series-panel h-100">
+          <%# ロゴは切り抜くと欠けるので contain 表示 %>
+          <a href="/specials/httf/" title="HACK TO THE FUTURE" class="img_wrap panel-thumb panel-thumb-contain">
+            <img src="/httf_logo.png" alt="" width="640" height="280" loading="lazy">
+          </a>
+          <div class="panel-body">
+            <a href="/specials/httf/" class="panel-title">HACK TO THE FUTURE</a>
+            <div class="panel-meta">フューチャー主催のプログラミングコンテストである、HACK TO THE FUTURE を紹介します。</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 概要

HACK TO THE FUTURE 特設ページ（#2345）への導線をホームに追加する。ガイドラインパネルの隣の列に置く。

close #2421

## 変更内容

- ホームのガイドライン枠に HTTF のパネルを追加し、2列で並べる。サムネはロゴ（切り抜くと絵が欠けるので `panel-thumb-contain` で全体表示）
- 見出しを「ガイドラインから学ぶ」→「**特設ページ**」に変更。HTTF はガイドラインではないため、両方を含む語にした。各パネルの説明文がそれぞれの中身を名乗る
- 今後ページが増えたときの方針をコメントに記載（3枚を超えたら /specials/ への導線1本にまとめる）

## 確認

- ホームで2枚のパネルが並び、それぞれ /specials/guidelines/ と /specials/httf/ に飛ぶことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)