### PR TITLE
中黒と本文の間隔を詰め、入れ子の字下げを緩める (#2531)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1085,6 +1085,18 @@ code {
 .article-entry li {
   padding-left: 0.4em;
 }
+/* 中黒は「1.」より字が細く、同じ 0.4em でも本文との間隔が広く見える (#2531)。
+   マーカーは本文の左端に右揃えで置かれるので、字が細いぶんだけ空きが増える。
+   子セレクタなのは、ul の中に置かれた ol の項目まで詰めないため */
+.article-entry ul > li {
+  padding-left: 0.15em;
+}
+/* 入れ子は1段ごとに字下げが積み上がる。2段目以降を詰めて、深い入れ子でも
+   モバイルの本文幅を残す (#2531)。1段目の 20px は本文との段差として保つ */
+.article-entry li ul,
+.article-entry li ol {
+  padding-inline-start: 16px;
+}
 .inline-code-color {
   border-radius: 3px;
   border: 1px solid #ddd;


### PR DESCRIPTION
Fixes #2531

## 実測

現状は `ul` / `ol` ともに `padding-inline-start: 20px`、`li` に `padding-left: 0.4em`（6.2px、#2500）。Issue の4パターンを確認した結果は次のとおり。

| 論点 | 実測 |
| --- | --- |
| 中黒と本文の間隔 | `1.` は字が広く本文まで届くが、`•` は細いため同じ 0.4em でも間隔が広く見える。**マーカーは本文左端に右揃え**で置かれるので、字が細いぶんだけ空きが増える |
| 二桁連番 | `10.` は左へ伸びて本文左端にちょうど接する。はみ出してはいない（詰めると出る） |
| 入れ子 | 1段ごとに 20px 累積。3段目で左端から 60px |
| `ul` と `ol` の値 | 同じ 20px でよい。差が要るのは `li` 側だけ |

## 変更

- **`ul` の項目だけ `padding-left: 0.15em`**。子セレクタ（`ul > li`）なので、`ul` の中に置かれた `ol` の項目は 0.4em のまま
- **入れ子の `ul` / `ol` を `padding-inline-start: 16px`**。1段目の 20px は本文との段差として保つ
- 字下げ本体（20px）は触らない。二桁連番が収まらなくなるため

## 確認

`make css` のみ（CSSだけの変更なので `hexo generate` は不要）。`ul` / `ol` / 入れ子3段 / 二桁連番 / `ul`の中の`ol` / `ol`の中の`ul` を並べて before-after を描画で確認した。二桁連番の位置は変わっていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)