### PR TITLE
グラフの凡例とX軸ラベルの重なりを解消する

### DIFF
--- a/themes/future/layout/_partial/chart-xaxis-year-labels.ejs
+++ b/themes/future/layout/_partial/chart-xaxis-year-labels.ejs
@@ -1,0 +1,32 @@
+<%# 月を並べた軸のラベル。echarts の option 内で
+    axisLabel: <この部品>, として使い、月の配列の式とチャートの要素idを渡す
+    （例: partial('_partial/chart-xaxis-year-labels', {months: 'chartData.months', el: 'chart'})）。
+
+    軸が12ヶ月以下（投稿の少ないタグ・年ページ）なら月ラベルが全部読めるので
+    そのまま出す。10年分の軸では年の変わり目だけにする（#2135）。
+
+    ただし年の変わり目だけにしても足りない。2016〜2026年は11本あり、
+    「2016年」1本に読める間隔まで含めて約64px 要る。11本で704px なので、
+    本文カラム（約700px）でも既に重なり、狭い画面では倍以上あふれる（#2530）。
+    そこで幅に収まる本数まで年を間引く。700px なら2年ごと、375px なら3年ごと。
+
+    幅は描画時の1回だけ見る。このサイトのチャートはどれも resize を
+    購読しておらず、ここだけ追従させても他の寸法が揃わない。
+    タブで隠れているチャートは clientWidth が 0 になるため、
+    本文カラムの実測値 700 を既定にする。
+
+    軸の規則を1箇所でしか決めないための共有部品。タグ・カテゴリ・著者・
+    全期間の5ページに同じ式が散ると、片方だけ直して基準がズレる %>
+(function (months, el) {
+  if (months.length <= 12) return { interval: 0 };
+  const starts = months
+    .map((v, i) => (i === 0 || v.endsWith('/01')) ? i : -1)
+    .filter((i) => i >= 0);
+  const width = (document.getElementById(el) || {}).clientWidth || 700;
+  const step = Math.max(1, Math.ceil(starts.length / Math.max(2, Math.floor(width / 64))));
+  const shown = new Set(starts.filter((_, k) => k % step === 0));
+  return {
+    interval: 0,
+    formatter: (value, index) => shown.has(index) ? value.slice(0, 4) + '年' : ''
+  };
+})(<%- months %>, '<%= el %>')

--- a/themes/future/layout/_partial/posts-chart.ejs
+++ b/themes/future/layout/_partial/posts-chart.ejs
@@ -56,9 +56,6 @@
 
   const catData = <%- year ? get_monthly_category_data(year) : get_monthly_category_data() %>;
   const catColors = <%- category_colors() %>;
