### PR TITLE
4箇所の列挙を箇条書きにして max-ten を0件にする

### DIFF
--- a/source/_posts/2020/20200401-vue-props-down.md
+++ b/source/_posts/2020/20200401-vue-props-down.md
@@ -235,10 +235,10 @@ export default {
 
 答えは、`ChildLayer.vue`の`props`の`value`プロパティです。`ParentLayer.vue`では`testData`という変数で扱われていた値は、`ChildLayer.vue`では`value`プロパティの値として扱われます。こうして、親コンポーネントから子コンポーネントへと値が流れ込んできます。`ChildLayer.vue`内では、その`value`を4箇所で使っています。
 
-- 1つ目は、マスタッシュ構文
-- 2つ目は、`input`の`:value`
-- 3つ目は、`button`タグのクリックイベントの引数
-- 4つ目は、さらに子コンポーネントの`grand-parent-layer`
+- 1つ目: マスタッシュ構文
+- 2つ目: `input`の`:value`
+- 3つ目: `button`タグのクリックイベントの引数
+- 4つ目: さらに子コンポーネントの`grand-parent-layer`
 
 `ParentLayer.vue`との違いに気づきましたか？`button`タグがあることが1番目立ちますがそれ以外です。
 

--- a/source/_posts/2020/20200401-vue-props-down.md
+++ b/source/_posts/2020/20200401-vue-props-down.md
@@ -235,10 +235,10 @@ export default {
 
 答えは、`ChildLayer.vue`の`props`の`value`プロパティです。`ParentLayer.vue`では`testData`という変数で扱われていた値は、`ChildLayer.vue`では`value`プロパティの値として扱われます。こうして、親コンポーネントから子コンポーネントへと値が流れ込んできます。`ChildLayer.vue`内では、その`value`を4箇所で使っています。
 
-1つ目は、マスタッシュ構文で、
-2つ目は、`input`の`:value`で、
-3つ目は、`button`タグのクリックイベントの引数で、
-4つ目は、さらに子コンポーネントの`grand-parent-layer`で使用しています。
+- 1つ目は、マスタッシュ構文
+- 2つ目は、`input`の`:value`
+- 3つ目は、`button`タグのクリックイベントの引数
+- 4つ目は、さらに子コンポーネントの`grand-parent-layer`
 
 `ParentLayer.vue`との違いに気づきましたか？`button`タグがあることが1番目立ちますがそれ以外です。
 


### PR DESCRIPTION
#2381 の一部。#2513 で1件だけ残っていた `max-ten` を解消し、**`max-ten` を0件**にします。

## 変更内容

`20200401-vue-props-down.md` の4箇所の列挙が、各行末の読点で1文につながっていました。

```
- 1つ目は、マスタッシュ構文で、
- 2つ目は、`input`の`:value`で、
- 3つ目は、`button`タグのクリックイベントの引数で、
- 4つ目は、さらに子コンポーネントの`grand-parent-layer`で使用しています。
```

Markdown では改行しても同じ段落になるため、読点8個の一文として扱われます。箇条書きにしました。

```
+ - 1つ目は、マスタッシュ構文
+ - 2つ目は、`input`の`:value`
+ - 3つ目は、`button`タグのクリックイベントの引数
+ - 4つ目は、さらに子コンポーネントの`grand-parent-layer`
```

直前の文が「`ChildLayer.vue`内では、その`value`を4箇所で使っています。」と述語を持っているので、
各項目は名詞句で揃えました。落としたのは行末の「で」と「で使用しています」だけで、語は足していません。

## 検証

- `max-ten` は解消（全記事で0件）
- 同ファイルに残る `ja-no-mixed-period`（L311、図の説明行）は変更前から出ている既存の指摘で、
  今回の変更とは無関係

## #2381 の状況

| ルール | 当初 | 現在 |
| --- | --- | --- |
| `no-doubled-joshi` | 4,383 | 300 |
| `no-mix-dearu-desumasu` | 3,186 | 0 |
| `ja-no-mixed-period` | 2,087 | 663 |
| `ja-no-redundant-expression` | 1,791 | 29 |
| `max-ten` | 1,510 | **0** |
