### PR TITLE
モバイルのタグ列を文字の位置で左端に揃える

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -996,6 +996,10 @@ code {
 @media (max-width: 767px) {
   .blog-info-tags {
     flex-basis: 100%;
+    /* チップの左 padding（8px）の分だけ戻す。揃えるのは枠の位置ではなく
+       文字の位置で、補正しないと上の行（日付・著者）より右にずれて見える (#2429)。
+       行ごとに分けてあるので、折り返した2行目以降も同じだけ効く */
+    margin-left: -8px;
   }
 }
 .tag-list-link {


### PR DESCRIPTION
## 概要

モバイルの記事ページで、タグのチップ列が右寄せに見えるのを直す。

close #2429

## 原因

狭い画面（≤767px）ではタグが行ごと分かれる（`flex-basis: 100%`）が、チップの**左 padding 8px** の分だけ文字が内側に入るため、上の行（日付・著者）より右にずれて見えていた。揃えるべきは枠の位置ではなく**文字の位置**（光学的な左端）。

## 修正

- 同じメディアクエリに `margin-left: -8px`（チップの左 padding と同値）を追加。行ごとに分かれているので、折り返した2行目以降にも同じだけ効く
- リンク型（`.tag-list-link`）と単発タグ型（`.tag-list-text`）の両方とも左 padding が 8px であることを確認済み。どちらで始まる行でも揃う

## 確認

- モバイル幅の記事ページで、日付の行とタグの行の左端が揃うことを確認（補正量 8px が過不足ないことも確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)