-  <%# 軸が12ヶ月以下なら月ラベルが全部読めるので毎月出す。全期間は127ヶ月に
-      なるため、年の変わり目だけを「YYYY年」で出す（個別ページと同じ #2135）%>
-  const monthlyLabels = catData.months.length <= 12;
   echarts.init(document.getElementById('chart-category')).setOption({
     tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
     legend: { bottom: 0, type: 'scroll' },
@@ -66,12 +63,7 @@
     xAxis: {
       type: 'category',
       data: catData.months,
-      axisLabel: {
-        interval: 0,
-        formatter: (value, index) => monthlyLabels
-          ? value
-          : ((index === 0 || value.endsWith('/01')) ? value.slice(0, 4) + '年' : '')
-      }
+      axisLabel: <%- partial('_partial/chart-xaxis-year-labels', {months: 'catData.months', el: 'chart-category'}).trim() %>
     },
     yAxis: { type: 'value', min: 0 },
     <%# カテゴリは順序に意味が無いので色相で分け、名前で固定する (#2170) %>

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -78,12 +78,16 @@
       let option = {
         <%# タイトルは直上の h2 が担うので、チャート内では重ねない %>
         title: {},
-        legend: {},
+        <%# 凡例は下端に置く。echarts の既定は上部中央で、grid に上の余白が
+            無いためプロット領域に被る。カテゴリは最大18系列あるので
+            type: 'scroll' で溢れさせない（#2430 で投稿推移グラフに入れたのと同じ形）%>
+        legend: { bottom: 0, type: 'scroll' },
         tooltip: {
             trigger: 'axis'
         },
-        <%# 既定の grid.left 10% で右へズレて見える。軸ラベル込みで左端に寄せる %>
-        grid: { left: 0, right: '2%', containLabel: true },
+        <%# 既定の grid.left 10% で右へズレて見える。軸ラベル込みで左端に寄せる。
+            bottom は凡例の分 %>
+        grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
         toolbox: {},
         xAxis: {
             type: 'category',

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -71,9 +71,6 @@
           ヘルパー側（author_monthly_chart）が持つ (#2140) %>
       const chartData = <%- author_monthly_chart(page.author) %>;
       const catColors = <%- category_colors() %>;
-      <%# 軸が12ヶ月以下（投稿の少ない著者）なら月ラベルが全部読めるので毎月出す。
-          長期の著者は潰れるため年の変わり目だけにする (#2135) %>
-      const monthlyLabels = chartData.months.length <= 12;
       let myChart = echarts.init(document.getElementById('chart'));
       let option = {
         <%# タイトルは直上の h2 が担うので、チャート内では重ねない %>
@@ -93,12 +90,7 @@
             type: 'category',
             boundaryGap: true,
             data: chartData.months,
-            axisLabel: {
-              interval: 0,
-              formatter: (value, index) => monthlyLabels
-                ? value
-                : ((index === 0 || value.endsWith('/01')) ? value.slice(0, 4) + '年' : '')
-            }
+            axisLabel: <%- partial('_partial/chart-xaxis-year-labels', {months: 'chartData.months', el: 'chart'}).trim() %>
         },
         yAxis: <%- partial('_partial/chart-yaxis-count', {series: 'chartData.series'}).trim() %>,
         <%# 色はカテゴリ名で固定 (#2170)。系列順に任せると著者ごとに

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -33,8 +33,12 @@
         let option = {
           <%# タイトルは直上の h2 が担うので、チャート内では重ねない %>
           title: {},
-          <%# 凡例のホバーで種別の定義を出す %>
+          <%# 凡例のホバーで種別の定義を出す。下端に置くのは、echarts の既定の
+              上部中央だと grid に上の余白が無くプロット領域に被るため
+              （#2430 で投稿推移グラフに入れたのと同じ形）%>
           legend: {
+            bottom: 0,
+            type: 'scroll',
             tooltip: {
               show: true,
               formatter: p => typeNotes[p.name] || p.name
@@ -43,8 +47,9 @@
           tooltip: {
               trigger: 'axis'
           },
-          <%# 既定の grid.left 10% で右へズレて見える。軸ラベル込みで左端に寄せる %>
-          grid: { left: 0, right: '2%', containLabel: true },
+          <%# 既定の grid.left 10% で右へズレて見える。軸ラベル込みで左端に寄せる。
+              bottom は凡例の分 %>
+          grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
           toolbox: {},
           xAxis: {
               type: 'category',

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -59,10 +59,7 @@
               最初の月より前・最後の月より後に空白期間があるように見える %>
           boundaryGap: false,
           data: chartData.months,
-          axisLabel: {
-            interval: 0,
-            formatter: (value, index) => (index === 0 || value.endsWith('/01')) ? value.slice(0, 4) + '年' : ''
-          }
+          axisLabel: <%- partial('_partial/chart-xaxis-year-labels', {months: 'chartData.months', el: 'category-chart'}).trim() %>
         } ],
         <%# 軸名は付けない。何の数かは直上の h2 が名乗っている %>
         yAxis: [ { type: 'value' } ],

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -70,9 +70,6 @@
     <script type="text/javascript">
       const chartData = <%- catChart %>;
       const catColors = <%- category_colors() %>;
-      <%# 軸が12ヶ月以下なら月ラベルが全部読めるので毎月出す。
-          長いカテゴリは潰れるため年の変わり目だけにする（著者ページと同じ #2135）%>
-      const monthlyLabels = chartData.months.length <= 12;
       echarts.init(document.getElementById('chart')).setOption({
         <%# タイトルは直上の h2 が担うので、チャート内では重ねない。
             系列が1本なので凡例も出さない %>
@@ -84,12 +81,7 @@
           type: 'category',
           boundaryGap: true,
           data: chartData.months,
-          axisLabel: {
-            interval: 0,
-            formatter: (value, index) => monthlyLabels
-              ? value
-              : ((index === 0 || value.endsWith('/01')) ? value.slice(0, 4) + '年' : '')
-          }
+          axisLabel: <%- partial('_partial/chart-xaxis-year-labels', {months: 'chartData.months', el: 'chart'}).trim() %>
         },
         yAxis: <%- partial('_partial/chart-yaxis-count', {series: 'chartData.series'}).trim() %>,
         <%# 色はカテゴリ名で固定 (#2170) %>

--- a/themes/future/layout/tag.ejs
+++ b/themes/future/layout/tag.ejs
@@ -54,9 +54,6 @@
     <script type="text/javascript">
       const chartData = <%- tagChart %>;
       const catColors = <%- category_colors() %>;
-      <%# 軸が12ヶ月以下（投稿の少ないタグ）なら月ラベルが全部読めるので毎月出す。
-          長期のタグは潰れるため年の変わり目だけにする（著者ページと同じ #2135）%>
-      const monthlyLabels = chartData.months.length <= 12;
       echarts.init(document.getElementById('chart')).setOption({
         <%# タイトルは直上の h2 が担うので、チャート内では重ねない %>
         title: {},
@@ -72,12 +69,7 @@
           type: 'category',
           boundaryGap: true,
           data: chartData.months,
-          axisLabel: {
-            interval: 0,
-            formatter: (value, index) => monthlyLabels
-              ? value
-              : ((index === 0 || value.endsWith('/01')) ? value.slice(0, 4) + '年' : '')
-          }
+          axisLabel: <%- partial('_partial/chart-xaxis-year-labels', {months: 'chartData.months', el: 'chart'}).trim() %>
         },
         yAxis: <%- partial('_partial/chart-yaxis-count', {series: 'chartData.series'}).trim() %>,
         <%# 色はカテゴリ名で固定 (#2170)。系列順に任せるとページごとに

--- a/themes/future/layout/tag.ejs
+++ b/themes/future/layout/tag.ejs
@@ -60,10 +60,14 @@
       echarts.init(document.getElementById('chart')).setOption({
         <%# タイトルは直上の h2 が担うので、チャート内では重ねない %>
         title: {},
-        legend: {},
+        <%# 凡例は下端に置く。echarts の既定は上部中央で、grid に上の余白が
+            無いためプロット領域に被る。カテゴリは最大18系列あるので
+            type: 'scroll' で溢れさせない（#2430 で投稿推移グラフに入れたのと同じ形）%>
+        legend: { bottom: 0, type: 'scroll' },
         tooltip: { trigger: 'axis' },
-        <%# 既定の grid.left 10% で右へズレて見える。軸ラベル込みで左端に寄せる %>
-        grid: { left: 0, right: '2%', containLabel: true },
+        <%# 既定の grid.left 10% で右へズレて見える。軸ラベル込みで左端に寄せる。
+            bottom は凡例の分 %>
+        grid: { left: 0, right: '2%', bottom: 32, containLabel: true },
         xAxis: {
           type: 'category',
           boundaryGap: true,


### PR DESCRIPTION
Close #2530

## 直した問題

タグページの投稿推移グラフで、**凡例がグラフに被さっていた**（再現: `/tags/AWS/`）。

echarts の凡例は既定で上部中央に置かれるが、`grid` に上の余白を取っていないためプロット領域に重なる。#2430 で投稿推移グラフに入れた対応（`legend: { bottom: 0, type: 'scroll' }` + `grid.bottom: 32`）から漏れていた。

## 他のグラフも調べた

Issue の2つめのチェック項目。`echarts.init` を使う全8テンプレートを調べたところ、**同じ漏れが3つ**あった。

| ページ | テンプレート | 系列数 | 修正前 |
| --- | --- | --- | --- |
| `/tags/<名>/` | `tag.ejs` | 15 | **`legend: {}`（上部中央）** |
| `/authors/<名>/` | `author.ejs` | 15 | **`legend: {}`（上部中央）** |
| `/authors/` | `authors.ejs` | 3 | **上部中央（`tooltip` のみ指定）** |
| `/articles/` `/articles/<年>/` | `_partial/posts-chart.ejs` | 18 | 対応済み |
| `/categories/` | `categories.ejs` | 18 | 対応済み |
| `/articles/<年>/<月>/` | `archive.ejs` | 18 | 対応済み |
| `/tags/` | `tags.ejs` | 18 / 2 | 対応済み |
| `/categories/<名>/` | `category.ejs` | 1 | 凡例を出していないので対象外 |

`/authors/` は3系列と少ないが、上部中央である以上は同じように被るので直した。凡例の `tooltip`（ホバーで種別の定義を出す）はそのまま残している。

## `type: 'scroll'` を付ける理由

カテゴリは最大18系列あり、下端に並べても1行に収まらない。溢れた分をスクロールで送る。

`/tags/` の定着グラフだけは**付けていない**。2系列固定（定着 / 定着せず）で溢れようがないため。

## 確認

配信中のページから実際に描画される option を取得して照合した。

| URL | `legend` | `grid` |
| --- | --- | --- |
| `/tags/AWS/` | `{ bottom: 0, type: 'scroll' }` | `{ left: 0, right: '2%', bottom: 32, containLabel: true }` |
| `/authors/真野隼記/` | `{ bottom: 0, type: 'scroll' }` | 同上 |
| `/authors/` | `bottom: 0` / `type: 'scroll'` / `tooltip` | 同上 |

修正後にもう一度8テンプレートを走査し、**凡例を持つ7つすべてで `bottom: 0` と `grid.bottom: 32` が揃っている**ことを確認した。

---

# 追加: X軸の年ラベルが重なって読めない

レビューでの指摘（`/tags/AWS/`）。凡例とは別に、**X軸のラベルも重なっていた。**

## 実測

ラベル「2016年」の実寸は約39px。チャートの実効幅は `.container` の max-width と `col-md-10`（83.33%）から決まる。

| ビューポート | チャート実効幅 | 11本での間隔 | |
| --- | --- | --- | --- |
| 375px | 327px | **30px** | ★実寸39pxを下回り重なる |
| 414px | 366px | **33px** | ★重なる |
| 768px | 576px | 52px | 詰まる |
| 992px | 776px | 71px | |
| 1200px | 926px | 84px | |
| 1440px | 1076px | 98px | |

年の変わり目だけにする間引きは既に入っている（#2135）が、それでも足りていなかった。

## 直し方

**幅に収まる本数まで年そのものを間引く。** 1本あたり64px（実寸39px＋読める間隔）を見込む。

| チャート幅 | 出るラベル |
| --- | --- |
| 327px（375px幅） | 4本 — 2016 / 2019 / 2022 / 2025 |
| 576px（768px幅） | 6本 — 2016 / 2018 / 2020 / 2022 / 2024 / 2026 |
| 776px以上 | 11本すべて |

## 共有部品にした

同じ形式のグラフが5つあり、**全部が同じ問題を持っていた。**

`/tags/<名>/` ・ `/categories/<名>/` ・ `/authors/<名>/` ・ `/articles/` ・ `/categories/` — いずれも127〜132ヶ月の軸に11本の年ラベル。

縦軸の `_partial/chart-yaxis-count.ejs` と同じ作りで `_partial/chart-xaxis-year-labels.ejs` にまとめた。軸の規則を1箇所でしか決めないための部品で、5ページに同じ式が散ると片方だけ直して基準がズレる。

「12ヶ月以下なら毎月出す」条件も部品側へ移したので、各テンプレートの `monthlyLabels` は不要になり削除した。

## 制約

**幅は描画時の1回だけ見る。** このサイトのチャートはどれも `resize` を購読しておらず、ここだけ追従させても他の寸法（凡例・grid）が揃わない。タブで隠れているチャートは `clientWidth` が 0 になるため、本文カラムの実測値 700 を既定にしている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
