### PR TITLE
CSSだけ再生成する make css を追加し、hexo generate の使い分けを明記する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ lede: "Go 1.27 で標準ライブラリに追加されたuuidパッケージを�
 ```sh
 make s      # ローカルサーバ（http://localhost:4000、ライブリロード付き。hexo-server-live）
 make g      # 静的ファイル生成（public/）
+make css    # public/css/site.css だけ再生成（0.3秒。CSSの確認用）
 make clean  # キャッシュ・生成物の削除
 make fix    # textlint --fix（source/_posts 配下）
 make fmt    # markdownlint-cli2 --fix ＋ prettier（scripts/*.js と *.mjs のみ。記事MDは対象外 #2307）
@@ -94,6 +95,18 @@ make mermaid # mermaid 図のSVGキャッシュ更新（Docker必須、記事の
 
 記事を書き換えたら `make fix` か、対象ファイルだけの
 `node_modules/.bin/textlint --fix <path>` を通してから push する。
+
+**`hexo generate` は必要なときだけ回す。** 何も変えていなくても1分半以上かかる
+（記事1,449本ぶんの処理が毎回走り、書き出し0ファイルでも同じ）。
+
+| 変えたもの | 確認に必要なもの |
+| --- | --- |
+| CSS（`themes/future/css-src/*.styl`） | `make css`（0.3秒）だけ。ページの再生成は不要 |
+| テンプレート（`.ejs`）・`scripts/` のヘルパー・記事 | `hexo generate` |
+
+`_config.fast.yml` を渡す差分ビルドは効いていない。`ignore` のパターンが実パスに
+1つもマッチせず、記事数も画像コピー（1.2GB）も素のビルドと変わらない。
+時間の内訳は書き出しではなく Hexo 側の処理なので、除外しても縮まない。
 
 ## Lint ルール
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ fix:
 g:
 	node_modules/.bin/hexo g
 
+css:
+	node css.mjs
+
 mermaid:
 	node mermaid_svg.mjs
 

--- a/css.mjs
+++ b/css.mjs
@@ -1,0 +1,38 @@
+// CSS だけを public/css/site.css に書き出す開発用スクリプト（make css）。
+//
+// hexo generate は何も変えていなくても1分半以上かかる（記事1,449本ぶんの
+// 処理が毎回走るため。書き出し0ファイルでも同じ）。CSS の見た目を確かめる
+// だけならページの再生成は要らないので、連結済みの CSS を直接置き換える。
+//
+// 連結の順序と内容は scripts/combine_css.js と同じにすること。
+// あちらが公開ビルドの正で、ここはその写し。順序を変えると表示が壊れる。
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const stylus = require('stylus');
+
+const root = dirname(fileURLToPath(import.meta.url));
+const themeDir = join(root, 'themes/future');
+const stylPath = join(themeDir, 'css-src/theme-styles.styl');
+
+stylus.render(readFileSync(stylPath, 'utf8'), { filename: stylPath }, (err, css) => {
+  if (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+  const combined = [
+    '/* bootstrap-subset.css */',
+    readFileSync(join(themeDir, 'css-src/bootstrap-subset.css'), 'utf8'),
+    '/* metronic/assets/style.css */',
+    readFileSync(join(themeDir, 'metronic-src/assets/style.css'), 'utf8'),
+    '/* theme-styles.styl */',
+    css,
+  ].join('\n');
+
+  const out = join(root, 'public/css/site.css');
+  writeFileSync(out, combined);
+  console.log(`${out} (${Math.round(combined.length / 1024)}KB)`);
+});


### PR DESCRIPTION
CSS の見た目を確かめるだけのときに `hexo generate`（1分半以上）を回していたので、CSS だけを差し替える経路を用意します。

## 実測

| やること | かかる時間 |
| --- | --- |
| `hexo generate`（何も変えていない状態） | **1分36秒**・書き出し0ファイル |
| `make css` | **0.16秒** |

`hexo generate` の時間は書き出しではなく Hexo 側の処理（記事1,449本ぶん）なので、生成対象を減らしても縮みません。

## 変更

- `css.mjs` / `make css`: `bootstrap-subset.css` → `metronic/assets/style.css` → `theme-styles.styl`（Stylus描画）を連結して `public/css/site.css` に書き出す。**順序と内容は `scripts/combine_css.js` と同じ**で、あちらが公開ビルドの正、こちらはその写し
- CLAUDE.md に使い分けの表を追加。CSS だけなら `make css`、テンプレート・ヘルパー・記事を変えたときは `hexo generate`

## あわせて記録した事実

`_config.fast.yml` を渡す差分ビルドは**効いていません**でした。

- `ignore` のパターン（`'**/source/images/**'` 等）が実パスに**1つもマッチしない**（micromatch で確認）
- 読み込む記事数は fast あり / なしとも **1469 件で同じ**
- `public/images` は 1.2GB がコピーされ、今日のビルドでも更新されている

CLAUDE.md にその旨を書きました。fast config 自体をどうするか（パターンを直すか廃止するか）は別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)