### PR TITLE
殿堂入りカードの受賞年チップを左端に揃える

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1959,6 +1959,9 @@ a.series-nav-item:hover .series-nav-item-title {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+  /* チップの左 padding（8px）の分だけ戻す。揃えるのは枠の位置ではなく
+     中身の位置で、補正しないと上の称号・著者名より右にずれて見える (#2429 と同じ規則) */
+  margin-left: -8px;
 }
 .awards-hall-medal {
   display: inline-flex;


### PR DESCRIPTION
#2451 の追従。マージ済みの #2472 に入れ損ねた分。

## 変更

`.awards-hall-years` に `margin-left: -8px` を入れ、受賞年チップの中身をカード内の左端（「殿堂入り」ラベル・著者名）に揃えた。

## 理由

チップの pill には左 padding が 8px あるため、ラベルと著者名がカード内側 22px から始まるのに対し、メダルの描画は 30px から始まっていた。揃えるべきは枠の位置ではなく中身の位置。

記事のタグ列（`.blog-info-tags`）に同じ理由の補正が既にあり（#2429）、値と根拠を合わせている。

なおメダルの SVG は viewBox 24 のうち円が 6〜18 なので両脇に約5px の余白を内包しており、完全に揃えるなら -13px になる。pill がカードの文字列より外へ張り出すため、今回は padding 分の 8px のみ戻した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)