### PR TITLE
Markdown コードブロックに色が付いていなかったのを直す

### DIFF
--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -8,10 +8,6 @@ highlight-background = #2b2b2b     // 以前は #2d2d2d。わずかに明るく�
 highlight-current-line = #323232
 highlight-selection = #214283
 highlight-foreground = #a9b7c6     // 青みのあるグレー
-// Markdown の強調用。地の文より明るくして、太字・斜体が浮き上がるようにする。
-// 色相は地の文と同じ青みのグレーのまま明度だけ上げるので、他の構文色と競合しない
-highlight-strong = #bcc6d1         // #2b2b2b に対して 8.18
-highlight-emphasis = #b0bac6       // 〃 7.20（地の文 6.93 と強調 8.18 の間）
 highlight-comment = #9a9a9a
 highlight-red = #ff6b68
 highlight-orange = #e08744         // キーワード
@@ -252,17 +248,19 @@ pre
   .link
   .symbol
     color: highlight-blue
-  // 強調。highlight.js は ** ごと1つの span にするので（`**text**` で1トークン）、
-  // 記号だけを別の色にはできない。字面（太字・斜体）に明るさを足して、
-  // 記号と中身をまとめて「強調の記法」として見せる。
-  // 有彩色は使わない。強調は「目立たせる」だけで意味の種類を表さないので、
-  // 構文の色（見出しの黄、記号のオレンジ）と並ぶと役割が読み取りにくくなる。
-  // 地の文と同じ色相のまま明度だけ上げて、白に寄せることで浮き上がらせる
+  // 強調は色を持たせず、字面だけで示す。
+  //
+  // 強調は「目立たせる」だけで意味の種類を表さないため、構文の色（見出しの黄、
+  // 記号のオレンジ）と並ぶと色が役割の手がかりにならなくなる。かといって
+  // 明度だけ上げる案も、地の文との差を付けると浮いて見えた（11.49 → 9.44 →
+  // 8.18 と3段階下げても明るく感じる）。太字・斜体という字面の変化だけで
+  // 強調は十分に伝わるので、色は地の文のまま置く。
+  //
+  // なお highlight.js は ** ごと1つの span にするので（`**text**` で1トークン）、
+  // 記号だけを別扱いにすることはそもそもできない
   .strong
-    color: highlight-strong
     font-weight: bold
   .emphasis
-    color: highlight-emphasis
     font-style: italic
   // diff_[language] ではキーワードから色を外し、太字だけ残す。
   // 差分の赤緑と構文の色が同時に出ると色数が多すぎて読み取りにくいため

--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -10,8 +10,8 @@ highlight-selection = #214283
 highlight-foreground = #a9b7c6     // 青みのあるグレー
 // Markdown の強調用。地の文より明るくして、太字・斜体が浮き上がるようにする。
 // 色相は地の文と同じ青みのグレーのまま明度だけ上げるので、他の構文色と競合しない
-highlight-strong = #cbd4dd         // #2b2b2b に対して 9.44
-highlight-emphasis = #b9c3ce       // 〃 7.93（地の文 6.93 と強調 9.44 の間）
+highlight-strong = #bcc6d1         // #2b2b2b に対して 8.18
+highlight-emphasis = #b0bac6       // 〃 7.20（地の文 6.93 と強調 8.18 の間）
 highlight-comment = #9a9a9a
 highlight-red = #ff6b68
 highlight-orange = #e08744         // キーワード

--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -10,8 +10,8 @@ highlight-selection = #214283
 highlight-foreground = #a9b7c6     // 青みのあるグレー
 // Markdown の強調用。地の文より明るくして、太字・斜体が浮き上がるようにする。
 // 色相は地の文と同じ青みのグレーのまま明度だけ上げるので、他の構文色と競合しない
-highlight-strong = #e3e8ee         // #2b2b2b に対して 11.49
-highlight-emphasis = #c3ccd6       // 〃 8.72（地の文 6.93 と強調 11.49 の間）
+highlight-strong = #cbd4dd         // #2b2b2b に対して 9.44
+highlight-emphasis = #b9c3ce       // 〃 7.93（地の文 6.93 と強調 9.44 の間）
 highlight-comment = #9a9a9a
 highlight-red = #ff6b68
 highlight-orange = #e08744         // キーワード

