### PR TITLE
殿堂入りの受賞年を新しい順に並べる

### DIFF
--- a/scripts/awards.js
+++ b/scripts/awards.js
@@ -73,7 +73,13 @@ hexo.extend.helper.register('awards_list', function () {
     .filter(([, ys]) => ys.length >= HALL_OF_FAME_WINS)
     // 到達が早い順（同数なら名前）に並べる
     .sort((a, b) => a[1][HALL_OF_FAME_WINS - 1] - b[1][HALL_OF_FAME_WINS - 1])
-    .map(([author, ys]) => ({ author, years: ys, wins: ys.length }));
+    // 表示は新しい受賞が先 (#2451)。nth は昇順の位置で決まるので、
+    // 並べ替える前に年へ埋めておく
+    .map(([author, ys]) => ({
+      author,
+      years: ys.map((year, i) => ({ year, nth: i + 1 })).reverse(),
+      wins: ys.length,
+    }));
 
   return { hall, years };
 });

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1971,9 +1971,11 @@ a.series-nav-item:hover .series-nav-item-title {
   font-weight: bold;
   color: #7a5f16;
 }
+/* 数字が読める実寸が要る。1.1em だと数字が5px前後にしかならず消える (#2451)。
+   チップ（.award-chip 1.15em × 1.35em）と同じ約20pxに揃える */
 .awards-hall-medal .svg-icon {
-  width: 1.1em;
-  height: 1.1em;
+  width: 1.6em;
+  height: 1.6em;
   margin-right: 0;
 }
 /* メダルの色は回数で決まる。規則は .award-medal（部品側）が1箇所で持つ */

--- a/themes/future/layout/_partial/award-medal.ejs
+++ b/themes/future/layout/_partial/award-medal.ejs
@@ -11,6 +11,8 @@
   <%# withNumber: false なら色だけ使い、数字は描かない。記事のバッジでは
       「3」が記事の何を指すか読み取れないため色だけにしている (#2422) %>
   <% if (typeof nth !== 'undefined' && nth && (typeof withNumber === 'undefined' || withNumber)) { %>
-  <text x="12" y="9" text-anchor="middle" dominant-baseline="central" font-size="9" font-weight="bold" fill="currentColor" stroke="none"><%= nth %></text>
+  <%# font-size は viewBox の単位。円は r=6 で線が最大 2.6 なので内径 9.4、
+      11 なら大文字高さ約 7.9 で収まる。9 では実寸 5px 前後になって読めなかった (#2451) %>
+  <text x="12" y="9" text-anchor="middle" dominant-baseline="central" font-size="11" font-weight="bold" fill="currentColor" stroke="none"><%= nth %></text>
   <% } %>
 </svg>

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -102,7 +102,7 @@
         <div class="awards-hall-card">
           <span class="awards-hall-label"><%- partial('_partial/svg-icon', {icon: 'crown'}) %>殿堂入り</span>
           <a class="awards-hall-name" href="<%- url_for('authors/' + h.author + '/') %>"><%= h.author %></a>
-          <span class="awards-hall-years"><% h.years.forEach(function(y, i){ %><span class="awards-hall-medal"><%- partial('_partial/award-medal', {nth: i + 1}) %><%= y %></span><% }) %></span>
+          <span class="awards-hall-years"><% h.years.forEach(function(y){ %><span class="awards-hall-medal"><%- partial('_partial/award-medal', {nth: y.nth}) %><%= y.year %></span><% }) %></span>
         </div>
         <% }) %>
       </div>


### PR DESCRIPTION
Close #2451

## 変更

/authors/ の殿堂入りカードで、受賞年のメダルを降順にした。

- 変更前: 🥇2020 🥈2021 🥉2022
- 変更後: 🥉2022 🥈2021 🥇2020

著者ページの受賞バッジ（`author_awards`）は既に新しい順なので、これで揃う。

## 実装

メダルの中の数字は「何回目の受賞か」で、テンプレート側が配列の添字（`i + 1`）から出していた。単に配列を反転すると 1 → 2 → 3 の対応が崩れる。

`awards_list` の `hall[].years` を `[{year, nth}]` に変え、**昇順のうちに nth を確定させてから reverse** する形にした。表示順と受賞回数が独立するので、今後並べ替えても壊れない。

`hall[].years` の利用箇所は `authors.ejs` の1行のみ。

## 確認

- ビルド後の `/authors/` で `2022`（medal-3）→ `2021`（medal-2）→ `2020`（medal-1）の順に出ることを確認
- `prettier --check "scripts/**/*.js" "*.mjs"` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)