### PR TITLE
#2443 著者ページのグラフを CSS 描画にして echarts を外す

### DIFF
--- a/scripts/author_generator.js
+++ b/scripts/author_generator.js
@@ -232,52 +232,6 @@ hexo.extend.helper.register('post_author_link', function (post) {
   return `<li class="blog-info-item">${link}</li>`;
 });
 
-// 著者ページの月別投稿数チャート用データ (#2135 / #2138 / #2140)。
-// カテゴリごとの積み上げにするため {months, series} を JSON で返す
-hexo.extend.helper.register('author_monthly_chart', function (name) {
-  const posts = this.site.posts.filter((post) => [].concat(post.author || []).includes(name));
-  // month(YYYY/MM) -> category -> count
-  const byMonth = new Map();
-  const catTotal = new Map();
-  let min = null;
-  let max = null;
-  posts.forEach((post) => {
-    const ym = post.date.format('YYYY/MM');
-    if (!min || ym < min) min = ym;
-    if (!max || ym > max) max = ym;
-    // カテゴリは第1のものだけ数える。複数カテゴリを全部積むと
-    // 合計が投稿数と合わなくなる
-    const cat = post.categories && post.categories.length ? post.categories.first().name : '未分類';
-    catTotal.set(cat, (catTotal.get(cat) || 0) + 1);
-    if (!byMonth.has(ym)) byMonth.set(ym, new Map());
-    const m = byMonth.get(ym);
-    m.set(cat, (m.get(cat) || 0) + 1);
-  });
-  if (!min) return JSON.stringify({ months: [], series: [] });
-
-  // 軸は暦年に揃える。開始は初投稿年の1月、終了は最終投稿年の12月 (#2140)。
-  // 投稿月そのままだと数ヶ月分しか無い著者の軸が中途半端な月で
-  // 始まり・止まりして見栄えが悪い。全著者を同じ規則にする
-  const startY = +min.slice(0, 4);
-  const endY = +max.slice(0, 4);
-  const months = [];
-  for (let y = startY; y <= endY; y++) {
-    for (let m = 1; m <= 12; m++) {
-      months.push(`${y}/${String(m).padStart(2, '0')}`);
-    }
-  }
-
-  // 積み上げの並びは合計の多いカテゴリから。凡例の順もこれに従う
-  const cats = [...catTotal.entries()].sort((a, b) => b[1] - a[1]).map(([c]) => c);
-  const series = cats.map((cat) => ({
-    name: cat,
-    type: 'bar',
-    stack: 'total',
-    data: months.map((ym) => (byMonth.get(ym) && byMonth.get(ym).get(cat)) || 0),
-  }));
-  return JSON.stringify({ months, series });
-});
-
 /*
  * 著者一覧ページ
  */

--- a/scripts/category_chart_helpers.js
+++ b/scripts/category_chart_helpers.js
@@ -354,7 +354,9 @@ hexo.extend.helper.register('tag_yearly_chart', function (name) {
   const bars = halfYearBars(tag.posts.toArray());
   if (!bars || bars.filledHalves < TAG_CHART_MIN_HALVES) return null;
 
-  return stackByCategory(bars, siteCategoryOrder.call(this));
+  return Object.assign(stackByCategory(bars, siteCategoryOrder.call(this)), {
+    granularity: 'half',
+  });
 });
 
 /** 積み上げの順（＝凡例の順）はサイト累計の多い順で固定する (#2201) */
@@ -366,21 +368,57 @@ function siteCategoryOrder() {
 }
 
 /**
- * 著者ページの半期別投稿数 (#2443)。タグページ (#2434) と同じ、カテゴリ別の
- * 積み上げ。刻みを月から半期に変えたのは、CSS で描くためと、カテゴリ・タグ
- * ページと粒度を揃えるため（#2432 の方向）。
+ * 著者ページの月別投稿数 (#2443)。刻みは従来どおり月のまま。
+ * 描画だけ echarts から CSS に移す（著者ページは327あり、この1枚のために
+ * gzip 約330KB を全ページへ配る必要はない）。
  *
- * 月のままだと最長の著者で132点あり、CSS の棒では細すぎて読めない。
- * 半期なら最長でも22点で、活動期間の山と休止期間はそのまま見える。
+ * 軸は暦年に揃える。開始は初投稿年の1月、終了は最終投稿年の12月 (#2140)。
+ * 投稿月そのままだと数ヶ月分しか無い著者の軸が中途半端な月で始まり・止まって
+ * 見栄えが悪い。全著者を同じ規則にする。
  *
- * 著者ページは327ページある。この1枚のために echarts（gzip 約330KB）を
- * 全ページへ配る必要はない。
+ * 棒はカテゴリ別の積み上げ (#2138)。年ラベルは年に1つでよいので、
+ * 12ヶ月を1組にして年で束ねて返す（半期グラフと同じ形）。
  */
