### PR TITLE
記事から生HTMLの note と Font Awesome の残骸を除く

### DIFF
--- a/source/_posts/2017/20170605-urushi.md
+++ b/source/_posts/2017/20170605-urushi.md
@@ -38,7 +38,7 @@ Web Componentsの作り方・使い方については本記事では割愛させ
 
 ## どのようなもの？
 
-[<i class="fa fa-arrow-right"></i>Urushi 公式](http://future-architect.github.io/urushi/ja-jp/)
+[Urushi 公式](http://future-architect.github.io/urushi/ja-jp/)
 フューチャーアーキテクトのWebアプリケーション開発現場で、上述しているWeb Componentsの技術を使わずに実装したWeb componentフレームワークです。
 
 2017年5月時点では下記の形で提供しています。

--- a/source/_posts/2023/20230307a_CircleCIでPullRequest作成時の負荷を軽減する.md
+++ b/source/_posts/2023/20230307a_CircleCIでPullRequest作成時の負荷を軽減する.md
@@ -320,8 +320,6 @@ CircleCIのOnly build pull requests
 <img src="/images/2023/20230307a/image_2.png" alt="image.png" width="1200" height="569" loading="lazy">
 
 ::: note warn
-<span class="fa fa-fw fa-exclamation-circle"></span>
-
 GitHubアカウントのユーザー名
 add_label.shでは、author.nameがスペースで区切られていないことを想定しています。
 アカウント名にスペースが含まれる場合は、author.nameを別にリクエストして変数に格納するなどしてください。

--- a/source/_posts/2023/20230329a_tftarget：Terraformターゲットを選択的に実行するためのGo製CLIツール.md
+++ b/source/_posts/2023/20230329a_tftarget：Terraformターゲットを選択的に実行するためのGo製CLIツール.md
@@ -69,10 +69,9 @@ https://github.com/future-architect/tftarget/releases
 
 冒頭で述べたように、複数人で開発し、各人が個別に定義したリソースに影響を与えずに開発を進める際に役立ちます。`terraform target`を簡単に実行したい場面全般で利用価値があるおもいます。
 
-<div class="note alert" style="background: #feebee; padding:16px; margin:24px 12px; border-radius:8px;">
-  <span class="fa fa-fw fa-times-circle"></span>
+::: note alert
 動作検証はAWS環境でしか行っていないため、GCPやAzure環境で利用する際は事前に動作確認をお願いします。
-</div>
+:::
 
 ## 3 tftargetのインストール方法
 

--- a/themes/future/css-src/_variables.styl
+++ b/themes/future/css-src/_variables.styl
@@ -27,9 +27,6 @@ font-serif = Georgia, "Times New Roman", serif
 font-ja = "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic UI", "Yu Gothic", Meiryo, "Noto Sans CJK JP", sans-serif
 // 等幅。ui-monospace で各OSの推奨等幅フォント（SF Mono など）を優先する
 font-mono = ui-monospace, "SF Mono", "Cascadia Code", "Source Code Pro", Menlo, Monaco, Consolas, "Liberation Mono", monospace
-font-icon = FontAwesome
-font-icon-path = "fonts/fontawesome-webfont"
-font-icon-version = "4.0.3"
 font-size = 14px
 line-height = 1.6em
 line-height-title = 1.1em


### PR DESCRIPTION
#2459 の一部。#2492 の調査で見つかったものをまとめて片付ける。

## 分かったこと

**Font Awesome はこのサイトに読み込まれていない。** 配信中の `/css/site.css` に `.fa` で始まるルールが 0件、`fontawesome-webfont` の参照も 0件。`_variables.styl` に `font-icon` / `font-icon-path` / `font-icon-version` の3変数が残っていたが、どこからも参照されていなかった。

つまり記事に書かれた `class="fa …"` の要素は**以前から何も描画していない**空要素だった。`::: note` のアイコンが CSS の `background-image` で実装されているのも、これが理由と思われる。

## 変更

| 記事 | 変更前 | 変更後 |
| --- | --- | --- |
| `/articles/20230329a/` | `<div class="note alert" style="…">` ＋ `<span class="fa fa-fw fa-times-circle">` | `::: note alert` |
| `/articles/20230307a/` | `::: note warn` の中に空の `<span class="fa fa-fw fa-exclamation-circle">` | 削除 |
| `/articles/20170605/` | リンク内の空の `<i class="fa fa-arrow-right">` | 削除 |

併せて `themes/future/css-src/_variables.styl` から未参照の `font-icon` 系3変数を削除した。

これで**記事から `class="note` と `class="fa` が無くなる**。

## 20230329a について

生 HTML のときはインラインスタイルで背景 `#feebee` を指定していた。`::: note alert` にすることで alert の標準色 `#ffdbdb` になり、**アイコン（赤の感嘆符）も出るようになる**。どちらもピンクなので印象は変わらない。

なお #2492 でクラス名を `note-alert` に改名したため、この記事の `class="note alert"` はテーマの背景指定に当たらなくなっていた（インラインスタイルのおかげで見た目は保たれていた）。ここで記法を揃えることで整合する。

## 確認

- 記事全体を grep して `class="note` / `class="fa` / `<i class=` が 0件
- `/articles/20230329a/` が `<div class="note-container note-alert">` ＋ `class="note-icon"` で出力されること
- `/articles/20230307a/`、`/articles/20170605/` に `class="fa ` が残っていないこと
- `_variables.styl` の変更後も `/css/site.css` が正常にビルドされること（200 / 133KB）
- textlint: 3ファイルとも**変更行にエラーなし**（既存のエラーは残るが、いずれも触っていない行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
