### PR TITLE
全期間の投稿推移グラフを月粒度にそろえる

### DIFF
--- a/scripts/category_chart_helpers.js
+++ b/scripts/category_chart_helpers.js
@@ -113,58 +113,6 @@ hexo.extend.helper.register('get_monthly_category_data', function (year) {
   return JSON.stringify({ months, series });
 });
 
-/**
- * /categories/ の構成比グラフ (#2432)。年ごとに、その年の投稿を100%として
- * カテゴリの割合を返す。
- *
- * 実数の積み上げにすると /articles/ の全期間グラフと同じ図になる。あちらは
- * 「どれくらい書かれているか」を見る図で、こちらは「どの分野が伸びて、
- * どの分野が縮んだか」を見る図。実数のままだと投稿の多い月は全部の帯が
- * 太くなるので、構成が変わったのか総量が増えただけなのかを区別できない。
- *
- * 粒度は年。構成比は分母が小さいと激しく揺れる（3本の月は33%刻みになる）ので、
- * 月では構成の変化を読み取れない。読み取る問いが違うので、
- * 全期間を月で刻む他のグラフとは粒度が違ってよい。
- *
- * 割合だけだと「4本中2本で50%」のような薄い根拠が読めないため、
- * 実数も添えて返す（ツールチップで併記する）。
- */
-hexo.extend.helper.register('get_yearly_category_ratio', function () {
-  const first = this.site.posts.sort('date', 1).first();
-  if (!first) return JSON.stringify({ years: [], series: [], totals: [] });
-  const startY = first.date.year();
-  const endY = new Date().getFullYear();
-  const years = [];
-  for (let y = startY; y <= endY; y++) years.push(String(y));
-
-  const byCat = new Map(); // カテゴリ -> 年ごとの本数
-  const totals = new Array(years.length).fill(0);
-  this.site.posts.forEach((post) => {
-    const i = post.date.year() - startY;
-    if (i < 0 || i >= years.length) return;
-    const cat = post.categories.first();
-    if (!cat) return;
-    if (!byCat.has(cat.name)) byCat.set(cat.name, new Array(years.length).fill(0));
-    byCat.get(cat.name)[i]++;
-    totals[i]++;
-  });
-
-  // 並びと色の規則は他のグラフと同じ（サイト累計の多い順で固定 #2201）
-  const series = this.site.categories
-    .toArray()
-    .sort((a, b) => b.length - a.length || (a.name < b.name ? -1 : 1))
-    .filter((c) => byCat.has(c.name))
-    .map((c) => {
-      const counts = byCat.get(c.name);
-      return {
-        name: c.name,
-        counts,
-        data: counts.map((n, i) => (totals[i] ? Math.round((n / totals[i]) * 1000) / 10 : 0)),
-      };
-    });
-  return JSON.stringify({ years, series, totals });
-});
-
 // 月ページの週別 × カテゴリ別の投稿数 (#2227)。週は「その月の何日目か」で
 // 決める（1〜7日 = 第1週）。posts_stack_series と同じ規則で、ISO週だと
 // 月をまたぐ週が出て合計が月の投稿数と合わなくなる

--- a/scripts/category_chart_helpers.js
+++ b/scripts/category_chart_helpers.js
@@ -1,77 +1,5 @@
 'use strict';
 
