### PR TITLE
画像の直下に書いたキャプションを効くようにする (#2553)

### DIFF
--- a/scripts/figure_caption.js
+++ b/scripts/figure_caption.js
@@ -20,6 +20,25 @@
  * `出典：URL` をリンク化する autolink_image_source.js と同じ after_post_render で
  * 動くため、優先度を下げて後に回す。
  */
+const { replaceOutsideFences } = require('./lib/fence');
+
+/**
+ * 画像の行と、その直下のキャプション行の間に空行を入れる（#2553）。
+ *
+ * 行頭の <img> から始まる塊を marked は HTML ブロックとして扱い、空行までを
+ * raw のまま出す。そのため直下に書いた `*…*` は <em> にならず、下の
+ * after_post_render が探している形（<p><em>…</em></p>）にならない。
+ * 記法は「直下の行」と決まっている（#2517）ので、実装側で空行を補う。
+ *
+ * キャプションの中身は空行を空けたあとに marked が描くため、`code` や
+ * リンクといったインライン記法もそのまま効く。
+ */
+const IMAGE_LINE = '(?:<a\\b[^>]*>\\s*)?<img\\b[^>]*>(?:\\s*</a>)?|!\\[[^\\]]*\\]\\([^)\\n]*\\)';
+const BLANK_BEFORE_CAPTION = new RegExp(
+  `^([ \\t]*(?:${IMAGE_LINE})[ \\t]*)\\n(?=[ \\t]*\\*[^*\\n]+\\*[ \\t]*$)`,
+  'gm',
+);
+
 const IMG = '(?:<a\\b[^>]*>\\s*)?<img\\b[^>]*>(?:\\s*</a>)?';
 const CAPTION = '<p><em>((?:(?!</em>)[\\s\\S])+)</em></p>';
 const PATTERN = new RegExp(`(?:<p>\\s*(${IMG})\\s*</p>|(${IMG}))\\s*${CAPTION}`, 'g');
@@ -33,6 +52,17 @@ function toFigure(content) {
     return `<figure>${image}<figcaption>${caption}</figcaption></figure>`;
   });
 }
+
+hexo.extend.filter.register('before_post_render', function (data) {
+  if (!data || !data.content) return;
+  // コードフェンスの中の見本は記法の説明なので触らない (#2549)
+  data.content = replaceOutsideFences(
+    data.content,
+    BLANK_BEFORE_CAPTION,
+    (m, line) => `${line}\n\n`,
+  );
+  return data;
+});
 
 hexo.extend.filter.register(
   'after_post_render',


### PR DESCRIPTION
Fixes #2553

## 症状

CLAUDE.md が定めている「画像の直下の行を `*` で挟む」キャプション記法（#2517 / #2519）が効いておらず、公開中のページで `*Auth0 のコンソール画面では…*` のようにアスタリスクが見えていた。

## 原因

行頭の `<img>` から始まる塊を marked は **HTML ブロック**として扱い、空行までを raw のまま出す。そのため直下の `*…*` は `<em>` にならず、figure に組み替える `after_post_render` が探している形（`<p><em>…</em></p>`）にならない。

| 書き方 | marked の出力 |
| --- | --- |
| 直下の行 | `<img …>\n*キャプション*`（em にならない） |
| 空行を1つ空ける | `<img …>\n\n<p><em>キャプション</em></p>` |

## 変更

記法は決まっているので実装側を合わせる。`before_post_render` で画像行とキャプション行の間に**空行を補い**、marked に段落として描かせてから既存の組み替えに渡す。

- キャプションの中身も marked が描くので、`` `code` `` やリンクがそのまま効く
- Markdown 記法の画像（`![alt](url)`）も同じ形になるため併せて拾う
- コードフェンスの中の見本は #2549 の判定で素通しする

## 確認

6パターンをフィルタとレンダラを通して確認した。

| ケース | figcaption |
| --- | --- |
| 直下の行（生の `<img>`） | OK |
| キャプションにインライン記法（`` `code` ``） | OK（`<code>` になる） |
| Markdown 画像 `![alt](url)` | OK |
| 空行あり（従来の形） | OK |
| ただの強調段落（画像の下に無い） | 対象外のまま |
| コードフェンスの中の見本 | 対象外のまま |

`make clean` からのフルビルドで、`<figure><img` を持つ記事が **16 → 18 件**に増えた。既存の壊れていた記事（20221007a）でアスタリスクが消え、`<figcaption>` になっていることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)