### PR TITLE
モバイルで目次を本文の前に折りたたんで出す (#2452)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1162,6 +1162,9 @@ code {
   margin-bottom: 20px;
   border: 1px solid #e0e0e0;
   border-radius: 3px;
+  /* details には全体で padding-bottom: 24px が掛かっている（本文中の折りたたみ
+     ブロック向け）。枠で囲む目次では最後の項目の下だけ余白が空くので打ち消す */
+  padding-bottom: 0;
 }
 .toc-mobile > summary {
   padding: 10px 12px;
@@ -1173,7 +1176,12 @@ code {
   border-bottom: 1px solid #e0e0e0;
 }
 .toc-mobile .toc-section {
-  padding: 6px 12px 10px;
+  padding: 6px 12px;
+}
+/* 素の ol が持つ下マージン（1rem）が残ると、最後の項目の下だけ余白が広くなる。
+   枠の中の余白は上下ともこのブロックの padding で決める */
+.toc-mobile .toc-section > ol {
+  margin-bottom: 0;
 }
 /* サイドバーの目次が出る幅（1024px より上）では本文前の目次は出さない。
    max-width: 1024px の裏返しなので、両方出る幅も両方消える幅も無い */

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1105,7 +1105,10 @@ code {
      line-height は既存の 1.75em が自身のサイズ基準で再計算されるため触らない */
   font-size: 1em;
 }
-.toc-section {
+/* .toc-section は目次の見た目（リストと行）だけを持つ。サイドバー特有の
+   余白と、モバイルで隠す指定はサイドバー側のセレクタに寄せる。
+   本文前のモバイル目次（.toc-mobile）が同じ見た目を使い回すため (#2452) */
+.blog-sidebar .toc-section {
   padding: 50px 0px 0px 0px;
 }
 .toc-section ol, .toc-section li {
@@ -1144,8 +1147,38 @@ code {
     width: 100%;
   }
   /* サイドバーごと本文の下に落ちた目次は末尾に出ても役に立たないため隠す。
-     以前はモバイル（768px）だけ隠していた */
-  .toc-section {
+     以前はモバイル（768px）だけ隠していた。
+     代わりに本文の直前へ .toc-mobile を出す (#2452) */
+  .blog-sidebar .toc-section {
+    display: none;
+  }
+}
+
+/* モバイルの目次 (#2452)。表示・非表示は下の min-width で切り替える。
+   max-width 側に display を書くと、ここの指定と同じ詳細度で後勝ちになり、
+   どちらが効くかが記述順で決まってしまう */
+.toc-mobile {
+  display: block;
+  margin-bottom: 20px;
+  border: 1px solid #e0e0e0;
+  border-radius: 3px;
+}
+.toc-mobile > summary {
+  padding: 10px 12px;
+  cursor: pointer;
+  font-weight: bold;
+}
+/* 開いたときだけ見出しと中身を線で分ける */
+.toc-mobile[open] > summary {
+  border-bottom: 1px solid #e0e0e0;
+}
+.toc-mobile .toc-section {
+  padding: 6px 12px 10px;
+}
+/* サイドバーの目次が出る幅（1024px より上）では本文前の目次は出さない。
+   max-width: 1024px の裏返しなので、両方出る幅も両方消える幅も無い */
+@media (min-width: 1025px) {
+  .toc-mobile {
     display: none;
   }
 }

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -27,6 +27,22 @@
           </ul>
           </header>
         <% } %>
+        <%# モバイルの目次 (#2452)。サイドバーの目次は 1024px 以下で本文の下に
+            落ちて役に立たないため隠しており、その代わりに本文の直前へ置く。
+            details/summary で開閉するので JS は足さない。PC では CSS で隠す。
+            既定は閉じる。開いたままだと本文の書き出しが画面外へ押し下がり、
+            記事に入るまでのスクロールが増える。長さで既定を変えると
+            ページごとに挙動が変わって戸惑わせるので、記事によらず閉じる %>
+        <% if (!index) { %>
+        <% const tocHtml = toc(post.content, {list_number: false, max_depth: 4}); %>
+        <%# 見出しが1つの記事は目次にならないので出さない %>
+        <% if ((tocHtml.match(/<li/g) || []).length >= 2) { %>
+        <details class="toc-mobile" data-nosnippet>
+          <summary>目次</summary>
+          <div class="toc-section"><%- tocHtml %></div>
+        </details>
+        <% } %>
+        <% } %>
         <div class="article-entry" itemprop="articleBody">
           <% if (post.excerpt && index){ %>
             <%- post.excerpt %>


### PR DESCRIPTION
#2452 モバイルで目次を本文の前に折りたたみで出す。

## 変更

記事ページの本文直前に `<details class="toc-mobile">` を置き、1024px 以下でだけ表示します。JS は足していません（details/summary）。PC のサイドバー目次は現状のままです。

- **既定は閉じる。** 開いたままだと本文の書き出しが画面外へ押し下がり、記事に入るまでのスクロールが増えます。記事の長さで既定を変える案は採りませんでした。ページごとに開閉が変わると、読者は次のページでどちらになるか分からず戸惑います
- **見出しが1つの記事には出しません。** 目次として機能しないためです（2026年の記事96本はすべて2つ以上で、実際には全記事に出ます）
- 目次の中身はサイドバーと同じ（`max_depth: 4`）。リンクと字下げの見た目も `.toc-section` を使い回しています

## CSS の切り替え

表示・非表示は `@media (min-width: 1025px)` 側だけで決めています。サイドバーを畳む `max-width: 1024px` に `display: block` を書くと、`.toc-mobile` の素の指定と同じ詳細度で後勝ちになり、**どちらが効くかが記述順で決まってしまう**ためです（実際、最初の実装はこれで表示されませんでした）。境界を裏返しにしたことで、両方出る幅も両方消える幅もありません。

あわせて `.toc-section` からサイドバー特有の指定（上の余白50px、モバイルで隠す）を `.blog-sidebar .toc-section` へ移し、`.toc-section` は目次の見た目だけを持つようにしました。

## 検証

ローカルビルドを 390px 幅のヘッドレスブラウザで描画し、閉じた状態・開いた状態を確認しました。生成HTMLでは、目次が `.article-entry`（articleBody）の**外側・直前**にあり、`open` 属性が付いていないことを確認しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