-/**
- * サイトの全投稿を集計し、時間軸ごとのカテゴリ別投稿データを生成する
- * - 2018年以前は年ごと、2019年以降は四半期ごと
- * @returns {object} { quarters: string[], series: object[], categories: string[] }
- */
-function getQuarterlyCategoryData() {
-  const posts = this.site.posts.sort('date', 1); // 日付順にソート
-  if (!posts.length) {
-    return { quarters: [], series: [], categories: [] };
-  }
-
-  const dataByTimeBucket = new Map();
-
-  // 1. 全投稿をループして、時間軸ごとにカテゴリ別投稿数を集計
-  posts.forEach((post) => {
-    const year = post.date.year();
-    let timeKey;
-
-    if (year >= 2019) {
-      // 2019年以降は四半期ごと
-      const quarter = Math.floor(post.date.month() / 3) + 1;
-      timeKey = `${year}-Q${quarter}`;
-    } else {
-      // 2018年以前は年ごと
-      timeKey = year.toString();
-    }
-
-    if (!dataByTimeBucket.has(timeKey)) {
-      dataByTimeBucket.set(timeKey, new Map());
-    }
-
-    const bucketData = dataByTimeBucket.get(timeKey);
-    const postCategories = post.categories.map((cat) => cat.name);
-    if (!postCategories.length) return;
-
-    postCategories.forEach((catName) => {
-      const currentCount = bucketData.get(catName) || 0;
-      bucketData.set(catName, currentCount + 1);
-    });
-  });
-
-  // 2. サイトの全カテゴリを取得し、「合計記事数」で降順にソートする。
-  //    同点の決着が無いとビルドごとに並びが変わる
-  const sortedCategoryObjects = this.site.categories
-    .toArray()
-    .sort((a, b) => b.length - a.length || (a.name < b.name ? -1 : 1));
-  const sortedCategoryNames = sortedCategoryObjects.map((cat) => cat.name);
-
-  // 3. X軸のラベル（時間軸）を生成し、ソートする
-  const sortedTimeKeys = Array.from(dataByTimeBucket.keys()).sort();
-
-  // 4. カテゴリごとの時系列に整形する。チャートの種類（棒・折れ線）や色は
-  //    表示側の関心なので、ここでは名前とデータだけを返す
-  const series = sortedCategoryObjects.map((category) => {
-    const catName = category.name;
-    const data = sortedTimeKeys.map((timeKey) => {
-      const bucketData = dataByTimeBucket.get(timeKey);
-      return bucketData.get(catName) || 0; // その期間に投稿がなければ0
-    });
-    return { name: catName, data: data };
-  });
-
-  return {
-    quarters: sortedTimeKeys, // キー名はEJS側と合わせるため'quarters'のまま
-    series: series,
-    categories: sortedCategoryNames,
-  };
-}
-
-// ヘルパーとして登録
-hexo.extend.helper.register('get_quarterly_category_data', getQuarterlyCategoryData);
-
 // カテゴリの色は名前で固定する (#2170)。系列順に既定パレットを当てると、
 // 著者やページごとにカテゴリの並びが違うため、同じ Programming が青だったり
 // 緑だったりして色が手がかりにならない。記事数の多いカテゴリから
@@ -123,25 +51,57 @@ hexo.extend.helper.register('category_colors', function () {
   return JSON.stringify(colors);
 });
 
