### PR TITLE
_multiconfig.yml を .gitignore に追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ temp.json
 .claude/settings.local.json
 .claude/worktrees/
 _config.fast.yml
+
+# hexo generate --config a,b が設定を合成して吐く一時ファイル
+_multiconfig.yml


### PR DESCRIPTION
`hexo generate --config _config.yml,_config.fast.yml` のように設定を複数渡すと、Hexo が合成結果を `_multiconfig.yml` として作業ディレクトリに書き出します。差分ビルドを使うたびに未追跡ファイルとして残り、`git status` が汚れるので無視します。

同じ理由で `_config.fast.yml` は既に無視済みなので、その隣に置きました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)