### PR TITLE
年ページのグラフで2タブの月軸を揃える

### DIFF
--- a/scripts/archive_post_chart.js
+++ b/scripts/archive_post_chart.js
@@ -48,8 +48,7 @@ const generatePostsSeries = (posts, year) => {
   // 同じページの「カテゴリ別」タブと軸の長さが食い違う (#2430)
   if (year) {
     const now = new Date();
-    const monthCount =
-      Number(year) === now.getFullYear() ? now.getMonth() + 1 : 12;
+    const monthCount = Number(year) === now.getFullYear() ? now.getMonth() + 1 : 12;
     const counts = new Array(monthCount).fill(0);
     target.forEach((post) => {
       const m = post.date.month();

--- a/scripts/archive_post_chart.js
+++ b/scripts/archive_post_chart.js
@@ -43,6 +43,21 @@ const generatePostsSeries = (posts, year) => {
     : posts;
   if (target.length === 0) return [];
 
+  // 年ページは1月から（今年は現在の月まで、過去の年は12月まで）を必ず並べる。
+  // 投稿のある月だけにすると、月が抜けて期間が詰まって見えるうえ、
+  // 同じページの「カテゴリ別」タブと軸の長さが食い違う (#2430)
+  if (year) {
+    const now = new Date();
+    const monthCount =
+      Number(year) === now.getFullYear() ? now.getMonth() + 1 : 12;
+    const counts = new Array(monthCount).fill(0);
+    target.forEach((post) => {
+      const m = post.date.month();
+      if (m < monthCount) counts[m]++;
+    });
+    return counts.map((count, i) => ({ groupKey: `${i + 1}月`, count }));
+  }
+
   const quarterOf = (date) =>
     `${date.format('YYYY')}年${Math.ceil(Number(date.format('MM')) / 3)}Q`;
   const unit = year ? 'month' : 'quarter';

--- a/scripts/category_chart_helpers.js
+++ b/scripts/category_chart_helpers.js
@@ -127,8 +127,7 @@ hexo.extend.helper.register('get_monthly_category_data', function (year) {
   // 同じページの「週別」タブ（posts_stack_series）と軸の長さが食い違い、
   // タブを切り替えるたびに棒の幅と位置が変わっていた (#2430)
   const now = new Date();
-  const monthCount =
-    Number(year) === now.getFullYear() ? now.getMonth() + 1 : 12;
+  const monthCount = Number(year) === now.getFullYear() ? now.getMonth() + 1 : 12;
 
   const byCat = new Map(); // カテゴリ -> 月ごとの配列
   this.site.posts.forEach((post) => {

--- a/scripts/category_chart_helpers.js
+++ b/scripts/category_chart_helpers.js
@@ -122,16 +122,24 @@ hexo.extend.helper.register('category_colors', function () {
 
 // 指定年の月別 × カテゴリ別の投稿数 (#2171)
 hexo.extend.helper.register('get_monthly_category_data', function (year) {
-  const byCat = new Map(); // カテゴリ -> 12ヶ月分の配列
+  // 今年はまだ来ていない月を出さない。月の探索リンク（archive.ejs）と同じ規則。
+  // 12ヶ月固定にすると、今年のグラフに未来の空欄が並ぶうえ、
+  // 同じページの「週別」タブ（posts_stack_series）と軸の長さが食い違い、
+  // タブを切り替えるたびに棒の幅と位置が変わっていた (#2430)
+  const now = new Date();
+  const monthCount =
+    Number(year) === now.getFullYear() ? now.getMonth() + 1 : 12;
+
+  const byCat = new Map(); // カテゴリ -> 月ごとの配列
   this.site.posts.forEach((post) => {
     if (String(post.date.year()) !== String(year)) return;
     const cat = post.categories.first();
     if (!cat) return;
-    if (!byCat.has(cat.name)) byCat.set(cat.name, new Array(12).fill(0));
-    byCat.get(cat.name)[post.date.month()]++;
+    if (!byCat.has(cat.name)) byCat.set(cat.name, new Array(monthCount).fill(0));
+    if (post.date.month() < monthCount) byCat.get(cat.name)[post.date.month()]++;
   });
   const months = [];
-  for (let m = 1; m <= 12; m++) months.push(`${m}月`);
+  for (let m = 1; m <= monthCount; m++) months.push(`${m}月`);
   // 並びはその年の多い順ではなく、全期間ページと同じサイト累計の多い順で
   // 固定する。年ごとに入れ替わると、年を移動したとき凡例と積み上げの
   // 色の位置が動いて比較しにくい (#2201)

--- a/themes/future/layout/_partial/posts-chart.ejs
+++ b/themes/future/layout/_partial/posts-chart.ejs
@@ -22,7 +22,11 @@
   const periodData = <%- year ? posts_stack_series(year) : posts_stack_series() %>;
   echarts.init(document.getElementById('chart-period')).setOption({
     tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
-    legend: { bottom: 0 },
+    <%# 凡例は1行に収める。折り返すと grid.bottom（1行分の32px）を越えて
+        X軸の月ラベルに重なる。モバイルでは「第1週〜第5週」の5項目が
+        入り切らず実際に重なっていた (#2430)。
+        カテゴリ別のグラフと同じ type:'scroll' で、溢れた分は矢印で送る %>
+    legend: { bottom: 0, type: 'scroll' },
     grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
     xAxis: { type: 'category', data: periodData.buckets },
     yAxis: { type: 'value', min: 0, max: <%= year ? max_posts(year) : max_posts() %> },


### PR DESCRIPTION
## 概要

年ページ（例: /articles/2026/）の投稿数グラフで、「週別」と「カテゴリ別」のタブで X 軸の期間が食い違っていたのを直す。

close #2430

## 原因

| タブ | 実装 | 2026年の X 軸 |
| --- | --- | --- |
| 週別 | `posts_stack_series` — **最初の投稿〜最後の投稿**の範囲 | 1月〜**8月** |
| カテゴリ別 | `get_monthly_category_data` — 常に**12ヶ月固定** | 1月〜**12月**（9月以降が空欄） |

同じページの同じデータなのにタブを切り替えると棒の幅と位置が変わり、カテゴリ別は**未来の4ヶ月を空欄で描いていた**。過去年は両方12ヶ月になるため、今年のページでだけ表面化していた。

## 修正

- 両方を「**今年は現在の月まで、過去の年は12月まで**」に統一。月の探索リンク（archive.ejs の「今年のまだ来ていない月だけは出さない」）と同じ規則
- 週別側は「投稿のある月だけ」をやめて1月からの連続にした。途中に0本の月があっても軸から落ちない
- 併せて週別グラフの凡例に `type: 'scroll'` を追加。5項目がモバイルで2行に折り返し、`grid.bottom`（1行分）を越えて月ラベルに重なっていた

## 確認

- 2026年: 両タブとも 1月〜8月、月合計が完全一致（8,14,6,14,14,17,16,7）
- 2025年: 両タブとも12ヶ月、月合計が完全一致

## 補足

Issue 本文では「年別 著者数の推移」と書いていたが、実際の症状は年ページの週別グラフだった（レビューで判明）。著者系のグラフには問題が無いことを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)