### PR TITLE
記事メタの並びを「文字数 → PV」にする

### DIFF
--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -11,16 +11,18 @@
             <li class="blog-info-item"><%- partial('post/date', {class_name: 'archive-article-date', date_format: 'YYYY.MM.DD'}) %></li>
             <%- post_author_link(post) %>
             <li class="blog-info-item blog-info-tags"><%- partial('post/tag') %></li>
+            <%# 読了時間ではなく文字数。読む速度は個人差が大きく、分数で示すと誠実さを欠く。
+                コードブロックと <details> の中身は除外している（scripts/char_count.js）。
+                PV より前に置く。文字数は記事を書き換えない限り変わらないが、
+                PV は毎日の集計で動く。変わらない情報を先に置く (#2431) %>
+            <% if (!index) { %>
+            <%# 数え方は title 属性で補足する。ネイティブのツールチップなので JS を足さずに済む %>
+            <li class="blog-info-item blog-info-metric"><span title="コードブロックと折りたたみ（details）の中身、空白を除いた本文の文字数です。インラインコードは含みます"><%= char_count(post) %></span></li>
+            <% } %>
             <%# 更新タイミングを title で補足する。集計値が無い記事（公開直後など）は項目ごと出さない %>
             <% const pv = get_ga4_pv(post.path); %>
             <% if (pv) { %>
             <li class="blog-info-item blog-info-metric"><span title="Google Analytics による閲覧数です。毎日 9:00 JST に集計が更新され、サイトが再ビルドされます"><%= pv %> View</span></li>
-            <% } %>
-            <%# 読了時間ではなく文字数。読む速度は個人差が大きく、分数で示すと誠実さを欠く。
-                コードブロックと <details> の中身は除外している（scripts/char_count.js） %>
-            <% if (!index) { %>
-            <%# 数え方は title 属性で補足する。ネイティブのツールチップなので JS を足さずに済む %>
-            <li class="blog-info-item blog-info-metric"><span title="コードブロックと折りたたみ（details）の中身、空白を除いた本文の文字数です。インラインコードは含みます"><%= char_count(post) %></span></li>
             <% } %>
           </ul>
           </header>


### PR DESCRIPTION
## 概要

記事のメタ情報の並びを「日付 → 著者 → タグ → **文字数 → PV**」にする（従来は PV → 文字数）。

close #2431

## 理由

文字数は記事を書き換えない限り変わらないが、PV は毎日の集計で動く。**変わらない情報を先に置く**方が読み手にとって安定する。理由はコードコメントにも記録した。

## 確認

- 記事ページでメタ行が「文字数 → View」の順になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)