### PR TITLE
ヘッダーの検索がタイトルと干渉するのを直す

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2227,6 +2227,7 @@ input[name="tab_item"] {
   top: 10px;
   right: 12px;
   display: flex;
+  align-items: center;
 }
 .header-search input {
   width: 200px;
@@ -2259,22 +2260,20 @@ input[name="tab_item"] {
   background: #337ab7;
   transition: all 0.1s linear;
 }
-/* モバイル展開用の虫眼鏡ラベル。PC では入力欄が常時出ているので使わない */
+/* 展開用の虫眼鏡ラベル。入力欄が常時出ている広い画面では使わない */
 .header-search-open {
   display: none;
 }
-@media (max-width: 558px) {
-  .header-search {
-    position: static;
-    justify-content: flex-end;
-    align-items: center;
-    padding: 6px 10px 0 0;
-  }
-  /* モバイルは虫眼鏡アイコンだけを出し、タップ（label→input フォーカス）で
-     :focus-within により入力欄が展開する。JS は使わない。
-     送信はキーボードの検索キーが担うため、送信ボタンは出さない
-     （タップでの送信は Safari が button にフォーカスを与えず、
-     blur で先に閉じてしまうため成立しない） */
+/* 検索は常に絶対配置にする。フローに置くとヘッダーの高さを押し広げ、
+   タイトルが検索の分だけ下へずれる (#2428)。
+   畳む幅の下限は「展開した入力欄（約240px）が中央のタイトルに被らない幅」。
+   タイトルは1204px以下で65pxになり "Future Tech Blog" が約540px を占めるので、
+   ここから下は虫眼鏡だけにする。タップ（label→input フォーカス）で
+   :focus-within により展開する。JS は使わない。
+   送信はキーボードの検索キーが担うため、送信ボタンは出さない
+   （タップでの送信は Safari が button にフォーカスを与えず、
+   blur で先に閉じてしまうため成立しない） */
+@media (max-width: 1204px) {
   .header-search-open {
     display: flex;
     align-items: center;
@@ -2299,6 +2298,13 @@ input[name="tab_item"] {
   }
   .header-search button {
     display: none;
+  }
+}
+/* 狭い画面ではタイトルが横幅いっぱいに近いので、虫眼鏡を角へ寄せて間合いを取る */
+@media (max-width: 558px) {
+  .header-search {
+    top: 6px;
+    right: 8px;
   }
 }
 .blog-news {


### PR DESCRIPTION
## 概要

ヘッダー右上の検索ボックス（#2399 / #2401）がタイトルと干渉していたのを直す。

close #2428

## 原因と修正

| 症状 | 原因 | 修正 |
| --- | --- | --- |
| モバイルでタイトルが下にずれる | `position: static` にしていたため検索がフローを占有し、ヘッダーの高さを押し広げていた | **常に絶対配置**にする |
| タブレットで検索がタイトルに被る | 絶対配置の展開状態（入力欄+ボタンで約240px）が、中央寄せのタイトル（1204px以下で65px・約540px幅）と横方向で重なっていた | **折りたたみのしきい値を 558px → 1204px** に拡大し、この幅から下は虫眼鏡だけにする |

- 1204px はタイトルのフォントサイズが 80px → 65px に変わる既存のブレークポイントで、「入力欄を出すと被る」境界と一致する
- 狭い画面（≤558px）では虫眼鏡を角に寄せ（top 6px / right 8px）、タイトルとの間合いを確保

## 確認

- 開発者ツールで幅を変え、390px（スマホ）・768px（タブレット）・1300px（PC）でタイトルの位置と検索の表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)