--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -8,6 +8,10 @@ highlight-background = #2b2b2b     // 以前は #2d2d2d。わずかに明るく�
 highlight-current-line = #323232
 highlight-selection = #214283
 highlight-foreground = #a9b7c6     // 青みのあるグレー
+// Markdown の強調用。地の文より明るくして、太字・斜体が浮き上がるようにする。
+// 色相は地の文と同じ青みのグレーのまま明度だけ上げるので、他の構文色と競合しない
+highlight-strong = #e3e8ee         // #2b2b2b に対して 11.49
+highlight-emphasis = #c3ccd6       // 〃 8.72（地の文 6.93 と強調 11.49 の間）
 highlight-comment = #9a9a9a
 highlight-red = #ff6b68
 highlight-orange = #e08744         // キーワード
@@ -249,15 +253,16 @@ pre
   .symbol
     color: highlight-blue
   // 強調。highlight.js は ** ごと1つの span にするので（`**text**` で1トークン）、
-  // 記号だけを別の色にはできない。字面（太字・斜体）に色を足して、
+  // 記号だけを別の色にはできない。字面（太字・斜体）に明るさを足して、
   // 記号と中身をまとめて「強調の記法」として見せる。
-  // 紫は Markdown のブロックに出る他のクラス（見出しの黄、記号のオレンジ）と
-  // 当たらない。#2b2b2b に対して 4.92 で AA を満たす
+  // 有彩色は使わない。強調は「目立たせる」だけで意味の種類を表さないので、
+  // 構文の色（見出しの黄、記号のオレンジ）と並ぶと役割が読み取りにくくなる。
+  // 地の文と同じ色相のまま明度だけ上げて、白に寄せることで浮き上がらせる
   .strong
-    color: highlight-purple
+    color: highlight-strong
     font-weight: bold
   .emphasis
-    color: highlight-purple
+    color: highlight-emphasis
     font-style: italic
   // diff_[language] ではキーワードから色を外し、太字だけ残す。
   // 差分の赤緑と構文の色が同時に出ると色数が多すぎて読み取りにくいため

--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -232,6 +232,27 @@ pre
   .javascript .function
     color: highlight-orange
     font-weight: bold
+  // Markdown / AsciiDoc の記法 (#2460)。言語自体は highlight.js の既定バンドルに
+  // 入っていてトークンには分かれていたが、これらのクラスに色の指定が無く、
+  // すべて地の文の色で出ていた（＝ハイライトされていないように見えた）。
+  // 色は既存のパレットから選び、新しい色は増やしていない
+  .section
+    color: highlight-yellow
+    font-weight: bold
+  .bullet
+    color: highlight-orange
+  .quote
+    color: highlight-comment
+  .code
+    color: highlight-green
+  .link
+  .symbol
+    color: highlight-blue
+  // 強調は色ではなく字面で示す。Markdown の ** / * がそのまま太字・斜体になる
+  .strong
+    font-weight: bold
+  .emphasis
+    font-style: italic
   // diff_[language] ではキーワードから色を外し、太字だけ残す。
   // 差分の赤緑と構文の色が同時に出ると色数が多すぎて読み取りにくいため
   .keyword-plain

--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -248,10 +248,16 @@ pre
   .link
   .symbol
     color: highlight-blue
-  // 強調は色ではなく字面で示す。Markdown の ** / * がそのまま太字・斜体になる
+  // 強調。highlight.js は ** ごと1つの span にするので（`**text**` で1トークン）、
+  // 記号だけを別の色にはできない。字面（太字・斜体）に色を足して、
+  // 記号と中身をまとめて「強調の記法」として見せる。
+  // 紫は Markdown のブロックに出る他のクラス（見出しの黄、記号のオレンジ）と
+  // 当たらない。#2b2b2b に対して 4.92 で AA を満たす
   .strong
