### PR TITLE
モバイルの note を全幅にし、絵柄を左上の装飾にする

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2917,6 +2917,51 @@ note-alert-bg = #ffdbdb
   margin-bottom: 0;
 }
 
+/* モバイルでは note の本文だけが狭かった (#2521)。幅375pxで本文カラムは
+   351px あるのに、note の中は枠の padding 40px とアイコン列 28.4px を引いて
+   282.6px しかない。19.5% が一律に削られ、本文15.6pxで1行4文字強の差になる。
+
+   地の色を画面端まで伸ばし、文字の位置は段落と揃える。左右の padding を
+   .container と同じ12pxにすると note の中の文字の左端が段落の左端と一致し、
+   幅も完全に戻る。読者から見ると文字の位置は何も変わらず、色の帯だけが
+   端まで伸びた形になる。padding を20pxのまま全幅にすると、note の文字だけが
+   本文より8px内側へ入って段差がかえって目立つ。
+
+   50% は .container の内側幅を指すので、margin は左右とも -12px になる。
+   100vw と違いスクロールバーの幅を含まない。
+
+   絵柄は本文と連動させず、左上に置いた装飾として扱う。1行目の横に回り込ませる
+   float も試したが、float が避けるのは行ボックスだけで、箇条書きやコードブロックが
+   自前で持つ左の溝とは重なる。実際に箇条書きで始まる3件でマーカーが潰れていた。
+   絶対配置なら中身が何で始まっても関係が無く、要素ごとの特例を持たずに済む */
+@media (max-width: 767px) {
+  .article-entry .note-container {
+    display: block;
+    margin-inline: calc(50% - 50vw);
+    padding-left: 12px;
+    padding-right: 12px;
+    /* 画面端まで伸びた帯に角丸は掛からない */
+    border-radius: 0;
+    position: relative;
+  }
+  /* 絵柄のぶんの空きは、絵柄を単独で持つタイトル無しの note だけに掛ける。
+     タイトル付き（24件）は絵柄がタイトル行の中に収まっていて上に帯が要らない。
+     全体に掛けるとタイトルの上に何も無い空きが42px空く */
+  .article-entry .note-container:not(.note-has-title) {
+    padding-top: 42px;
+    /* 上が絵柄のぶん厚くなるので、下も広げて釣り合わせる。
+       16px のままだと本文の最終行が枠の下辺に近づいて詰まって見える */
+    padding-bottom: 24px;
+  }
+  .article-entry .note-container > .note-icon {
+    position: absolute;
+    top: 14px;
+    left: 12px;
+    height: 18px;
+    margin-right: 0;
+  }
+}
+
 /* タイトル付きの note (#2490)。タイトルがアイコンを引き受けるので2列をやめ、
    本文は枠いっぱいを使う。タイトル無しの note は従来の2列のままなので、
    既存の225件の見た目は動かない */


### PR DESCRIPTION
Close #2521

## 直した問題

モバイル幅で `::: note` の本文だけが狭かった。幅375pxでの内訳。

| | |
| --- | --- |
| 本文カラム幅（通常の段落） | 351px |
| `.note-container` の左右 padding | −40px |
| アイコン列（18px ＋ `margin-right: 0.8em`） | −28.4px |
| **note の本文幅** | **282.6px** |

**19.5% が一律に削られていた。** 本文15.6pxで1行4文字強の差になる。

対象は**228件中204件**（タイトル付き24件は既に `block` なので影響なし）。

## 方針: 地の色だけを画面端まで伸ばし、文字は段落と揃える

| 案 | 本文幅 | 通常段落比 |
| --- | --- | --- |
| 現状 | 282.6px | 80.5% |
| padding を12pxに詰める（2列のまま） | 298.6px | 85.1% |
| 全幅だが2列は維持 | 306.6px | 87.4% |
| 枠内のまま `block` 化 | 311.0px | 88.6% |
| 全幅 ＋ `block` 化（padding 20px） | 335.0px | 95.4% |
| **採用: 全幅 ＋ `block` 化 ＋ padding 12px** | **351.0px** | **100%** |

左右の padding を `.container` と同じ12pxにするのが要点。**note の中の文字の左端が段落の左端と一致し、幅も完全に戻る。** 読者から見ると「文字の位置は何も変わらず、色の帯だけが端まで伸びた」形になる。

padding を20pxのまま全幅にすると、note の文字だけが本文より8px内側へ入って段差がかえって目立つ。

`50%` は `.container` の内側幅を指すので margin は左右とも −12px になる。**`100vw` と違いスクロールバーの幅を含まない**ので横スクロールが出ない。

## 絵柄は本文と連動させない

左上に絶対配置し、本文の折り返しには一切影響させない。

**当初は `float: left` にしていたが、レビューで崩れが見つかった。** `float` が避けるのは行ボックスだけで、箇条書きが自前で持つ左の溝（`padding-inline-start: 20px` のマーカー領域）は避けない。溝の位置に絵柄が重なり、1つ目の項目のマーカーが読めなくなっていた。

実データを数えると、タイトル無し note 204件の「最初の要素」は次のとおり。

| 最初の要素 | 件数 |
| --- | --- |
| 段落 | 201件（98.5%） |
| 箇条書き | 3件（1.5%） |

98.5% は `float` でも問題ないが、**壊れ方が黙って起きる**うえ、将来コードブロックや表で始めれば同じことが起きる。`:has()` で要素ごとに分岐する案も書いたが、絶対配置なら**中身が何で始まっても関係が無く、特例そのものが要らない**ので、そちらを採った。

（`:has(> div > :first-child:is(ul, ol, ...))` は Stylus が括弧内のカンマをセレクタ区切りとして扱い、`:is(` の途中で改行した壊れた CSS を吐く。`@supports` の `selector()` を `unquote` で渡しているのと同じ罠。この分岐が消えたので問題自体が無くなった。）

## 余白

絵柄が1行ぶんの帯を専有するので、上を42pxにした。**下も16px→24pxに広げて釣り合わせる。** 16pxのままだと上下の空きが2.6倍違い、本文の最終行が枠の下辺に近づいて詰まって見える。16 / 20 / 24 / 28px を375px幅で並べて比較し、24pxを選んだ。

この上下の空きは**タイトル無しの note にだけ掛ける**。タイトル付きは絵柄がタイトル行の中に収まっていて上の帯が要らず、全体に掛けるとタイトルの上に何も無い空きが42px空く。

## 確認

- 幅375pxの iframe を並べた比較ページで、4種（tip / info / warn / alert）× タイトル有無、および箇条書き始まり・コードブロック始まりを確認
- 実記事: `/articles/20230922a/`（箇条書き始まりの alert）、`/articles/20241030a/`（タイトル無し7個・3種）、`/articles/20250827a/`（タイトル付き4個＋無し1個）
- 変更は `theme-styles.styl` の1ファイル、`@media (max-width: 767px)` のブロック1つ（45行追加、既存行の変更なし）
- 768px 以上の見た目は変わらない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
