### PR TITLE
コードフェンスの中は記法フィルタを効かせない (#2549)

### DIFF
--- a/scripts/csv_column_highlight.js
+++ b/scripts/csv_column_highlight.js
@@ -16,6 +16,8 @@
  * 色は highlight.styl の既存トークン色を6色循環させる（配色は CSS 側）。
  */
 
+const { replaceOutsideFences } = require('./lib/fence');
+
 const FENCE = /^([ \t]*)```csv[ \t]*(.*)\n([\s\S]*?)\n[ \t]*```/gm;
 
 // 色数。8列でも2周目が隣の列と重ならない
@@ -94,7 +96,8 @@ hexo.extend.filter.register(
     if (data.layout !== 'post' && data.layout !== 'page') return;
     if (data.content.indexOf('```csv') === -1) return;
 
-    data.content = data.content.replace(FENCE, (match, indent, caption, code) => {
+    // 外側のフェンスに入れ子で書かれた ```csv は記法の見本なので触らない (#2549)
+    data.content = replaceOutsideFences(data.content, FENCE, (match, indent, caption, code) => {
       const lines = tokenize(code);
       // 1列しかないブロックは色分けの対象にならない。全体が1色で塗られると
       // 意味のある色に見えてしまうので、hexo の素の描画に任せる

--- a/scripts/diff_language_highlight.js
+++ b/scripts/diff_language_highlight.js
@@ -21,6 +21,7 @@
  */
 
 const hljs = require('highlight.js');
+const { replaceOutsideFences } = require('./lib/fence');
 
 // ```diff_go / ```diff-go のどちらでも受ける。後ろにファイル名を書ける点は
 // hexo 標準のコードブロックと同じ
@@ -111,19 +112,24 @@ hexo.extend.filter.register(
     if (data.layout !== 'post' && data.layout !== 'page') return;
     if (data.content.indexOf('```diff') === -1) return;
 
-    data.content = data.content.replace(FENCE, (match, indent, lang, caption, code) => {
-      // hljs が知らない言語はそのまま素の diff として hexo に任せる
-      if (!hljs.getLanguage(lang)) return match;
+    // 外側のフェンスに入れ子で書かれた ```diff_xxx は記法の見本なので触らない (#2549)
+    data.content = replaceOutsideFences(
+      data.content,
+      FENCE,
+      (match, indent, lang, caption, code) => {
+        // hljs が知らない言語はそのまま素の diff として hexo に任せる
+        if (!hljs.getLanguage(lang)) return match;
 
-      const caption_ = caption.trim();
-      return (
-        indent +
-        `<figure class="highlight diff_${escapeHtml(lang)}">` +
-        (caption_ ? `<figcaption><span>${escapeHtml(caption_)}</span></figcaption>` : '') +
-        `<table><tbody><tr><td class="code"><pre>${render(code, lang)}</pre></td></tr></tbody></table>` +
-        `</figure>`
-      );
-    });
+        const caption_ = caption.trim();
+        return (
+          indent +
+          `<figure class="highlight diff_${escapeHtml(lang)}">` +
+          (caption_ ? `<figcaption><span>${escapeHtml(caption_)}</span></figcaption>` : '') +
+          `<table><tbody><tr><td class="code"><pre>${render(code, lang)}</pre></td></tr></tbody></table>` +
+          `</figure>`
+        );
+      },
+    );
   },
   9,
 );

--- a/scripts/lib/fence.js
+++ b/scripts/lib/fence.js
@@ -1,0 +1,66 @@
+'use strict';
+
+/**
+ * コードフェンスの範囲を求める（#2549）。
+ *
+ * 独自記法のフィルタは before_post_render で生の Markdown に正規表現を当てるため、
+ * その時点ではコードフェンスという概念が無く、フェンスの中に書いた見本まで
+ * 置換してしまう。記法を説明する記事（#2533 の記法まとめページ）が書けない。
+ *
+ * 判定は「マッチの開始位置がフェンスの内側か」だけを見る。フェンスの開始位置
+ * そのものは内側に含めない。こうすると、フェンス自体が対象の記法（csv /
+ * diff_[language] / mermaid）は自分のフェンスでは素通しされず、外側のフェンスに
+ * 入れ子で書かれたときだけ素通しされる。note のようにフェンスでない記法は、
+ * フェンスの中にある限り必ず内側と判定される。同じ関数で両方を賄える。
+ *
+ * 見るのはフェンス（``` / ~~~）だけで、4字下げのコードブロックは見ない。
+ * 独自記法の正規表現は行頭の空白を許すので下げても逃げられず、下げる書き方で
+ * 見本を作ることが元からできないため。
+ */
+
+// 開始は3つ以上の ` か ~。閉じは同じ記号を同じ数以上並べた、他に何も無い行
+const FENCE_LINE = /^[ \t]*(`{3,}|~{3,})(.*)$/;
+
+/** フェンスの範囲を [開始位置, 終了位置) の配列で返す */
+function fenceRanges(content) {
+  const ranges = [];
+  let open = null;
+  let start = 0;
+  let pos = 0;
+
+  for (const line of content.split('\n')) {
+    const m = FENCE_LINE.exec(line);
+    if (m) {
+      if (!open) {
+        open = m[1];
+        start = pos;
+      } else if (m[1][0] === open[0] && m[1].length >= open.length && m[2].trim() === '') {
+        ranges.push([start, pos + line.length]);
+        open = null;
+      }
+    }
+    pos += line.length + 1;
+  }
+  // 閉じ忘れは本文の終わりまでをフェンスとみなす。Markdown 側も同じ扱いで、
+  // 閉じられていないフェンスは末尾までコードとして描画される
+  if (open) ranges.push([start, content.length]);
+  return ranges;
+}
+
+/**
+ * フェンスの中を避けて置換する。replacer は String#replace と同じ引数を受け取る。
+ */
+function replaceOutsideFences(content, regex, replacer) {
+  const ranges = fenceRanges(content);
+  if (!ranges.length) return content.replace(regex, replacer);
+
+  return content.replace(regex, function (...args) {
+    // 名前付きグループを使う正規表現ではコールバックの末尾に groups が付くため、
+    // 位置は「最初に現れる数値の引数」として取る
+    const offset = args.find((a) => typeof a === 'number');
+    if (ranges.some(([s, e]) => offset > s && offset < e)) return args[0];
+    return replacer.apply(null, args);
+  });
+}
+
+module.exports = { fenceRanges, replaceOutsideFences };

--- a/scripts/mermaid.js
+++ b/scripts/mermaid.js
@@ -24,6 +24,7 @@
 const fs = require('fs');
 const path = require('path');
 const { fenceRegExp, hashOf, CACHE_DIR } = require('./lib/mermaid');
+const { replaceOutsideFences } = require('./lib/fence');
 
 // hexo-mermaid-lastest 1.1.1 が付けていたものと同一（フォールバックの挙動を変えない）
 const MERMAID_SCRIPT = `<script type="module"> import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.esm.min.mjs';	mermaid.initialize({startOnLoad: true, flowchart: {curve: 'linear'}}); </script>`;
@@ -45,7 +46,9 @@ hexo.extend.filter.register(
     if (ignore(data)) return;
     let matched = false;
     let missing = 0;
-    data.content = data.content.replace(
+    // 外側のフェンスに入れ子で書かれた ```mermaid は記法の見本なので触らない (#2549)
+    data.content = replaceOutsideFences(
+      data.content,
       fenceRegExp(),
       (raw, start, quote, lang, source, endQuote, end) => {
         matched = true;

--- a/scripts/note_container.js
+++ b/scripts/note_container.js
@@ -15,6 +15,8 @@
  * タイトルを付けると、タイトル行と本文が分かれて本文が全幅になる (#2490)。
  * :::
  */
+const { replaceOutsideFences } = require('./lib/fence');
+
 hexo.extend.filter.register('before_post_render', function (data) {
   // ^([ \t]*): 行頭のインデントをキャプチャし、同じインデントの終了タグ（\1:::）と対にする。
   // 水平空白に限るのが要点で、\s にすると改行まで飲み、直前の空行から
@@ -26,67 +28,75 @@ hexo.extend.filter.register('before_post_render', function (data) {
   // ::: が本文に出ていた（書いた側は気づけない）
   const regex = /^([ \t]*):::[ \t]+note(?:[ \t]+(\S+))?(?:[ \t]+([^\n]*))?\n([\s\S]+?)\n\1:::$/gm;
 
-  data.content = data.content.replace(regex, (match, indent, firstWord, rest, content) => {
-    let className = 'info'; // デフォルトのクラス名
-    const allowedClasses = ['tip', 'info', 'warn', 'alert'];
-    // 1語目が種別ならそれを採り、残りをタイトルとする。種別でなければ
-    // 行の残り全部がタイトル（種別は既定の info）。
-    // 「tip」という語をタイトルにしたいときだけ取り違えるが、
-    // その場合は種別を明示して `::: note info tip` と書けばよい
-    let title = '';
-    if (firstWord && allowedClasses.includes(firstWord)) {
-      className = firstWord;
-      title = (rest || '').trim();
-    } else if (firstWord) {
-      title = [firstWord, rest || ''].join(' ').trim();
-    }
+  // コードフェンスの中の ::: は記法の見本なので置換しない (#2549)
+  data.content = replaceOutsideFences(
+    data.content,
+    regex,
+    (match, indent, firstWord, rest, content) => {
+      let className = 'info'; // デフォルトのクラス名
+      const allowedClasses = ['tip', 'info', 'warn', 'alert'];
+      // 1語目が種別ならそれを採り、残りをタイトルとする。種別でなければ
+      // 行の残り全部がタイトル（種別は既定の info）。
+      // 「tip」という語をタイトルにしたいときだけ取り違えるが、
+      // その場合は種別を明示して `::: note info tip` と書けばよい
+      let title = '';
+      if (firstWord && allowedClasses.includes(firstWord)) {
+        className = firstWord;
+        title = (rest || '').trim();
+      } else if (firstWord) {
+        title = [firstWord, rest || ''].join(' ').trim();
+      }
 
-    // キャプチャしたコンテナ内のコンテンツから、共通のインデントを削除
-    // これにより、Markdownレンダラが意図せずコードブロックとして解釈するのを防ぐ
-    const unindentedContent = content
-      .split('\n')
-      .map((line) => {
-        if (line.startsWith(indent)) {
-          return line.substring(indent.length);
-        }
-        return line;
-      })
-      .join('\n');
+      // キャプチャしたコンテナ内のコンテンツから、共通のインデントを削除
+      // これにより、Markdownレンダラが意図せずコードブロックとして解釈するのを防ぐ
+      const unindentedContent = content
+        .split('\n')
+        .map((line) => {
+          if (line.startsWith(indent)) {
+            return line.substring(indent.length);
+          }
+          return line;
+        })
+        .join('\n');
 
-    // インデントを削除したコンテンツをMarkdownとして正しくレンダリング
-    const renderedContent = hexo.render.renderSync({ text: unindentedContent, engine: 'markdown' });
+      // インデントを削除したコンテンツをMarkdownとして正しくレンダリング
+      const renderedContent = hexo.render.renderSync({
+        text: unindentedContent,
+        engine: 'markdown',
+      });
 
-    // クラス名に note- を付ける。tip/info/warn/alert のような一般語をそのまま使うと
-    // 他のCSSと衝突する。実際 alert は bootstrap の .alert に当たっていた (#2486)。
-    // アイコンの fa-check-circle も Font Awesome 由来の名前で、実体（警告なら
-    // 感嘆符、tip なら電球）と合っていなかったため役割名にする
-    //
-    // タイトルがあるときだけ構造を変える。無ければ従来どおりの2列。
-    // 既存の note は225件あり、そのすべての見た目を動かさないため (#2490)
-    //
-    // コードブロックとして認識されてしまわないよう、インデントされないよう愚直に文字列結合
-    if (title) {
-      // タイトルも Markdown として描く。`code` やリンクを本文と同じ書き方で
-      // 使えるようにするため。1行なので描画結果の <p> を外して中身だけ使う
-      const renderedTitle = hexo.render
-        .renderSync({ text: title, engine: 'markdown' })
-        .trim()
-        .replace(/^<p>/, '')
-        .replace(/<\/p>$/, '');
+      // クラス名に note- を付ける。tip/info/warn/alert のような一般語をそのまま使うと
+      // 他のCSSと衝突する。実際 alert は bootstrap の .alert に当たっていた (#2486)。
+      // アイコンの fa-check-circle も Font Awesome 由来の名前で、実体（警告なら
+      // 感嘆符、tip なら電球）と合っていなかったため役割名にする
+      //
+      // タイトルがあるときだけ構造を変える。無ければ従来どおりの2列。
+      // 既存の note は225件あり、そのすべての見た目を動かさないため (#2490)
+      //
+      // コードブロックとして認識されてしまわないよう、インデントされないよう愚直に文字列結合
+      if (title) {
+        // タイトルも Markdown として描く。`code` やリンクを本文と同じ書き方で
+        // 使えるようにするため。1行なので描画結果の <p> を外して中身だけ使う
+        const renderedTitle = hexo.render
+          .renderSync({ text: title, engine: 'markdown' })
+          .trim()
+          .replace(/^<p>/, '')
+          .replace(/<\/p>$/, '');
+        return (
+          `<div class="note-container note-${className} note-has-title">` +
+          `<div class="note-title"><span class="note-icon"></span>${renderedTitle}</div>` +
+          `<div class="note-body">${renderedContent.trim()}</div>` +
+          `</div>`
+        );
+      }
       return (
-        `<div class="note-container note-${className} note-has-title">` +
-        `<div class="note-title"><span class="note-icon"></span>${renderedTitle}</div>` +
-        `<div class="note-body">${renderedContent.trim()}</div>` +
+        `<div class="note-container note-${className}">` +
+        `<span class="note-icon"></span>` +
+        `<div>${renderedContent.trim()}</div>` +
         `</div>`
       );
-    }
-    return (
-      `<div class="note-container note-${className}">` +
-      `<span class="note-icon"></span>` +
-      `<div>${renderedContent.trim()}</div>` +
-      `</div>`
-    );
-  });
+    },
+  );
 
   return data;
 });


### PR DESCRIPTION
Fixes #2549

## 問題

独自記法のフィルタは `before_post_render` で**生の Markdown に正規表現を当てて**いる。この時点ではコードフェンスという概念が無いため、フェンスの中に書いた見本まで置換される。実際のフィルタを読み込んで確認した結果:

| 入力（```` ```markdown ```` フェンスの中） | 出力 |
| --- | --- |
| `::: note tip` … `:::` | `<div class="note-container note-tip">…</div>` |
| ```` ```csv ```` … ```` ``` ```` | `<figure class="highlight csv">…</figure>` |

4連バッククォートで囲っても、インデントしても防げない（フィルタが Markdown を解釈しないため）。記法を説明する記事や #2533 の記法まとめページが書けない。

## 変更

`scripts/lib/fence.js` にフェンスの範囲を求める処理を置き、`note_container` / `csv_column_highlight` / `diff_language_highlight` / `mermaid` の4フィルタから使う。

判定は **「マッチの開始位置がフェンスの内側か」だけ**を見て、フェンスの開始位置そのものは内側に含めない。これで2種類の記法を同じ関数で賄える。

- `note` のようにフェンスでない記法 → フェンスの中にある限り必ず内側と判定されて素通し
- `csv` / `diff_[language]` / `mermaid` のようにフェンス自体が対象の記法 → 自分のフェンスは開始位置が一致するので対象のまま、**外側のフェンスに入れ子で書かれたときだけ**素通し

見るのはフェンス（```` ``` ```` / `~~~`）だけで、4字下げのコードブロックは見ない。独自記法の正規表現は行頭の空白を許すので、下げても元から逃げられないため。

## 確認

**退行なし。** `make clean` からのフルビルドで、変更前後の描画件数が完全に一致した。

| | 変更前 | 変更後 |
| --- | --- | --- |
| note | 228 | 228 |
| csv | 14 | 14 |
| diff_[lang] | 10 | 10 |
| mermaid | 53 | 53 |

あわせて、実フィルタを読み込んで「本物は変換され、フェンスの中の見本は残る」ことを確認した（note / csv / diff の3種とも）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)