### PR TITLE
csv のコードブロックを列ごとに色分けする (#2529)

### DIFF
--- a/scripts/csv_column_highlight.js
+++ b/scripts/csv_column_highlight.js
@@ -1,0 +1,117 @@
+'use strict';
+
+/**
+ * ```csv のコードブロックを列ごとに色分けする（#2529）。
+ *
+ * highlight.js に csv の定義は無く、フェンスに csv と書いても素のテキストで
+ * 出ていた。列に色を付けるには「いま何列目か」を数える必要があるが、
+ * highlight.js の言語定義は正規表現のモードだけで状態を持てない。
+ * そのため rego のように言語を足す形は採れず、terraform や diff_[language] と
+ * 同じくコードブロックごと横取りして自前で組み立てる。
+ *
+ * 区切りは RFC 4180 に沿って読む。実データに引用符付きが4件あり、うち1件は
+ * 引用符の中に改行を含む（Go の encoding/csv の記事）。素の split(',') だと
+ * その行から先が丸ごと崩れる。
+ *
+ * 色は highlight.styl の既存トークン色を6色循環させる（配色は CSS 側）。
+ */
+
+const FENCE = /^([ \t]*)```csv[ \t]*(.*)\n([\s\S]*?)\n[ \t]*```/gm;
+
+// 色数。8列でも2周目が隣の列と重ならない
+const COLORS = 6;
+
+const escapeHtml = (s) =>
+  String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+/**
+ * 物理行ごとのトークン列に分解する。返す配列の1要素が出力の1行になる。
+ *
+ * 引用符の中の改行でも行は分ける。行は表示の単位（span.line と行番号）であって
+ * レコードの単位ではないので、ここで畳むと元のテキストと見た目がずれる。
+ * 列番号は引用符の外のカンマでだけ進み、レコードの終わりでだけ戻る。
+ */
+function tokenize(code) {
+  const lines = [[]];
+  let col = 0;
+  let quoted = false;
+
+  const push = (cls, text) => {
+    const line = lines[lines.length - 1];
+    const last = line[line.length - 1];
+    if (last && last.cls === cls) last.text += text;
+    else line.push({ cls, text });
+  };
+  const colClass = () => `csv-col-${(col % COLORS) + 1}`;
+
+  for (let i = 0; i < code.length; i++) {
+    const ch = code[i];
+    if (ch === '\r') continue;
+    if (ch === '"') {
+      // 引用符の中の "" は文字としての " なので、閉じ引用符と見ない
+      if (quoted && code[i + 1] === '"') {
+        push(colClass(), '""');
+        i++;
+        continue;
+      }
+      quoted = !quoted;
+      push(colClass(), ch);
+      continue;
+    }
+    if (ch === '\n') {
+      lines.push([]);
+      if (!quoted) col = 0;
+      continue;
+    }
+    if (ch === ',' && !quoted) {
+      push('csv-comma', ch);
+      col++;
+      continue;
+    }
+    push(colClass(), ch);
+  }
+  return lines;
+}
+
+function render(lines) {
+  return lines
+    .map(
+      (cells) =>
+        '<span class="line">' +
+        cells.map((c) => `<span class="${c.cls}">${escapeHtml(c.text)}</span>`).join('') +
+        '</span><br>',
+    )
+    .join('');
+}
+
+hexo.extend.filter.register(
+  'before_post_render',
+  function (data) {
+    if (data.layout !== 'post' && data.layout !== 'page') return;
+    if (data.content.indexOf('```csv') === -1) return;
+
+    data.content = data.content.replace(FENCE, (match, indent, caption, code) => {
+      const lines = tokenize(code);
+      // 1列しかないブロックは色分けの対象にならない。全体が1色で塗られると
+      // 意味のある色に見えてしまうので、hexo の素の描画に任せる
+      const columns = Math.max(
+        ...lines.map((cells) => cells.filter((c) => c.cls === 'csv-comma').length),
+      );
+      if (columns < 1) return match;
+
+      const caption_ = caption.trim();
+      return (
+        indent +
+        '<figure class="highlight csv">' +
+        (caption_ ? `<figcaption><span>${escapeHtml(caption_)}</span></figcaption>` : '') +
+        `<table><tbody><tr><td class="code"><pre>${render(lines)}</pre></td></tr></tbody></table>` +
+        '</figure>'
+      );
+    });
+  },
+  9,
+);

--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -262,6 +262,26 @@ pre
     font-weight: bold
   .emphasis
     font-style: italic
+  // csv は列ごとに色を変える（scripts/csv_column_highlight.js、#2529）。
+  // 色は構文の意味ではなく列の位置を表すだけなので、専用の色は作らず既存の
+  // トークン色を順に借りる。csv のブロックには他のトークンが出ないため、
+  // 同じ色でも意味が衝突しない。6色で足りない列は先頭に戻って循環する
+  .csv-col-1
+    color: highlight-orange
+  .csv-col-2
+    color: highlight-yellow
+  .csv-col-3
+    color: highlight-green
+  .csv-col-4
+    color: highlight-blue
+  .csv-col-5
+    color: highlight-purple
+  .csv-col-6
+    color: highlight-foreground
+  // 区切りは列の中身より一段引く。カンマが色の主役になると列の切れ目より
+  // 記号の並びが目に付く
+  .csv-comma
+    color: highlight-comment
   // diff_[language] ではキーワードから色を外し、太字だけ残す。
   // 差分の赤緑と構文の色が同時に出ると色数が多すぎて読み取りにくいため
   .keyword-plain


### PR DESCRIPTION
Fixes #2529

## 実データの確認

`csv` ブロックは15箇所、`tsv` は0件。

| 列数 | 件数 |
| --- | --- |
| 1〜2列 | 2件 |
| 3列 | 2件 |
| 4〜6列 | 9件 |
| 8列 | 1件 |

- **引用符付きが4件**。うち1件は**引用符の中に改行**を含む（Go の `encoding/csv` の記事）ため、素の `split(',')` ではその行から先が崩れる
- **行ごとに列数が違うブロックが2件**（AWK 記事・Casbin 記事）

## 実装

`scripts/csv_column_highlight.js` を追加し、`csv` フェンスを横取りして組み立てる（`register_hljs_terraform.js` / `diff_language_highlight.js` と同じ手口）。highlight.js の言語定義は正規表現のモードだけで状態を持てず、「いま何列目か」を数えられないため、rego のように言語を足す形は採れない。

- 区切りは RFC 4180 に沿って読む。引用符・`""` エスケープ・引用符の中の改行に対応
- 行は**表示の単位**なので、引用符の中の改行でも行を分ける。列番号は引用符の外のカンマでだけ進み、レコードの終わりでだけ戻る
- **1列だけのブロックは横取りしない**。全体が1色に塗られると意味のある色に見えるため（該当1件）

## 配色

`highlight.styl` の既存トークン色を6色循環（orange → yellow → green → blue → purple → foreground）。**新しい色の値は追加していない**。色は構文の意味ではなく列の位置を表すだけで、csv のブロックには他のトークンが出ないため意味が衝突しない。8列でも2周目が隣の列と重ならない。区切りのカンマは `highlight-comment` に落とし、記号が色の主役にならないようにした。

全色が背景 #2b2b2b に対してコントラスト比 4.5 以上（最低は blue の 4.54）。

## 確認

`make clean` してからのフルビルド（`scripts/` のフィルタは `db.json` のキャッシュを消さないと既存記事に効かない #2517）。

- `figure.highlight.csv` が **14箇所**生成された（15箇所のうち1列の1件は素のまま＝設計どおり）
- 引用符の中に改行を含むブロックが、元のテキストと同じ行数・同じ列の色で出ている
- 全項目が引用符のブロック、列数が行で違うブロック、8列のブロックを描画で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)