### PR TITLE
インラインコードの地の規則を code-bg() に一本化する

### DIFF
--- a/themes/future/css-src/_variables.styl
+++ b/themes/future/css-src/_variables.styl
@@ -65,3 +65,13 @@ columns = main-column + _sidebar-column
 mq-mobile = "screen and (max-width: 479px)"
 mq-tablet = "screen and (min-width: 480px) and (max-width: 767px)"
 mq-normal = "screen and (min-width: 768px)"
+// 色の付いた地の上に置くインラインコードの背景を返す (#2487)。
+// 「地より一段濃い同じ色」という関係を1箇所で定義し、note の4色でも
+// テーブルヘッダでも同じ規則が効くようにする。個別に値を決めていた頃は
+// note が色相ベース、テーブルヘッダが無彩色固定と導き方が2つに分かれていた。
+//
+// 倍率は joshwcomeau.com の --color-*-100 → *-200 の実測値から取った (#2482)。
+// 明度だけでなく彩度も少し下げるのは、明度を落とすと同じ彩度でも色が強く
+// 出るため。無彩色（テーブルヘッダの #f2f2f2）では彩度が 0 なので明度だけが効く
+code-bg(bg)
+  hsl(hue(bg), saturation(bg) * 0.94, lightness(bg) * 0.94)

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -782,6 +782,7 @@ ul.social-button li a {
   縞が効く長さの表はそもそも少ない。
 */
 table-border = #ccc
+table-header-bg = #f2f2f2
 
 table {
   table-layout: auto;
@@ -797,13 +798,16 @@ th {
   // 900 は Hiragino / Yu Gothic に該当ウェイトが無く、ブラウザの合成太字になって輪郭が濁る
   font-weight: 700;
   // 従来のゼブラと同じ中立グレー。Zenn は青みのある #edf2f7 だが、
-  // 本ブログの配色では水色に寄って浮くため、見慣れた無彩色をそのまま使う
-  background-color: #f2f2f2;
+  // 本ブログの配色では水色に寄って浮くため、見慣れた無彩色をそのまま使う。
+  // 中のインラインコードの地はこの値から code-bg() で導く (#2487)
+  background-color: table-header-bg;
 }
 // インラインコードの地色 #eee はヘッダの地色とほぼ同じ明度で、そのままだと溶ける。
-// ヘッダ内では一段暗くして、本文セル（白地に #eee）と同じ「浮いて見える」関係を保つ
+// ヘッダ内では一段暗くして、本文セル（白地に #eee）と同じ「浮いて見える」関係を保つ。
+// 濃さの決め方は note の中と同じ規則（code-bg）に寄せた。以前は #e2e2e2 の
+// 固定値で、狙いは同じなのに導き方が2つに分かれていた (#2487)
 .article-entry th code {
-  background: #e2e2e2;
+  background: code-bg(table-header-bg);
 }
 .highlight .pre {
   margin-bottom: 50px;
@@ -2621,17 +2625,22 @@ pre.mermaid,
    tip の地は以前 #8E96AA24 と透過色だったが、他の3つに合わせて不透明にした。
    白地に載せた実効値と同じなので見た目は変わらない。透過のままだと、ここから
    色を導くたびに合成計算が要る（#2482 でその合成を誤って1段濃い色を算出した） */
+note-tip-bg = #eff0f3
+note-info-bg = #e5f8e2
+note-warn-bg = #fdf9e2
+note-alert-bg = #ffdbdb
+
 .note-container.note-tip {
-  background: #eff0f3;
+  background: note-tip-bg;
 }
 .note-container.note-info {
-  background: #e5f8e2;
+  background: note-info-bg;
 }
 .note-container.note-warn {
-  background: #fdf9e2;
+  background: note-warn-bg;
 }
 .note-container.note-alert {
-  background: #ffdbdb;
+  background: note-alert-bg;
 }
 
 .note-container {
@@ -2656,16 +2665,16 @@ pre.mermaid,
 /* tip の地だけ透過色（rgba(142,150,170,0.141)）なので、白地に載せた
    実効値 #eff0f3 から導く */
 .article-entry .note-container.note-tip :not(pre) > code {
-  background: #dfe1e6;
+  background: code-bg(note-tip-bg);
 }
 .article-entry .note-container.note-info :not(pre) > code {
-  background: #d1f1cc;
+  background: code-bg(note-info-bg);
 }
 .article-entry .note-container.note-warn :not(pre) > code {
-  background: #faf2c9;
+  background: code-bg(note-warn-bg);
 }
 .article-entry .note-container.note-alert :not(pre) > code {
-  background: #fdc0c0;
+  background: code-bg(note-alert-bg);
 }
 
 /* note の中のリンクは一段暗い青にする。地を濃くした分、本文色（#424242）は


### PR DESCRIPTION
Close #2487

#2482 で note の中のインラインコードを「地の色を一段濃くしたもの」にしたが、テーブルヘッダの中は `#e2e2e2` の無彩色固定のままだった。狙いは同じなのに導き方が2つに分かれていたので、**1つの関数に寄せた**。

## 変更

`_variables.styl` に関数を1つ置いた。

```styl
code-bg(bg)
  hsl(hue(bg), saturation(bg) * 0.94, lightness(bg) * 0.94)
```

地の色を変数にして、コードの地はそこから導く。

```styl
note-info-bg = #e5f8e2
.note-container.note-info { background: note-info-bg; }
.article-entry .note-container.note-info :not(pre) > code { background: code-bg(note-info-bg); }
```

テーブルヘッダも同じ形にした（`table-header-bg = #f2f2f2`）。

## 結果

**note の4色は関数化しても値が1つも変わらない。** Stylus の HSL 計算が、これまで手で計算していた値と完全に一致した。

| 種別 | 地 | コードの地（変更前 = 変更後） |
| --- | --- | --- |
| tip | `#eff0f3` | `#dfe1e6` |
| info | `#e5f8e2` | `#d1f1cc` |
| warn | `#fdf9e2` | `#faf2c9` |
| alert | `#ffdbdb` | `#fdc0c0` |

テーブルヘッダだけ値が動く。

| | 地 | コードの地 |
| --- | --- | --- |
| 変更前 | `#f2f2f2` | `#e2e2e2`（手で決めた値） |
| 変更後 | `#f2f2f2` | `#e3e3e3`（`code-bg()` で導出） |

**差は 1/255 で、目視で区別できない。** 元の値が規則とほぼ一致していたということで、規則そのものの妥当性の裏付けにもなっている。

コントラスト比も実質変わらない（本文 7.76 → 7.83、リンク 4.97 → 5.02、訪問済 6.99 → 7.06）。いずれも AA を満たす。

## この変更の意味

値が変わらないので**見た目の改善ではない**。効くのは次に色を触るときで、

- note の地の色を変えれば、コードの地が自動で追従する
- 色付きの地を持つ枠を新しく作るとき、`code-bg()` を呼ぶだけで規則が揃う
- 「一段濃い」の定義が1箇所にあるので、根拠（joshwcomeau.com の `--color-*-100` → `*-200` の実測）もそこに書ける

## 調査

記事本文の中で地に色が付くのは **note の4種とテーブルヘッダだけ**だった。配信 CSS を全走査して確認済み（本文行は `#fff`、引用は左ボーダーのみで背景なし）。したがって対象はこの5箇所で全部。

## 確認

配信中の `/css/site.css` で、上の表のとおりの値が出ていること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
