### PR TITLE
投稿が途切れた著者の印を /doctor/ へ移す

### DIFF
--- a/scripts/author_generator.js
+++ b/scripts/author_generator.js
@@ -106,38 +106,14 @@ hexo.extend.helper.register('list_authors', function (year = 'all') {
   let authorMapper;
 
   if (year === 'all') {
-    // 全期間表示の場合のロジック
-    const currentYear = new Date().getFullYear(); // 今年 (2025)
-    const lastYear = currentYear - 1; // 昨年 (2024)
-    const twoYearsAgo = currentYear - 2; // 2年前 (2023)
-
-    // 特定の年に著者の投稿があるかチェックするヘルパー
-    const hasPostsInYear = (author, checkYear) => {
-      const years = yearsByAuthor.get(author);
-      return years ? years.has(checkYear) : false;
-    };
-
-    authorMapper = (author) => {
-      let suffix = '';
-      const hasNoPostsThisYear = !hasPostsInYear(author, currentYear);
-
-      // 今年の投稿実績がない著者のみを対象にサフィックスを判定
-      if (hasNoPostsThisYear) {
-        // 条件(拡張): 昨年実績があるか -> '**'を付与
-        if (hasPostsInYear(author, lastYear)) {
-          suffix = '**';
-          // 条件: 2年前に実績があるか -> '*'を付与
-        } else if (hasPostsInYear(author, twoYearsAgo)) {
-          suffix = '*';
-        }
-      }
-
-      return `
+    // 名前の後ろに付けていた * / **（投稿が途切れている著者の印）は /doctor/ へ移した (#2418)。
+    // 凡例がページのどこにも無く、読者には意味が読めない記号になっていた。
+    // 「そろそろ声をかけると再開してくれるかも」は運営の関心なので置き場所は /doctor/
+    authorMapper = (author) => `
         <li class="author-list-item">
-          <a class="author-list-link" href="/authors/${author_to_url.call(this, author)}">${author}${suffix}</a>
+          <a class="author-list-link" href="/authors/${author_to_url.call(this, author)}">${author}</a>
           <span class="author-list-count">${count_posts(author)} 件</span>
         </li>`;
-    };
   } else {
     // 年指定: その年が初投稿の著者に NEW を付ける (#2413)。
     // 「1本目を踏み出してくれた新しい寄稿者数/年」という運営のキーメトリクスと

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -351,6 +351,42 @@ hexo.extend.helper.register('doctor_external_links', function () {
 
 /**
  * カテゴリの一言説明（source/_data/categories.yml #2405）の突き合わせ。
+ * 投稿が途切れている著者 (#2418)。/authors/ の全期間タブで名前の後ろに
+ * ** / * を付けていたものの移設。凡例がページのどこにも無く、読者には
+ * 意味が読めない記号だった。「そろそろ声をかけると再開してくれるかも」は
+ * 運営の関心なので、読者向けの一覧ではなくこちらに置く。
+ *
+ * 今年まだ投稿が無く、最後の投稿が昨年か一昨年の著者を返す。
+ * それより古い著者は「途切れている」ではなく「離れた」なので出さない
+ * （声かけの候補として現実的な範囲に絞る）。
+ */
+hexo.extend.helper.register('doctor_dormant_authors', function () {
+  const thisYear = new Date().getFullYear();
+  const byAuthor = new Map(); // 著者 -> {years:Set, count}
+  this.site.posts.forEach((post) => {
+    // 共著の旧記事は author が配列
+    [].concat(post.author || []).forEach((name) => {
+      if (!name) return;
+      if (!byAuthor.has(name)) byAuthor.set(name, { years: new Set(), count: 0 });
+      const entry = byAuthor.get(name);
+      entry.years.add(post.date.year());
+      entry.count++;
+    });
+  });
+
+  const rows = [];
+  for (const [name, entry] of byAuthor) {
+    if (entry.years.has(thisYear)) continue;
+    const last = Math.max(...entry.years);
+    const gap = thisYear - last;
+    if (gap === 1 || gap === 2) rows.push({ name, last, count: entry.count, gap });
+  }
+  // 表示は本数でまとめるので本数の多い順。同数なら最近まで書いていた人を先に
+  rows.sort((a, b) => b.count - a.count || a.gap - b.gap || (a.name < b.name ? -1 : 1));
+  return rows;
+});
+
+/**
  * 説明の無いカテゴリ（新設時の書き忘れ）と、カテゴリとして実在しない
  * 説明（改名・統合後の消し忘れやタイプミス）を両方向で検出する。
  */

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1348,6 +1348,27 @@ code {
   color: #6e6e6e;
   font-size: 0.9em;
 }
+/* 名前の直後に添える注記。横に流したい列で使う（#2418）。
+   行ごとに区切り線が入るので、行間・項目間は開けすぎない */
+.doctor-note-inline {
+  color: #6e6e6e;
+  font-size: 0.9em;
+  margin: 0 5px 0 2px;
+}
+.doctor-list .doctor-inline-row {
+  line-height: 1.9;
+}
+/* 件数の少ない検査どうしを横に並べる (#2418)。狭い画面では縦に戻す。
+   節の見出しごと並べるので、中の一覧は各列で通常どおり縦に積む */
+.doctor-cols {
+  display: grid;
+  gap: 0 32px;
+}
+@media (min-width: 768px) {
+  .doctor-cols {
+    grid-template-columns: 1fr 1fr;
+  }
+}
 /* /doctor/ のオントロジーツリー。系統ごとの小さな木を多段組で敷き詰める */
 .ontology-forest {
   column-width: 300px;

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -15,30 +15,39 @@
         <li><span class="summary-count"><%= checks.nearDuplicates.length %></span><br><span class="summary-label">統合候補のタグ</span></li>
         <li><span class="summary-count"><%= checks.categoryDupTags.length %></span><br><span class="summary-label">カテゴリと同名のタグ</span></li>
         <li><span class="summary-count"><%= checks.singleUse.length %></span><br><span class="summary-label">1記事タグ</span></li>
+        <% const dormant = doctor_dormant_authors(); %>
+        <li><span class="summary-count"><%= dormant.length %></span><br><span class="summary-label">投稿が途切れた著者</span></li>
       </ul>
 
-      <h2 class="bottom-content-header">タグが1つも無い記事</h2>
-      <% if (checks.untagged.length) { %>
-      <ul class="doctor-list">
-        <% checks.untagged.forEach(function(p){ %>
-        <li><a href="<%- url_for(p.path) %>"><%= p.title %></a></li>
-        <% }) %>
-      </ul>
-      <% } else { %>
-      <p>該当なし</p>
-      <% } %>
-
-      <h2 class="bottom-content-header">タグが付きすぎている記事</h2>
-      ※10タグ以上を見直し候補として出しています（記事あたりのタグ数の中央値は3）
-      <% if (checks.overTagged.length) { %>
-      <ul class="doctor-list">
-        <% checks.overTagged.forEach(function(p){ %>
-        <li><a href="<%- url_for(p.path) %>"><%= p.title %></a> <span class="doctor-note"><%= p.count %>タグ</span></li>
-        <% }) %>
-      </ul>
-      <% } else { %>
-      <p>該当なし</p>
-      <% } %>
+      <%# タグ無しと付けすぎは、どちらも件数の少ない「記事単位の粗さ」の検査。
+          縦に積むと1件ずつのために画面を1つ使うので、2つの節を横に並べる %>
+      <div class="doctor-cols">
+        <section>
+          <h2 class="bottom-content-header">タグが1つも無い記事</h2>
+          <% if (checks.untagged.length) { %>
+          <ul class="doctor-list">
+            <% checks.untagged.forEach(function(p){ %>
+            <li><a href="<%- url_for(p.path) %>"><%= p.title %></a></li>
+            <% }) %>
+          </ul>
+          <% } else { %>
+          <p>該当なし</p>
+          <% } %>
+        </section>
+        <section>
+          <h2 class="bottom-content-header">タグが付きすぎている記事</h2>
+          ※10タグ以上を見直し候補として出しています（記事あたりのタグ数の中央値は3）
+          <% if (checks.overTagged.length) { %>
+          <ul class="doctor-list">
+            <% checks.overTagged.forEach(function(p){ %>
+            <li><a href="<%- url_for(p.path) %>"><%= p.title %></a><span class="doctor-note-inline"><%= p.count %>タグ</span></li>
+            <% }) %>
+          </ul>
+          <% } else { %>
+          <p>該当なし</p>
+          <% } %>
+        </section>
+      </div>
 
       <h2 class="bottom-content-header">ほぼ重なるタグ（統合候補）</h2>
       ※片方の記事すべてがもう片方にも付いていて、差が2本以内のペア。実質同じ集合に2つの名前が付いています。Go1.27 ⊆ Go のような差の大きい健全な階層は出しません
@@ -146,11 +155,35 @@
         <% }) %>
       </div>
       <ul class="doctor-list">
-        <li>
+        <%# 投稿が途切れた著者の列と同じ扱い。数十件が横に流れるので、
+            区切りの「、」ではなく行間と余白で分ける (#2418) %>
+        <li class="doctor-inline-row">
           <span class="doctor-note">親も子も無い根タグ（<%= onto.standalone.length %>件）</span>
-          <% onto.standalone.forEach(function(n, i){ %><a href="<%- url_for(n.path) %>"><%= n.name %></a><span class="ontology-count"><%= n.posts %>本<%= (n.versions || []).length ? '・版' + n.versions.length : '' %></span><%= i < onto.standalone.length - 1 ? '、' : '' %><% }) %>
+          <% onto.standalone.forEach(function(n){ %><a href="<%- url_for(n.path) %>"><%= n.name %></a><span class="ontology-count doctor-note-inline"><%= n.posts %>本<%= (n.versions || []).length ? '・版' + n.versions.length : '' %></span><% }) %>
         </li>
       </ul>
+
+      <h2 class="bottom-content-header">投稿が途切れている著者</h2>
+      ※今年まだ投稿が無く、最後の投稿が昨年か一昨年の著者。声をかけると再開してくれるかもしれない候補です（/authors/ に <code>*</code> / <code>**</code> で出していたものの移設。読者向けのページには凡例の無い記号を置かない #2418）
+      <%# 累計本数でまとめて横に並べる。本数が同じ人は声かけの重みも同じなので、
+          1人1行にするより「何本書いた人が何人いるか」が一目で分かる。
+          並びは本数の多い順。区切りの「、」は使わず間隔で分ける %>
+      <% if (dormant.length) { %>
+      <% const dormantCounts = [...new Set(dormant.map(d => d.count))].sort((a, b) => b - a); %>
+      <ul class="doctor-list">
+        <% dormantCounts.forEach(function(c){ %>
+        <% const members = dormant.filter(d => d.count === c); %>
+        <li class="doctor-inline-row">
+          <span class="doctor-note"><%= c %>本（<%= members.length %>名）</span>
+          <%# 最終投稿年は名前の直後に添える。行を折らないインラインの注記にする
+              （.doctor-note は display:block で1件ごとに改行されてしまう）%>
+          <% members.forEach(function(d){ %><a href="<%- url_for('authors/' + d.name + '/') %>"><%= d.name %></a><span class="doctor-note-inline"><%= d.last %>年</span><% }) %>
+        </li>
+        <% }) %>
+      </ul>
+      <% } else { %>
+      <p>該当なし</p>
+      <% } %>
 
       <h2 class="bottom-content-header">カテゴリの説明の抜け・食い違い</h2>
       ※カテゴリの一言説明は <code>source/_data/categories.yml</code>（#2405）。新設カテゴリの説明漏れと、実在しないカテゴリの説明（改名・統合後の消し忘れ）を両方向で照合します
@@ -184,16 +217,16 @@
       <h2 class="bottom-content-header">タイトルにタグ名を含むのに、そのタグが付いていない記事</h2>
       ※英数3文字・和文4文字未満のタグ名は一般語に当たりやすいので照合していません
       <ul class="doctor-list">
+        <%# 畳まない。運営が上から順に見て潰していく作業リストなので、
+            開く操作を挟むと候補の全体量が掴めない %>
         <% checks.missing.forEach(function(m){ %>
         <li>
-          <details>
-            <summary><a href="<%- url_for(m.path) %>"><%= m.name %></a>（<%= m.posts.length %>記事）</summary>
-            <ul>
-              <% m.posts.forEach(function(p){ %>
-              <li><a href="<%- url_for(p.path) %>"><%= p.title %></a></li>
-              <% }) %>
-            </ul>
-          </details>
+          <a href="<%- url_for(m.path) %>"><%= m.name %></a><span class="doctor-note-inline"><%= m.posts.length %>記事</span>
+          <ul>
+            <% m.posts.forEach(function(p){ %>
+            <li><a href="<%- url_for(p.path) %>"><%= p.title %></a></li>
+            <% }) %>
+          </ul>
         </li>
         <% }) %>
       </ul>


### PR DESCRIPTION
## 概要

/authors/ の全期間タブで著者名の後ろに付けていた `*` / `**` を、/doctor/ の検査に移す。

close #2418

## 移設の理由

- `*` / `**` の**凡例がページのどこにも無く**、読者には「澁川喜規**」のような意味の読めない記号になっていた
- 中身は「今年まだ投稿が無く、昨年（`**`）または一昨年（`*`）に投稿していた著者」＝**そろそろ声をかけると再開してくれるかも**という運営の関心。読者向けの一覧ではなく /doctor/ が置き場所として正しい

## 変更内容

- `scripts/author_generator.js`: 全期間タブから記号を削除
- `scripts/doctor.js`: `doctor_dormant_authors` を追加（今年未投稿かつ最終投稿が1〜2年前の著者を、累計本数の多い順に返す）
- `/doctor/` に「投稿が途切れている著者」の節とサマリータイルを追加。**累計本数でまとめて横並び**にし、各名前に最終投稿年を添える（本数が同じ人は声かけの重みも同じなので、1人1行より「何本書いた人が何人いるか」が掴める）

## 併せて /doctor/ の読みやすさを調整

- 「タグが1つも無い記事」と「タグが付きすぎている記事」を**横並び**に（どちらも件数が少なく、縦に積むと1件のために画面を1つ使っていた）
- 「タイトルにタグ名を含むのに、そのタグが付いていない記事」の `<details>` を廃止して**全件展開**（上から順に潰す作業リストなので、開く操作を挟むと全体量が掴めない）
- 「親も子も無い根タグ」も横並びの列として間隔を統一。区切りの「、」は使わず余白で分ける
- 横並びの列用に `.doctor-note-inline` を追加（既存の `.doctor-note` は `display:block` で1件ごとに改行されてしまうため）

## 確認

- /authors/ から記号が消えたこと（0件）、/doctor/ の新セクションと各節の表示を確認
- prettier / reviewdog 通過見込み（ローカルで prettier --check 通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)