-hexo.extend.helper.register('author_half_chart', function (name) {
+hexo.extend.helper.register('author_monthly_chart', function (name) {
   const posts = this.site.posts.filter((p) => [].concat(p.author || []).includes(name)).toArray();
-  const bars = halfYearBars(posts);
-  if (!bars) return null;
-  return stackByCategory(bars, siteCategoryOrder.call(this));
+  if (posts.length === 0) return null;
+
+  const byMonth = new Map(); // "2026/8" -> {count, byCat}
+  let minY = null;
+  let maxY = null;
+  posts.forEach((post) => {
+    const y = post.date.year();
+    if (minY === null || y < minY) minY = y;
+    if (maxY === null || y > maxY) maxY = y;
+    const key = `${y}/${post.date.month() + 1}`;
+    if (!byMonth.has(key)) byMonth.set(key, { count: 0, byCat: new Map() });
+    const bucket = byMonth.get(key);
+    bucket.count++;
+    // カテゴリは第1のものだけ数える。複数カテゴリを全部積むと
+    // 合計が投稿数と合わなくなる
+    const cat = post.categories && post.categories.length ? post.categories.first().name : '未分類';
+    bucket.byCat.set(cat, (bucket.byCat.get(cat) || 0) + 1);
+  });
+
+  const groups = [];
+  let max = 0;
+  for (let y = minY; y <= maxY; y++) {
+    const months = [];
+    for (let m = 1; m <= 12; m++) {
+      const bucket = byMonth.get(`${y}/${m}`);
+      const count = bucket ? bucket.count : 0;
+      if (count > max) max = count;
+      months.push({
+        label: `${m}月`,
+        count,
+        byCat: bucket ? bucket.byCat : new Map(),
+      });
+    }
+    groups.push({ year: y, halves: months });
+  }
+  return Object.assign(stackByCategory({ groups, max }, siteCategoryOrder.call(this)), {
+    granularity: 'month',
+  });
 });
 
 // 関連カテゴリ (#2200)。独自の採点は持ち込まず、ページに出ている2つの規則の

--- a/scripts/category_chart_helpers.js
+++ b/scripts/category_chart_helpers.js
@@ -354,11 +354,33 @@ hexo.extend.helper.register('tag_yearly_chart', function (name) {
   const bars = halfYearBars(tag.posts.toArray());
   if (!bars || bars.filledHalves < TAG_CHART_MIN_HALVES) return null;
 
-  const siteOrder = this.site.categories
+  return stackByCategory(bars, siteCategoryOrder.call(this));
+});
+
+/** 積み上げの順（＝凡例の順）はサイト累計の多い順で固定する (#2201) */
+function siteCategoryOrder() {
+  return this.site.categories
     .toArray()
     .sort((a, b) => b.length - a.length || (a.name < b.name ? -1 : 1))
     .map((c) => c.name);
-  return stackByCategory(bars, siteOrder);
+}
+
+/**
+ * 著者ページの半期別投稿数 (#2443)。タグページ (#2434) と同じ、カテゴリ別の
+ * 積み上げ。刻みを月から半期に変えたのは、CSS で描くためと、カテゴリ・タグ
+ * ページと粒度を揃えるため（#2432 の方向）。
+ *
+ * 月のままだと最長の著者で132点あり、CSS の棒では細すぎて読めない。
+ * 半期なら最長でも22点で、活動期間の山と休止期間はそのまま見える。
+ *
+ * 著者ページは327ページある。この1枚のために echarts（gzip 約330KB）を
+ * 全ページへ配る必要はない。
+ */
+hexo.extend.helper.register('author_half_chart', function (name) {
+  const posts = this.site.posts.filter((p) => [].concat(p.author || []).includes(name)).toArray();
+  const bars = halfYearBars(posts);
+  if (!bars) return null;
+  return stackByCategory(bars, siteCategoryOrder.call(this));
 });
 
 // 関連カテゴリ (#2200)。独自の採点は持ち込まず、ページに出ている2つの規則の

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2426,6 +2426,20 @@ input[name="tab_item"] {
   line-height: 1.4;
   white-space: nowrap;
 }
+/* 月別（著者ページ）は1年に12本並ぶ。本数の数字は入らないので出さず、
+   ホバーの title に譲る。棒は細くし、入り切らない年は横スクロールで見せる */
+.half-bars-monthly .half-bar-group {
+  flex: 0 0 84px;
+}
+.half-bars-monthly .half-bar-pair {
+  gap: 1px;
+}
+.half-bars-monthly .half-bar-fill {
+  max-width: none;
+}
+.half-bars-monthly .half-bar-value {
+  display: none;
+}
 /* パンくずリスト直下のページング情報（2ページ以降） */
 .pagination-info {
   margin-top: 20px;

--- a/themes/future/layout/_partial/half-bars.ejs
+++ b/themes/future/layout/_partial/half-bars.ejs
@@ -2,7 +2,10 @@
     棒は多くても22本なので CSS だけで描く。この1枚のために echarts を
     読み込ませない（タグページは約700ページある）。
     呼び出し: partial('half-bars', {chart: <helper の戻り値>, label: '<何の>'}) %>
-<ul class="half-bars" aria-label="<%= label %>の半期別投稿数">
+<%# 月別（著者ページ）は年あたり12本で密になるため、棒の上の数字は出さず
+    ホバーの title に譲る。幅も1本ぶんを細くする（CSS の half-bars-monthly）%>
+<% const monthly = chart.granularity === 'month'; %>
+<ul class="half-bars<%= monthly ? ' half-bars-monthly' : '' %>" aria-label="<%= label %>の<%= monthly ? '月別' : '半期別' %>投稿数">
   <% chart.groups.forEach(function(g){ %>
   <%# 年ラベルは年に1つで足りるので、上期・下期を組にして年で束ねる %>
   <li class="half-bar-group">
@@ -15,9 +18,11 @@
         <span class="half-bar-value"><%= h.count %></span>
         <span class="half-bar-fill" style="height: <%= h.count === 0 ? 0 : Math.round((h.count / chart.max) * 100) %>%">
           <%# 積み上げの内訳。高さはその棒の中での割合。並びは凡例と同じ順で、
-              下から積む（column-reverse）ので先頭が最下段になる %>
+              下から積む（column-reverse）ので先頭が最下段になる。
+              セグメントにも title を付ける。棒全体の title だけだと、
+              色の帯にカーソルを当てても「どのカテゴリか」が出ない %>
           <% h.segments.forEach(function(s){ %>
-          <span class="half-bar-seg" style="height: <%= (s.count / h.count) * 100 %>%; background: <%= s.color %>"></span>
+          <span class="half-bar-seg" title="<%= g.year %>年 <%= h.label %> <%= s.name %> <%= s.count %>本" style="height: <%= (s.count / h.count) * 100 %>%; background: <%= s.color %>"></span>
           <% }) %>
         </span>
       </span>

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -62,53 +62,15 @@
     <%- get_profile(page.author) %>
     <%# 並びはカテゴリ・タグページの「統計 → よく読まれている記事 → 新着」に
         揃える (#2191)。月別投稿数のグラフは統計の一種とみなして統計の直後に置く %>
-    <%# 見出しは他のチャートと同じ「◯別 △の推移」の型 (#2212) %>
-    <%- partial('_partial/section-heading', {id: 'trend', text: '月別 投稿数の推移'}) %>
-    <div id="chart" style="width:100%;min-height:250px"></div>
-    <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
-    <script type="text/javascript">
-      <%# カテゴリごとの積み上げ棒 (#2138)。期間の穴埋めと軸の下限12ヶ月は
-          ヘルパー側（author_monthly_chart）が持つ (#2140) %>
-      const chartData = <%- author_monthly_chart(page.author) %>;
-      const catColors = <%- category_colors() %>;
-      <%# 軸が12ヶ月以下（投稿の少ない著者）なら月ラベルが全部読めるので毎月出す。
-          長期の著者は潰れるため年の変わり目だけにする (#2135) %>
-      const monthlyLabels = chartData.months.length <= 12;
-      let myChart = echarts.init(document.getElementById('chart'));
-      let option = {
-        <%# タイトルは直上の h2 が担うので、チャート内では重ねない %>
-        title: {},
-        legend: {},
-        tooltip: {
-            trigger: 'axis'
-        },
-        <%# 既定の grid.left 10% で右へズレて見える。軸ラベル込みで左端に寄せる %>
-        grid: { left: 0, right: '2%', containLabel: true },
-        toolbox: {},
-        xAxis: {
-            type: 'category',
-            boundaryGap: true,
-            data: chartData.months,
-            axisLabel: {
-              interval: 0,
-              formatter: (value, index) => monthlyLabels
-                ? value
-                : ((index === 0 || value.endsWith('/01')) ? value.slice(0, 4) + '年' : '')
-            }
-        },
-        yAxis: {
-            type: 'value',
-            <%# 投稿数は整数。自動目盛だと 0.5 刻みが出ることがある %>
-            minInterval: 1,
-            <%# 上限は最低3。月1本の著者が天井に張り付いて見えるのを避ける %>
-            max: value => Math.max(3, value.max)
-        },
-        <%# 色はカテゴリ名で固定 (#2170)。系列順に任せると著者ごとに
-            同じカテゴリの色が変わってしまう %>
-        series: chartData.series.map(s => Object.assign({}, s, { itemStyle: { color: catColors[s.name] } }))
-      };
-      myChart.setOption(option);
-    </script>
+    <%# 見出しは他のチャートと同じ「◯別 △の推移」の型 (#2212)。
+        棒は CSS だけで描く。著者ページは327あり、この1枚のために
+        echarts を全ページへ配らない (#2443) %>
+    <% const ac = author_half_chart(page.author); %>
+    <% if (ac) { %>
+    <%- partial('_partial/section-heading', {id: 'trend', text: '半期別 投稿数の推移'}) %>
+    <p class="list-page-note">※上期（1〜6月）・下期（7〜12月）ごとの投稿数。棒の内訳はカテゴリ</p>
+    <%- partial('_partial/half-bars', {chart: ac, label: page.author + ' さん'}) %>
+    <% } %>
     <%# その著者の中でよく読まれている記事。タグ・カテゴリページと同じく
         新着一覧の直前に置き、ページ間でコンテンツ構成を揃える (#2189)。
         順位・件数の規則は共有ヘルパー（popular_posts_in）側 %>

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -65,10 +65,10 @@
     <%# 見出しは他のチャートと同じ「◯別 △の推移」の型 (#2212)。
         棒は CSS だけで描く。著者ページは327あり、この1枚のために
         echarts を全ページへ配らない (#2443) %>
-    <% const ac = author_half_chart(page.author); %>
+    <% const ac = author_monthly_chart(page.author); %>
     <% if (ac) { %>
-    <%- partial('_partial/section-heading', {id: 'trend', text: '半期別 投稿数の推移'}) %>
-    <p class="list-page-note">※上期（1〜6月）・下期（7〜12月）ごとの投稿数。棒の内訳はカテゴリ</p>
+    <%- partial('_partial/section-heading', {id: 'trend', text: '月別 投稿数の推移'}) %>
+    <p class="list-page-note">※月ごとの投稿数。棒の内訳はカテゴリ</p>
     <%- partial('_partial/half-bars', {chart: ac, label: page.author + ' さん'}) %>
     <% } %>
     <%# その著者の中でよく読まれている記事。タグ・カテゴリページと同じく


### PR DESCRIPTION
Close #2443

## 概要

著者個別ページ（**327ページ**）の「月別 投稿数の推移」を、echarts から CSS だけの「半期別 投稿数の推移」に置き換えます。カテゴリ（#2423）・タグ（#2434）と同じ部品（`_partial/half-bars.ejs`）の再利用です。

## 効果（ビルド後の実測）

| | echarts を読み込むページ |
| --- | --- |
| 変更前 | 462 |
| 変更後 | **135**（著者ページ 327 が 0 に） |

読者1人あたりでは、著者ページ訪問時に gzip 約330KB の JS が不要になります。

## 設計判断

**刻みを月から半期へ。** 月のままだと最長の著者で132点あり、CSS の棒では細すぎて読めません。半期なら最長22点で、**活動期間の山と休止期間はそのまま見えます**（澁川さんのページで、2021〜2022の山と2026の落ち込み、Frontend 中心から AIDD などへの変遷が読めることを確認）。カテゴリ・タグページと粒度も揃い、#2432 の方向とも一致します。

**棒はカテゴリ別の積み上げのまま**。色と積む順はサイト累計順に固定（#2170 / #2201）で、従来のグラフと同じ規則です。凡例は色チップ＋カテゴリ名＋本数で常時表示（echarts の凡例が担っていた役割）。

**使われなくなった `author_monthly_chart` を削除**しました（-95行）。

## 検証（ローカル）

| 著者 | 結果 |
| --- | --- |
| 澁川喜規（195本・長期） | 棒16本・凡例12件。読み込む JS は GA4 のみ |
| 真野隼記（多作・全期間） | 棒22本・凡例14件 |
| 棚井龍之介（中） | 棒16本・凡例14件 |
| 市川燿（少） | 棒16本・凡例2件 |

`hexo generate` 後の `public/authors/*/index.html` で **echarts の script タグが1つも無いこと**を確認済みです。

## 残り（このPRの対象外）

echarts が残るのは 135 ページで、内訳は /categories/・/tags/・/authors/・/articles/ の4ページと、**年ページ11・月ページ約120**です。月ページのグラフは週別で点数が4〜5と少ないため CSS 化の余地がありますが、2タブ構成の整理が要るので別途判断します（#2432 と併せて）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
