### PR TITLE
note の中のテーブルに note の地を継承させる

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2970,6 +2970,33 @@ note-alert-bg = #ffdbdb
   background: code-bg(note-alert-bg);
 }
 
+/* note の中のテーブル (#2520)。table は全体で background-color: white を
+   持つため、色の付いた地の上では白い矩形が載り、note の一部ではなく
+   貼り付けた別物に見えていた。中では地を継承させる。
+
+   ヘッダは同じ note のインラインコードと同じ規則（code-bg）で導く。
+   「note の中の一段濃い面」が1つの規則で説明でき、値を個別に決めずに済む。
+   地との差は 1.07〜1.22 で、白地の表（#f2f2f2 と白で 1.06）と同程度。
+
+   罫線 #ccc は共通のまま変えない。線が示すのは表の構造で、地の色に
+   染めると表ごとに濃さが変わり構造の読み取りが不安定になる。
+   各 note の地とのコントラストは 1.25〜1.52 で、白地の 1.61 と大きく違わない */
+.article-entry .note-container table {
+  background-color: transparent;
+}
+.article-entry .note-container.note-tip th {
+  background-color: code-bg(note-tip-bg);
+}
+.article-entry .note-container.note-info th {
+  background-color: code-bg(note-info-bg);
+}
+.article-entry .note-container.note-warn th {
+  background-color: code-bg(note-warn-bg);
+}
+.article-entry .note-container.note-alert th {
+  background-color: code-bg(note-alert-bg);
+}
+
 /* note の中のリンクは一段暗い青にする。地を濃くした分、本文色（#424242）は
    まだ 6.5〜8.9 と余裕があるが、リンク色 #0a58ca は alert の上で 4.13 まで
    落ちて AA を割る。参考サイトも枠の中のリンク色を枠ごとに変えている。


### PR DESCRIPTION
Close #2520

## 直した問題

`::: note` の中にテーブルを置くと、テーブルだけが浮いて見えていた。

## 原因はヘッダのグレーではなかった

Issue は「色の付いた地の上に無彩色のグレーが載るから」と見ているが、測ると**グレー自体はほとんど差になっていない。**

| note の種別 | 地 | ヘッダ `#f2f2f2` とのコントラスト |
| --- | --- | --- |
| tip | `#eff0f3` | 1.02 |
| info | `#e5f8e2` | 1.01 |
| warn | `#fdf9e2` | 1.06 |
| alert | `#ffdbdb` | 1.14 |

浮いている主因は**テーブル本体の白**。`table` は全体で `background-color: white` を持っている。

```styl
table {
  ...
  background-color: white; // :::info の中で背景が塗りつぶされるため
}
```

色の付いた地の上に白い矩形が載るので、note の一部ではなく貼り付けた別物に見える。

## 方針

**note の中では地を継承させ、ヘッダは同じ note のインラインコードと同じ規則（`code-bg`）で導く。**

note の中のインラインコードには既に「その note 自身の地を一段濃くした色」を当てる規則がある（#2482 / #2486）。テーブルのヘッダも同じ規則に乗せることで、**「note の中の一段濃い面」が1つの規則で説明でき、値を個別に決めずに済む。**

| 種別 | 地 | ヘッダ `code-bg(地)` | 地との差 | 本文 `#424242` とのコントラスト |
| --- | --- | --- | --- | --- |
| tip | `#eff0f3` | `#dfe1e6` | 1.15 | 7.68 |
| info | `#e5f8e2` | `#d1f1cc` | 1.10 | 8.21 |
| warn | `#fdf9e2` | `#faf2c9` | 1.07 | 8.91 |
| alert | `#ffdbdb` | `#fdc0c0` | 1.22 | 6.45 |

ヘッダと本体の差 1.07〜1.22 は、**白地の表（`#f2f2f2` と白で 1.06）と同程度**。通常の表と同じくらいの区別が付く。

### 罫線は変えない

Issue の3つめの論点について。`#ccc` のまま共通にする。

**線が示すのは表の構造**で、地の色に染めると表ごとに線の濃さが変わり、構造の読み取りが不安定になる。各 note の地とのコントラストは 1.25〜1.52 で、白地の 1.61 と大きく違わない。

### ヘッダを透過にする案は採らない

Issue のもう一つの選択肢（ヘッダ・本体とも透過にして罫線だけで示す）だと、ヘッダの区別が `font-weight: 700` だけになる。本体の白をやめるだけで浮きは解消するので、ヘッダの区別まで落とす必要はない。

## 変更

`.note-container` の中だけに効く5つの規則を足した。**note の外のテーブルは触っていない**（`table` と `th` の共通指定はそのまま）。

## 影響範囲

正直に書くと、**この組み合わせは稀**。全1,469記事の `::: note` 228件のうち、テーブルを含むのは**2件**（いずれも `info`）。

| 種別 | note の数 | うちテーブルを含む |
| --- | --- | --- |
| info | 142 | 2 |
| warn | 72 | 0 |
| tip | 6 | 0 |
| alert | 4 | 0 |
| 種別なし | 4 | 0 |

件数は少ないが、直す価値は「note の中の一段濃い面」という規則の穴を塞ぐことにある。テーブルだけが規則から漏れていた。

## 確認

- 生成される `/css/site.css` に5規則が出ており、`code-bg()` が `#dfe1e6` / `#d1f1cc` / `#faf2c9` / `#fdc0c0` に解決されている
- `table { background-color: #fff }` と `th { background-color: #f2f2f2 }` の共通指定は変わっていない
- 実記事 `/articles/20250827a/` の `note-container note-info note-has-title` の中に `table` があることを DOM で確認
- 詳細度: 共通の `table`（0,0,1）に対し `.article-entry .note-container table`（0,2,1）で確実に勝つ。記述順に依存しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
