### PR TITLE
全期間・年別のグラフの上限を echarts の自動に任せる (#2466)

### DIFF
--- a/scripts/archive_post_chart.js
+++ b/scripts/archive_post_chart.js
@@ -1,15 +1,5 @@
 'use strict';
 
-// 上限はその年の実データに合わせる。年ごとに投稿ペースが違うため、
-// 固定にすると棒が潰れる年と余白だらけの年ができる。
-// 目盛が半端にならないよう 5 刻みに切り上げる
-hexo.extend.helper.register('max_posts', function (year) {
-  const acc = generatePostsSeries(this.site.posts, year);
-  const peak = Math.max(0, ...acc.map((item) => item.count));
-  const step = year ? 5 : 10;
-  return Math.max(step * 2, Math.ceil(peak / step) * step);
-});
-
 hexo.extend.helper.register('generate_posts_series_x', function (year) {
   const acc = generatePostsSeries(this.site.posts, year);
   return acc.map((e) => `'${e.groupKey}'`).join(',');

--- a/themes/future/layout/_partial/posts-chart.ejs
+++ b/themes/future/layout/_partial/posts-chart.ejs
@@ -29,7 +29,11 @@
     legend: { bottom: 0, type: 'scroll' },
     grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
     xAxis: { type: 'category', data: periodData.buckets },
-    yAxis: { type: 'value', min: 0, max: <%= year ? max_posts(year) : max_posts() %> },
+    <%# 上限は echarts の自動に任せる (#2466)。手で 90 に丸めると刻みは 20 のまま
+        最上段だけ 80→90 と間隔が変わる。自動は上限を刻みの倍数（100）に取る。
+        タブの2枚は同じ投稿を別の内訳で積んでいて合計が等しいので、
+        自動でも軸は揃い、タブを切り替えても目盛は動かない %>
+    yAxis: { type: 'value', min: 0 },
     <%# 棒の高さが期間の合計、内訳はその中の週。第1週→第5週と順序に意味が
         あるので同系の濃淡で塗る。ページャの現在地と同じ #337ab7 を最も濃い段に %>
     color: ['#337ab7', '#6097c7', '#8db5d7', '#b6cfe5', '#d2e2ef'],
@@ -48,7 +52,7 @@
     legend: { bottom: 0, type: 'scroll' },
     grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
     xAxis: { type: 'category', data: catData.<%= year ? 'months' : 'quarters' %> },
-    yAxis: { type: 'value', min: 0, max: <%= year ? max_posts(year) : max_posts() %> },
+    yAxis: { type: 'value', min: 0 },
     <%# カテゴリは順序に意味が無いので色相で分け、名前で固定する (#2170) %>
     series: catData.series.map(s => ({
       name: s.name,


### PR DESCRIPTION
#2466 の「相談したい」分（全期間 / 年別 / 全著者 / 全カテゴリ）です。**大きいグラフは echarts の自動目盛に任せます。**

## 調べた結果

けた違いに大きいので、小さいグラフの規則（上限を5の倍数・5刻み）はそのまま適用できません。

| ページ | ピーク | 変更前の上限 |
| --- | --- | --- |
| /articles/（四半期） | 87 | 90（`max_posts` が手で10の倍数へ切り上げ） |
| /articles/&lt;年&gt;/（月） | 26 | 30（同・5の倍数） |
| /categories/（四半期） | 87 | **自動**（元から） |
| /authors/（年・著者数） | 106 | **自動**（元から） |
| /tags/（年・新規タグ数） | 150 | **自動**（元から） |

手で上限を固定していたのは `_partial/posts-chart.ejs`（全期間・年別）**だけ**でした。他の3ページは元から自動です。

## 変更

`max_posts` による上限の手固定をやめ、`{ type: 'value', min: 0 }` にします。使う場所が無くなった `max_posts` ヘルパーも削除します。

**実データで描画して確認した差分は以下だけです。**

| チャート | 変更前の目盛 | 変更後 |
| --- | --- | --- |
| 全期間（四半期） | 0/20/40/60/80/**90** — 最上段だけ間隔が変わる | 0/20/40/60/80/**100** |
| 年別（月・2025） | 0/5/10/15/20/25/30 | **同じ**（自動でも同じ値を選ぶ） |

年別は見た目が変わりません。実質は全期間チャートの最上段と、ヘルパーの削除（データが増えても手入れが要らなくなる）です。

なお `_partial/posts-chart.ejs` のタブ2枚は、同じ投稿を「週/月の内訳」と「カテゴリの内訳」で積んでいて合計が等しいため、自動でも両者の軸は一致します。タブを切り替えても目盛は動きません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