+    color: highlight-purple
     font-weight: bold
   .emphasis
+    color: highlight-purple
     font-style: italic
   // diff_[language] ではキーワードから色を外し、太字だけ残す。
   // 差分の赤緑と構文の色が同時に出ると色数が多すぎて読み取りにくいため


### PR DESCRIPTION
Close #2460

## 調べた結果

**言語の登録は不要だった。** `markdown` は `highlight.js` の既定バンドル（`node_modules/highlight.js/lib/common.js`）に入っており、トークン化は正しく行われていた。

```html
<span class="section"># 要件定義</span>
<span class="bullet">-</span> <span class="strong">**単語落下タイミング**</span>：…
```

問題は**その先**で、`highlight.styl` にこれらのクラスの色指定が無かった。結果、すべて地の文の色（`#a9b7c6`）で描かれ、**ハイライトされていないように見えていた**。

`markdown` が出すクラスは9種類。うち色があったのは2つだけだった。

| クラス | 変更前 | 変更後 |
| --- | --- | --- |
| `string` | 緑（既存） | そのまま |
| `literal` | 青（既存） | そのまま |
| `section`（見出し） | **無し** | 黄 `#ffc66d` ＋ 太字 |
| `bullet`（リストの記号） | **無し** | オレンジ `#e08744` |
| `quote`（引用） | **無し** | コメント色 `#9a9a9a` |
| `code`（インラインコード） | **無し** | 緑 `#84a86f` |
| `link` / `symbol` | **無し** | 青 `#6897bb` |
| `strong` | **無し** | 太字（色は地の文のまま） |
| `emphasis` | **無し** | 斜体（色は地の文のまま） |

## 色の選び方

**新しい色は増やしていない。** すべて `highlight.styl` が既に持っているパレット（Darcula 由来、`#2b2b2b` に対して AA を満たすよう明度調整済み）から選んでいる。

- 見出しは構造を最も強く示すので、関数名・型名と同じ黄＋太字
- 引用は補足なのでコメントと同じ扱い
- インラインコードは文字列と同じ緑
- 強調（`**` / `*`）は**色を持たせず字面だけ**で示す

強調の色は試行のうえで外した。紫を当てる案、地の文と同じ色相で明度だけ上げる案（コントラスト比 11.49 → 9.44 → 8.18 と3段階）を試したが、いずれも浮いて見えた。強調は「目立たせる」だけで意味の種類を表さないので、構文の色（見出しの黄、記号のオレンジ）と並ぶと色が役割の手がかりにならなくなる。太字・斜体という字面の変化で十分に伝わる。

なお `highlight.js` は `**` ごと1つの span にするため（`**text**` で1トークン）、記号だけを別の色にすることはそもそもできない。

## 影響範囲

クラス名は言語をまたいで共有されるため、`markdown` 以外にも効く。

- `section` / `bullet` / `quote` — AsciiDoc など軽量マークアップ系
- `strong` / `emphasis` — 太字・斜体の意味は言語を問わず同じ
- `symbol` — Ruby のシンボルは `.ruby .symbol`（詳細度 0,2,0）が既存の緑で勝つため変わらない

いずれも意味に沿った割り当てなので、他言語で不自然にはならない。

## 対象記事

` ```markdown ` / ` ```md ` を使っているのは **11記事・15箇所**（`markdown` 表記6、`md` 表記9）。2022年から使われており、2026年だけで5箇所と直近が最多。プロンプトや Claude Code のスキルを扱う記事で今後も増える見込み。

## 確認

- `/articles/20250428a/`（Cursor によるAI駆動開発入門）で `section` / `bullet` の span に色が付き、`strong` が太字になること
- ` ```md ` 表記でも同じトークンが出ること（`/articles/20220419a/`）。`md` は `markdown` のエイリアスとして解決されるため、クラス名が同じで CSS がそのまま効く
- 配信中の `/css/site.css` に8クラスの規則が出ていること

なお `_config.yml` は `auto_detect: false` なので、**言語名を明示しない限りハイライトされない**点は変わらない（` ``` ` だけのブロックは対象外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