-// 指定年の月別 × カテゴリ別の投稿数 (#2171)
+// 月別 × カテゴリ別の投稿数 (#2171)。year を渡すとその年、省略すると全期間。
+//
+// 全期間も月で刻む (#2432)。以前は四半期（しかも2018年以前だけ年）だったが、
+// 同じ全期間を個別ページ（カテゴリ・タグ・著者）は月で描いており、粒度が
+// ページによって違っていた。読み手が知りたいのは「どれくらいのペースで
+// 書かれているか」で、それは月の単位で見るもの。粒度はページの種類ではなく
+// 読み取る問いで決める
 hexo.extend.helper.register('get_monthly_category_data', function (year) {
-  // 今年はまだ来ていない月を出さない。月の探索リンク（archive.ejs）と同じ規則。
-  // 12ヶ月固定にすると、今年のグラフに未来の空欄が並ぶうえ、
-  // 同じページの「週別」タブ（posts_stack_series）と軸の長さが食い違い、
-  // タブを切り替えるたびに棒の幅と位置が変わっていた (#2430)
   const now = new Date();
-  const monthCount = Number(year) === now.getFullYear() ? now.getMonth() + 1 : 12;
+  const nowY = now.getFullYear();
+  const nowM = now.getMonth() + 1;
+
+  // 軸の作り方。年を指定したときは 1月〜（今年なら現在月まで）。
+  // 今年で12ヶ月固定にすると未来の空欄が並ぶうえ、同じページの「週別」タブ
+  // （posts_stack_series）と軸の長さが食い違い、タブを切り替えるたびに
+  // 棒の幅と位置が変わっていた (#2430)
+  //
+  // 全期間は最初の投稿の月から現在月まで。ラベルは YYYY/MM で、
+  // 個別ページ（category.ejs / author.ejs）と同じ書式にそろえる
+  let months;
+  let indexOf;
+  if (year) {
+    const monthCount = Number(year) === nowY ? nowM : 12;
+    months = Array.from({ length: monthCount }, (_, i) => `${i + 1}月`);
+    indexOf = (post) =>
+      String(post.date.year()) === String(year) && post.date.month() < monthCount
+        ? post.date.month()
+        : -1;
+  } else {
+    const first = this.site.posts.sort('date', 1).first();
+    if (!first) return JSON.stringify({ months: [], series: [] });
+    const startY = first.date.year();
+    const startM = first.date.month() + 1; // moment の month() は 0 始まり
+    months = [];
+    for (let y = startY; y <= nowY; y++) {
+      for (let m = y === startY ? startM : 1; m <= (y === nowY ? nowM : 12); m++) {
+        months.push(`${y}/${String(m).padStart(2, '0')}`);
+      }
+    }
+    indexOf = (post) => (post.date.year() - startY) * 12 + (post.date.month() + 1) - startM;
+  }
 
   const byCat = new Map(); // カテゴリ -> 月ごとの配列
   this.site.posts.forEach((post) => {
-    if (String(post.date.year()) !== String(year)) return;
+    const i = indexOf(post);
+    if (i < 0 || i >= months.length) return;
     const cat = post.categories.first();
     if (!cat) return;
-    if (!byCat.has(cat.name)) byCat.set(cat.name, new Array(monthCount).fill(0));
-    if (post.date.month() < monthCount) byCat.get(cat.name)[post.date.month()]++;
+    if (!byCat.has(cat.name)) byCat.set(cat.name, new Array(months.length).fill(0));
+    byCat.get(cat.name)[i]++;
   });
-  const months = [];
-  for (let m = 1; m <= monthCount; m++) months.push(`${m}月`);
   // 並びはその年の多い順ではなく、全期間ページと同じサイト累計の多い順で
   // 固定する。年ごとに入れ替わると、年を移動したとき凡例と積み上げの
   // 色の位置が動いて比較しにくい (#2201)

--- a/scripts/category_chart_helpers.js
+++ b/scripts/category_chart_helpers.js
@@ -113,6 +113,58 @@ hexo.extend.helper.register('get_monthly_category_data', function (year) {
   return JSON.stringify({ months, series });
 });
 
+/**
+ * /categories/ の構成比グラフ (#2432)。年ごとに、その年の投稿を100%として
+ * カテゴリの割合を返す。
+ *
+ * 実数の積み上げにすると /articles/ の全期間グラフと同じ図になる。あちらは
+ * 「どれくらい書かれているか」を見る図で、こちらは「どの分野が伸びて、
+ * どの分野が縮んだか」を見る図。実数のままだと投稿の多い月は全部の帯が
+ * 太くなるので、構成が変わったのか総量が増えただけなのかを区別できない。
+ *
+ * 粒度は年。構成比は分母が小さいと激しく揺れる（3本の月は33%刻みになる）ので、
+ * 月では構成の変化を読み取れない。読み取る問いが違うので、
+ * 全期間を月で刻む他のグラフとは粒度が違ってよい。
+ *
+ * 割合だけだと「4本中2本で50%」のような薄い根拠が読めないため、
+ * 実数も添えて返す（ツールチップで併記する）。
+ */
+hexo.extend.helper.register('get_yearly_category_ratio', function () {
+  const first = this.site.posts.sort('date', 1).first();
+  if (!first) return JSON.stringify({ years: [], series: [], totals: [] });
+  const startY = first.date.year();
+  const endY = new Date().getFullYear();
+  const years = [];
+  for (let y = startY; y <= endY; y++) years.push(String(y));
+
+  const byCat = new Map(); // カテゴリ -> 年ごとの本数
+  const totals = new Array(years.length).fill(0);
+  this.site.posts.forEach((post) => {
+    const i = post.date.year() - startY;
+    if (i < 0 || i >= years.length) return;
+    const cat = post.categories.first();
+    if (!cat) return;
+    if (!byCat.has(cat.name)) byCat.set(cat.name, new Array(years.length).fill(0));
+    byCat.get(cat.name)[i]++;
+    totals[i]++;
+  });
+
+  // 並びと色の規則は他のグラフと同じ（サイト累計の多い順で固定 #2201）
+  const series = this.site.categories
+    .toArray()
+    .sort((a, b) => b.length - a.length || (a.name < b.name ? -1 : 1))
+    .filter((c) => byCat.has(c.name))
+    .map((c) => {
+      const counts = byCat.get(c.name);
+      return {
+        name: c.name,
+        counts,
+        data: counts.map((n, i) => (totals[i] ? Math.round((n / totals[i]) * 1000) / 10 : 0)),
+      };
+    });
+  return JSON.stringify({ years, series, totals });
+});
+
 // 月ページの週別 × カテゴリ別の投稿数 (#2227)。週は「その月の何日目か」で
 // 決める（1〜7日 = 第1週）。posts_stack_series と同じ規則で、ISO週だと
 // 月をまたぐ週が出て合計が月の投稿数と合わなくなる

--- a/themes/future/layout/_partial/posts-chart.ejs
+++ b/themes/future/layout/_partial/posts-chart.ejs
@@ -1,8 +1,12 @@
-<%# 投稿推移のグラフ。期間内訳（週・月の積み上げ）とカテゴリ内訳は別の軸で
-    同時に積めないため、タブで切り替える (#2171)。
-    ランキングと同じ radio + label 方式で JS は足さない。
-    棒の粒度は year が渡されればその年の月、無ければ全期間の四半期。
-    粒度は両タブ共通なので、タブ名は積み上げの内訳の方で名乗る (#2222) %>
+<%# 投稿推移のグラフ。粒度は年の指定に関わらず月 (#2432)。
+    読み手が知りたいのは「どれくらいのペースで書かれているか」で、
+    それは月の単位で見るもの。個別ページ（カテゴリ・タグ・著者）も月なので、
+    ページをまたいでも同じ密度で読める。
+
+    年ページだけタブを出す。期間タブは「バケットの中の内訳」を見るためのもので、
+    月バケットの内訳は週。全期間ページでも同じことをすると「10年分の月の中の
+    第何週か」になり、読み取るべき問いが無くなるのでタブごと出さない %>
+<% if (year) { %>
 <div class="nav tabs chart-tabs">
   <%# 既定はカテゴリ別。週の粗密より、何のジャンルが書かれているかの方が
       最初に見たい情報 %>
@@ -12,14 +16,18 @@
     <div id="chart-category" style="width:100%;min-height:250px"></div>
   </div>
   <input id="chart-tab-period" type="radio" name="chart_tab">
-  <label tabindex="0" class="tab_item" for="chart-tab-period"><%= year ? '週別' : '月別' %></label>
+  <label tabindex="0" class="tab_item" for="chart-tab-period">週別</label>
   <div class="tab_content">
     <div id="chart-period" style="width:100%;min-height:250px"></div>
   </div>
 </div>
+<% } else { %>
+<div id="chart-category" style="width:100%;min-height:250px"></div>
+<% } %>
 <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
 <script type="text/javascript">
-  const periodData = <%- year ? posts_stack_series(year) : posts_stack_series() %>;
+<% if (year) { %>
+  const periodData = <%- posts_stack_series(year) %>;
   echarts.init(document.getElementById('chart-period')).setOption({
     tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
     <%# 凡例は1行に収める。折り返すと grid.bottom（1行分の32px）を越えて
@@ -44,14 +52,27 @@
       data
     }))
   });
+<% } %>
 
-  const catData = <%- year ? get_monthly_category_data(year) : JSON.stringify(get_quarterly_category_data()) %>;
+  const catData = <%- year ? get_monthly_category_data(year) : get_monthly_category_data() %>;
   const catColors = <%- category_colors() %>;
+  <%# 軸が12ヶ月以下なら月ラベルが全部読めるので毎月出す。全期間は127ヶ月に
+      なるため、年の変わり目だけを「YYYY年」で出す（個別ページと同じ #2135）%>
+  const monthlyLabels = catData.months.length <= 12;
   echarts.init(document.getElementById('chart-category')).setOption({
     tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
     legend: { bottom: 0, type: 'scroll' },
     grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
-    xAxis: { type: 'category', data: catData.<%= year ? 'months' : 'quarters' %> },
+    xAxis: {
+      type: 'category',
+      data: catData.months,
+      axisLabel: {
+        interval: 0,
+        formatter: (value, index) => monthlyLabels
+          ? value
+          : ((index === 0 || value.endsWith('/01')) ? value.slice(0, 4) + '年' : '')
+      }
+    },
     yAxis: { type: 'value', min: 0 },
     <%# カテゴリは順序に意味が無いので色相で分け、名前で固定する (#2170) %>
     series: catData.series.map(s => ({

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -15,36 +15,43 @@
     </ul>
 
     <%# 統計の直下にグラフ、その後にコンテンツの一覧。全ページ同じ並びにする (#2211) %>
-    <%- partial('_partial/section-heading', {id: 'trend', text: 'カテゴリ別 投稿数の推移'}) %>
-    ※月ごとの投稿数を表示
+    <%- partial('_partial/section-heading', {id: 'trend', text: 'カテゴリ構成の推移'}) %>
+    <%# 実数の積み上げにすると /articles/ の全期間グラフと同じ図になる。
+        あちらは「どれくらい書かれているか」、ここは「どの分野が伸びて、
+        どの分野が縮んだか」を見る図なので、構成比で描く (#2432) %>
+    ※各年の投稿を100%としたカテゴリの割合
     <div id="category-chart" style="width: 100%; height: 400px;"></div>
 
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
 
     <script type="text/javascript">
-      const chartData = <%- get_monthly_category_data() %>;
+      const chartData = <%- get_yearly_category_ratio() %>;
       const catColors = <%- category_colors() %>;
       const myChart = echarts.init(document.getElementById('category-chart'));
       const option = {
-        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        tooltip: {
+          trigger: 'axis',
+          axisPointer: { type: 'shadow' },
+          <%# 割合だけだと「4本中2本で50%」のような薄い根拠が読めないので実数も出す。
+              0%の分野は行が並ぶだけなので省く %>
+          formatter: (params) => {
+            const i = params[0].dataIndex;
+            const rows = params
+              .filter(p => p.value > 0)
+              .map(p => p.marker + p.seriesName + ': '
+                + chartData.series.find(s => s.name === p.seriesName).counts[i] + '本（' + p.value + '%）');
+            return [chartData.years[i] + '年\u3000全' + chartData.totals[i] + '本'].concat(rows).join('<br>');
+          }
+        },
         legend: { bottom: 0, type: 'scroll' },
         <%# 余白と凡例位置は他のチャート（posts-chart）に合わせる (#2212) %>
         grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
-        <%# 全期間は127ヶ月になるため、年の変わり目だけを「YYYY年」で出す
-            （個別ページ・posts-chart と同じ #2135 / #2432）%>
-        xAxis: [ {
-          type: 'category',
-          boundaryGap: true,
-          data: chartData.months,
-          axisLabel: {
-            interval: 0,
-            formatter: (value, index) => (index === 0 || value.endsWith('/01')) ? value.slice(0, 4) + '年' : ''
-          }
-        } ],
-        <%# 軸名は付けない。何の数かは直上の h2 が名乗っている %>
-        yAxis: [ { type: 'value' } ],
+        xAxis: [ { type: 'category', boundaryGap: true, data: chartData.years } ],
+        <%# 構成比なので上限は100%で固定する。年ごとに上限が動くと
+            帯の高さを年をまたいで比べられない %>
+        yAxis: [ { type: 'value', min: 0, max: 100, axisLabel: { formatter: '{value}%' } } ],
         <%# 16本の折れ線の重なりは読めないので積み上げ棒にする (#2169)。
-            棒の高さが月の合計、内訳がカテゴリ。色は名前で固定 (#2170) %>
+            棒の高さは常に100%で、内訳がカテゴリ。色は名前で固定 (#2170) %>
         series: chartData.series.map(s => ({
           name: s.name,
           type: 'bar',

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -16,13 +16,13 @@
 
     <%# 統計の直下にグラフ、その後にコンテンツの一覧。全ページ同じ並びにする (#2211) %>
     <%- partial('_partial/section-heading', {id: 'trend', text: 'カテゴリ別 投稿数の推移'}) %>
-    ※四半期ごとの投稿数を表示（2018年以前は年単位）
+    ※月ごとの投稿数を表示
     <div id="category-chart" style="width: 100%; height: 400px;"></div>
 
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
 
     <script type="text/javascript">
-      const chartData = <%- JSON.stringify(get_quarterly_category_data()) %>;
+      const chartData = <%- get_monthly_category_data() %>;
       const catColors = <%- category_colors() %>;
       const myChart = echarts.init(document.getElementById('category-chart'));
       const option = {
@@ -30,11 +30,21 @@
         legend: { bottom: 0, type: 'scroll' },
         <%# 余白と凡例位置は他のチャート（posts-chart）に合わせる (#2212) %>
         grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
-        xAxis: [ { type: 'category', boundaryGap: true, data: chartData.quarters } ],
+        <%# 全期間は127ヶ月になるため、年の変わり目だけを「YYYY年」で出す
+            （個別ページ・posts-chart と同じ #2135 / #2432）%>
+        xAxis: [ {
+          type: 'category',
+          boundaryGap: true,
+          data: chartData.months,
+          axisLabel: {
+            interval: 0,
+            formatter: (value, index) => (index === 0 || value.endsWith('/01')) ? value.slice(0, 4) + '年' : ''
+          }
+        } ],
         <%# 軸名は付けない。何の数かは直上の h2 が名乗っている %>
         yAxis: [ { type: 'value' } ],
         <%# 16本の折れ線の重なりは読めないので積み上げ棒にする (#2169)。
-            棒の高さが四半期の合計、内訳がカテゴリ。色は名前で固定 (#2170) %>
+            棒の高さが月の合計、内訳がカテゴリ。色は名前で固定 (#2170) %>
         series: chartData.series.map(s => ({
           name: s.name,
           type: 'bar',

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -15,43 +15,36 @@
     </ul>
 
     <%# 統計の直下にグラフ、その後にコンテンツの一覧。全ページ同じ並びにする (#2211) %>
-    <%- partial('_partial/section-heading', {id: 'trend', text: 'カテゴリ構成の推移'}) %>
-    <%# 実数の積み上げにすると /articles/ の全期間グラフと同じ図になる。
-        あちらは「どれくらい書かれているか」、ここは「どの分野が伸びて、
-        どの分野が縮んだか」を見る図なので、構成比で描く (#2432) %>
-    ※各年の投稿を100%としたカテゴリの割合
+    <%- partial('_partial/section-heading', {id: 'trend', text: 'カテゴリ別 投稿数の推移'}) %>
+    ※月ごとの投稿数を表示
     <div id="category-chart" style="width: 100%; height: 400px;"></div>
 
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
 
     <script type="text/javascript">
-      const chartData = <%- get_yearly_category_ratio() %>;
+      const chartData = <%- get_monthly_category_data() %>;
       const catColors = <%- category_colors() %>;
       const myChart = echarts.init(document.getElementById('category-chart'));
       const option = {
-        tooltip: {
-          trigger: 'axis',
-          axisPointer: { type: 'shadow' },
-          <%# 割合だけだと「4本中2本で50%」のような薄い根拠が読めないので実数も出す。
-              0%の分野は行が並ぶだけなので省く %>
-          formatter: (params) => {
-            const i = params[0].dataIndex;
-            const rows = params
-              .filter(p => p.value > 0)
-              .map(p => p.marker + p.seriesName + ': '
-                + chartData.series.find(s => s.name === p.seriesName).counts[i] + '本（' + p.value + '%）');
-            return [chartData.years[i] + '年\u3000全' + chartData.totals[i] + '本'].concat(rows).join('<br>');
-          }
-        },
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
         legend: { bottom: 0, type: 'scroll' },
         <%# 余白と凡例位置は他のチャート（posts-chart）に合わせる (#2212) %>
         grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
-        xAxis: [ { type: 'category', boundaryGap: true, data: chartData.years } ],
-        <%# 構成比なので上限は100%で固定する。年ごとに上限が動くと
-            帯の高さを年をまたいで比べられない %>
-        yAxis: [ { type: 'value', min: 0, max: 100, axisLabel: { formatter: '{value}%' } } ],
+        <%# 全期間は127ヶ月になるため、年の変わり目だけを「YYYY年」で出す
+            （個別ページ・posts-chart と同じ #2135 / #2432）%>
+        xAxis: [ {
+          type: 'category',
+          boundaryGap: true,
+          data: chartData.months,
+          axisLabel: {
+            interval: 0,
+            formatter: (value, index) => (index === 0 || value.endsWith('/01')) ? value.slice(0, 4) + '年' : ''
+          }
+        } ],
+        <%# 軸名は付けない。何の数かは直上の h2 が名乗っている %>
+        yAxis: [ { type: 'value' } ],
         <%# 16本の折れ線の重なりは読めないので積み上げ棒にする (#2169)。
-            棒の高さは常に100%で、内訳がカテゴリ。色は名前で固定 (#2170) %>
+            棒の高さが月の合計、内訳がカテゴリ。色は名前で固定 (#2170) %>
         series: chartData.series.map(s => ({
           name: s.name,
           type: 'bar',

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -15,8 +15,8 @@
     </ul>
 
     <%# 統計の直下にグラフ、その後にコンテンツの一覧。全ページ同じ並びにする (#2211) %>
-    <%- partial('_partial/section-heading', {id: 'trend', text: 'カテゴリ別 投稿数の推移'}) %>
-    ※月ごとの投稿数を表示
+    <%- partial('_partial/section-heading', {id: 'trend', text: 'カテゴリ別 累計投稿数の推移'}) %>
+    ※各月末時点の累計投稿数を表示
     <div id="category-chart" style="width: 100%; height: 400px;"></div>
 
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
@@ -24,9 +24,30 @@
     <script type="text/javascript">
       const chartData = <%- get_monthly_category_data() %>;
       const catColors = <%- category_colors() %>;
+      <%# 月ごとの実数を足し上げて累計にする。ヘルパーは実数のまま返し、
+          表示側で累計にする（軸の作り方をヘルパー1箇所に保つ）。
+          /articles/ の同じデータは月ごとのペースを見る図なので、
+          こちらは分野ごとの蓄積を見る図として役割を分ける (#2432) %>
+      const cumulative = chartData.series.map(s => {
+        let sum = 0;
+        return { name: s.name, data: s.data.map(n => (sum += n)) };
+      });
+      const cumulativeTotals = chartData.months.map((_, i) => cumulative.reduce((a, s) => a + s.data[i], 0));
       const myChart = echarts.init(document.getElementById('category-chart'));
       const option = {
-        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        tooltip: {
+          trigger: 'axis',
+          axisPointer: { type: 'line' },
+          <%# 18系列あり、初期の月はほとんどが0。0の行は読む手がかりにならないので省き、
+              先頭にその時点の累計合計を出す %>
+          formatter: (params) => {
+            const i = params[0].dataIndex;
+            const rows = params
+              .filter(p => p.value > 0)
+              .map(p => p.marker + p.seriesName + ': ' + p.value + '本');
+            return [chartData.months[i] + '　累計' + cumulativeTotals[i] + '本'].concat(rows).join('<br>');
+          }
+        },
         legend: { bottom: 0, type: 'scroll' },
         <%# 余白と凡例位置は他のチャート（posts-chart）に合わせる (#2212) %>
         grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
@@ -34,7 +55,9 @@
             （個別ページ・posts-chart と同じ #2135 / #2432）%>
         xAxis: [ {
           type: 'category',
-          boundaryGap: true,
+          <%# 面グラフなので端の余白は無し。左右に隙間があると、
+              最初の月より前・最後の月より後に空白期間があるように見える %>
+          boundaryGap: false,
           data: chartData.months,
           axisLabel: {
             interval: 0,
@@ -43,12 +66,17 @@
         } ],
         <%# 軸名は付けない。何の数かは直上の h2 が名乗っている %>
         yAxis: [ { type: 'value' } ],
-        <%# 16本の折れ線の重なりは読めないので積み上げ棒にする (#2169)。
-            棒の高さが月の合計、内訳がカテゴリ。色は名前で固定 (#2170) %>
-        series: chartData.series.map(s => ({
+        <%# 累計は単調増加で、127点だと棒の差が1本刻みになって縞にしか見えない。
+            積み上げ面にすると帯の厚みがそのカテゴリの蓄積量、上端が総数になる。
+            折れ線の重なりが読めないという #2169 の理由は、積み上げれば起きない。
+            色は名前で固定 (#2170) %>
+        series: cumulative.map(s => ({
           name: s.name,
-          type: 'bar',
+          type: 'line',
           stack: 'categories',
+          symbol: 'none',
+          lineStyle: { width: 0 },
+          areaStyle: { color: catColors[s.name] },
           itemStyle: { color: catColors[s.name] },
           data: s.data
         }))


### PR DESCRIPTION
Close #2432

## 直した問題

粒度が**ページの種類**で決まっていた。個別ページ（カテゴリ・タグ・著者）は月なのに、全期間ページだけ四半期。しかもカテゴリ別タブは2018年以前を年1本にまとめていた。

**同じ幅の棒が、前半は1年分・後半は3ヶ月分を表していた。**

| 棒 | 期間 | 本数 |
| --- | --- | --- |
| `2017` | 1年分 | 24 |
| `2019-Q2` | 3ヶ月分 | 16 |
| `2020-Q1` | 3ヶ月分 | 42 |

2016年を四半期に割ると `[0, 0, 5, 4]` で、1本にまとめた `9` とは見え方が違う。前半が実態より高く見えていた。

さらに **`/articles/` の2つのタブで軸そのものが違っていた。**

| タブ | 点数 | 先頭 |
| --- | --- | --- |
| 期間タブ | 43点 | `2016年1Q` `2016年2Q` … |
| カテゴリタブ | 34点 | `2016` `2017` `2018` `2019-Q1` … |

タブを切り替えると棒の位置も幅もラベル書式も変わる。#2430 で年ページについて直したのと同じ形の不具合が、全期間ページに残っていた。

## 方針

**粒度はページの種類ではなく、読み手が読み取る問いで決める。**

読み手が知りたいのは「どれくらいのペースで書かれているか」で、それは月の単位で見るもの。全期間も月にすることで、個別ページと同じ密度で読める。

当初は「棒が多すぎるから粗くする」という案を出したが、それは描画の都合であって読み取りの都合ではない。Issue のコメントで測り直した結果、月のままにすべきという結論になっている。

## 変更

### 1. `/articles/`（全期間）を月粒度に

- 43点の四半期 → **127点の月**（2016/02〜2026/08）
- **期間タブを廃止。** 期間タブは「バケットの中の内訳」を見るためのもので、年ページなら「月の中の週」。全期間のバケットが月になると内訳は週になり、「10年分の月の中の第何週か」には読み取る問いが無い。カテゴリ別の1枚だけにした

### 2. `/categories/` の年集約を廃止し、累計の積み上げにする

34点（2018年以前は年） → **127点の月**。`/articles/` と同じ軸になった。

ただし軸をそろえた結果、**`/articles/` のカテゴリ別グラフと同じ図になった。** 系列も色も同じで、読み取れることが重複する。同じデータでも読み取る問いは分けられるので、`/categories/` を**累計**にした。

| ページ | 問い | 図 |
| --- | --- | --- |
| `/articles/` | どれくらいのペースで書かれているか | 月ごとの実数の積み上げ棒 |
| `/categories/` | どの分野がどれだけ積み上がったか | **累計の積み上げ面** |

- 帯の厚みがそのカテゴリの蓄積量、上端がその時点の総数（最終的に1469）
- 累計は単調増加で、127点だと棒の差が1本刻みになり縞にしか見えないため**積み上げ面**にした。折れ線の重なりが読めないという #2169 の理由は、積み上げれば起きない
- 足し上げは表示側で行い、**ヘルパーは実数のまま返す**。軸の作り方は `get_monthly_category_data` の1箇所に保たれる
- ツールチップは0本の行を省き、先頭にその時点の累計合計を出す（`2026/08　累計1469本` → `Programming: 327本`）。18系列あり、初期の月はほとんどが0
- 見出しは「カテゴリ別 **累計**投稿数の推移」

### 3. ヘルパーを統合

`get_quarterly_category_data` を削除し、`get_monthly_category_data` に寄せた。`year` を渡せばその年、省略すれば全期間。軸の作り方が1箇所になる。

### 4. 年ページ・月ページは変更なし

`/articles/<年>/`（12ヶ月＋週別タブ）と `/articles/<年>/<月>/`（5週）はそのまま。ここは「その期間の中の分布」を見るグラフで、粒度は既に問いと合っている。

### X軸のラベル

127点だと月ラベルは潰れるので、**年の変わり目だけ `YYYY年` を出す**。カテゴリ個別ページ・著者ページが既に使っている方式（#2135）に合わせた。

## 確認

配信中のページ、および `hexo generate` の出力から実データを取って照合した。

| ページ | 点数 | 範囲 | 合計 |
| --- | --- | --- | --- |
| `/articles/` | 127 | 2016/02〜2026/08 | 1469 |
| `/categories/` | 127 | 2016/02〜2026/08 | 1469 |
| `/articles/2025/` | 12（両タブ一致） | 1月〜12月 | — |
| `/articles/2026/` | 8（両タブ一致） | 1月〜8月 | — |
| `/articles/2025/09/` | 5 | 第1週〜第5週 | — |

- 全期間の合計 **1469** はカテゴリ付き記事の総数と一致（取りこぼしなし）
- 系列数18 = 全カテゴリ。集約はしていない
- `/categories/` の累計は全系列で単調増加。最終値は `Programming 327 / Frontend 134 / DevOps 133 / Culture 129 / DataScience 100 …` で、カテゴリ一覧の「累計」欄と一致。合計も1469
- 凡例の並びが `Programming, Frontend, DevOps, Culture, DataScience …` でサイト累計の多い順どおり（#2201）
- `/articles/` に期間タブが無いこと、年ページには**ある**ことを確認
- 年ページは2つのタブの軸が一致（#2430 の状態を維持）
- `prettier --check "scripts/**/*.js" "*.mjs"` 通過

## 積み残し

Issue のコメントに書いたとおり、**著者個別ページはどの粒度でも棒が0か1にしかならない**（中央値の著者は年1本ペース）。これは粒度ではなくグラフの要否の問題なので、この PR では触っていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

