### PR TITLE
折りたたみの開閉エフェクトを本文の外にも効かせる

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -190,18 +190,21 @@ h4 {
 /* 開閉を高さのアニメーションで見せる。対応ブラウザだけの上乗せで、
    未対応なら今までどおり即座に開く。
    interpolate-size は継承するので details に置き、サイト全体には広げない */
+/* 折りたたみは本文の外にもある（モバイル目次・関連記事・ランキング・被参照）。
+   同じページの同じ操作で反応が違うのを避けるため、セレクタは details 全体で持つ。
+   クラスを付けて回す方式にすると、折りたたみを増やすたびに付け忘れが起きる (#2522) */
 /* Stylus は selector(...) の中の :: を解釈できずパースに失敗するので、
    条件は unquote で文字列のまま渡す */
 @supports unquote('selector(details::details-content)') {
-  .article-entry details {
+  details {
     interpolate-size: allow-keywords;
   }
-  .article-entry details::details-content {
+  details::details-content {
     block-size: 0;
     overflow: hidden;
     transition: block-size 0.18s ease, content-visibility 0.18s allow-discrete;
   }
-  .article-entry details[open]::details-content {
+  details[open]::details-content {
     block-size: auto;
   }
 }


### PR DESCRIPTION
Close #2522

## 直した問題

折りたたみの開閉アニメーション（`interpolate-size` + `::details-content`）が `.article-entry` の中だけに掛かっており、**同じページの中で同じ操作の反応が違っていた。**

## Issue の前提の訂正

Issue は「本文中の折りたたみとモバイル目次（`.toc-mobile`）はこれが効く」と書いていますが、**モバイル目次にも効いていませんでした。**

`<details class="toc-mobile">` は `article.ejs:40`、`<div class="article-entry">` は同 46行で、**外側の兄弟**です。

効いていたのは記事本文中の折りたたみだけで、実際にパッと開いていたのは4種類でした。

| 折りたたみ | 出どころ | `.article-entry` |
| --- | --- | --- |
| 記事本文中 | Markdown | 中（唯一効いていた） |
| モバイル目次 | `article.ejs:40` | 外 |
| 関連記事 | `related_posts.js:132` | 外（`<aside class="footer-gap">` の中） |
| よく読まれている記事 | `popular_posts.js:44` | 外（サイドバー、入れ子2段） |
| 被参照記事 | `reference_posts.js:41` | 外 |

## 方針: セレクタを `details` 全体に引き上げる

Issue のチェック項目「セレクタを `details` 共通に引き上げるか、共通クラスを付けて回すか」について。

**`.article-entry` に閉じている理由が他にないかの確認** — 記録されているのは `theme-styles.styl:192` の一行だけでした。

> interpolate-size は継承するので details に置き、サイト全体には広げない

これは *html / body ではなく details に置く* という話で、`details` セレクタである限り継承範囲は details の中に閉じます。`.article-entry` を外してもこの理由は守られます。

**共通クラス方式を採らない理由** — 3つの JS（＋今後増える分）に付け忘れが起きます。「同じ操作の反応を揃える」のが目的なのに、付け忘れが即バグになる形は避けました。

なお `details` への全体指定には前例があります（`metronic-src/assets/style.css:382` の `details { padding-bottom: 24px }`、`summary { cursor: pointer }`）。

## 入れ子の確認

トップページのランキングで実測したところ、`details` 3個・**最大入れ子深さ2**（`残り 15本を表示` の中に `残りの 24本を表示`）でした。両段とも同じルールが当たります。内側は外側の `::details-content` の中にあり、外側が開くときは内側が閉じた高さで、内側を開くときは外側が `block-size: auto` なので、互いのトランジションは干渉しません。

## 変更

`themes/future/css-src/theme-styles.styl` の1ファイル、`@supports` ブロックのセレクタから `.article-entry` を外すだけです（6行追加・3行削除、うち3行はコメント）。

## 確認

- 配信中の `/css/site.css` で `.article-entry details::details-content` が **0件**、素の `details::details-content` になっていること
- サイト内の `<details>` の出どころが上表の5箇所ですべてであること（`scripts/` と `themes/` を走査、記事本文以外に生成元は無し）
- `@supports` による上乗せなので、`::details-content` 非対応ブラウザは従来どおり即座に開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)
