### PR TITLE
スライド・動画の埋め込みを画面幅に追従させる

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -3041,9 +3041,35 @@ note-alert-bg = #ffdbdb
   width: 100%;
 }
 
-/* Slideshareの埋め込み用途 */
-.slideshare-responsive {
-  width: min(500px, 90%);
+/* スライド・動画の埋め込み (#2454)。記事側は width / height を固定値で
+   書いているため、狭い画面では幅だけ縮んで高さが残り縦に空くか、
+   幅が画面を超えてはみ出す。幅を親に合わせ、高さは縦横比で決める。
+
+   Speakerdeck は埋め込みコードが自前で
+   `width:100%; height:auto; aspect-ratio:560/315` を持っているので触らない。
+
+   比率は提供元ごとの決め打ち。デッキの縦横比が枠と違っても、提供元の
+   プレイヤーが枠の中で余白を作るだけで中身は切れない。
+   迷う場合は縦長（値の小さい方）を採り、確実に収まる側へ倒している */
+.article-entry iframe[src*='docs.google.com'],
+.article-entry iframe[src*='slideshare.net'],
+.article-entry iframe[src*='youtube.com'] {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  height: auto;
+}
+/* 960x569。記事で幅も高さも指定しているものが揃ってこの比率 */
+.article-entry iframe[src*='docs.google.com'] {
+  aspect-ratio: 960 / 569;
+}
+/* 476x400。プレイヤーの操作バーを含む比率で、記事の実測は 1.19〜1.21 に
+   収まる。最も縦長の 1.19 を採る */
+.article-entry iframe[src*='slideshare.net'] {
+  aspect-ratio: 476 / 400;
+}
+.article-entry iframe[src*='youtube.com'] {
+  aspect-ratio: 560 / 315;
 }
 
 /* フッターのリンクは行の高さ分しかタップ領域が無く、Lighthouse の


### PR DESCRIPTION
Close #2454

## 実態

全記事の `<iframe>` を数えたところ、**パターンは4つ**あり、うち3つに同じ欠陥があった。

| 提供元 | 件数 | 指定 | 狭い画面での挙動 |
| --- | --- | --- | --- |
| **Google Slides** | **21** | `width="100%"` 等 ＋ `height="569"` 固定 | **幅だけ縮み、高さ569pxが残る** |
| Speakerdeck | 16 | `width:100%; height:auto; aspect-ratio:560/315`（インライン） | **正常** |
| YouTube | 13 | `width="560" height="315"` 固定px | **幅が画面を超える** |
| SlideShare | 7 | 幅も高さもバラバラ（476/427/510/714 × 400/356/600/420） | **両方起きる** |

Issue に挙がっていた `/articles/20250919a/` は SlideShare。`class="slideshare-responsive"` が付いていたが、CSS は `width: min(500px, 90%)` の1行だけで**高さの `600` は固定のまま**だった。これが「縦に空きすぎる」の直接の原因。

**件数が最多の Google Slides（21件）も症状は同じ。** `width="100%"` なので横幅は追従するが `height="569"` が残るため、幅350pxの画面では 350×569 の枠に 16:9 のスライドが表示され、上下に200px以上の空白が出る。

## 変更

Speakerdeck が正しく動いている理由がそのまま答えになっている。

```html
style="width: 100%; height: auto; aspect-ratio: 560 / 315;"
```

同じことを CSS の属性セレクタで他の3つに当てた。

```styl
.article-entry iframe[src*='docs.google.com'],
.article-entry iframe[src*='slideshare.net'],
.article-entry iframe[src*='youtube.com'] {
  display: block;
  width: 100%;
  max-width: 100%;
  height: auto;
}
```

比率は提供元ごとに決め打ち。

| 提供元 | `aspect-ratio` | 根拠 |
| --- | --- | --- |
| Google Slides | `960 / 569` | 記事で幅も高さも指定しているものが揃ってこの比率 |
| SlideShare | `476 / 400` | プレイヤーの操作バーを含む比率。記事の実測は 1.19〜1.21 で、最も縦長の 1.19 を採る |
| YouTube | `560 / 315` | 標準の埋め込み寸法 |

**Speakerdeck は触っていない。** 埋め込みコードが自前で同じ指定を持っているため。

## 「切れない」ことについて

デッキの縦横比が枠と違っても、**提供元のプレイヤーが枠の中で余白を作るだけで中身は切れない**。iframe の中身は提供元のページで、そのページが自分の枠に合わせて縮小表示するため。

そのうえで、迷う場合は**縦長（比率の値が小さい方）**を採り、確実に収まる側へ倒している。

## 併せて

`.slideshare-responsive` の規則を削除した。`width` だけを決める規則で、今回の指定に完全に置き換わるため。クラス名は記事側（`/articles/20250919a/`）に残るが、当たる規則が無くなるだけで害はない。

## 対象外

- `w.soundcloud.com`（1件、`height="300"`）— 高さ固定のプレイヤーで、これが正しい
- `drive.google.com`（1件）、`hatenablog-parts.com`（1件）— 各1件で症状も出ていない

## 確認

配信中の `/css/site.css` に4つの規則が出ていること、`.slideshare-responsive` が消えていることを確認済み。

見るなら `/articles/20250919a/`（SlideShare）と、Google Slides を埋めている記事。ブラウザ幅を狭めて縦の空きが消えることを確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
