### PR TITLE
note の中身を二重に Markdown 描画しない (#2547)

### DIFF
--- a/scripts/note_container.js
+++ b/scripts/note_container.js
@@ -59,12 +59,6 @@ hexo.extend.filter.register('before_post_render', function (data) {
         })
         .join('\n');
 
-      // インデントを削除したコンテンツをMarkdownとして正しくレンダリング
-      const renderedContent = hexo.render.renderSync({
-        text: unindentedContent,
-        engine: 'markdown',
-      });
-
       // クラス名に note- を付ける。tip/info/warn/alert のような一般語をそのまま使うと
       // 他のCSSと衝突する。実際 alert は bootstrap の .alert に当たっていた (#2486)。
       // アイコンの fa-check-circle も Font Awesome 由来の名前で、実体（警告なら
@@ -74,6 +68,7 @@ hexo.extend.filter.register('before_post_render', function (data) {
       // 既存の note は225件あり、そのすべての見た目を動かさないため (#2490)
       //
       // コードブロックとして認識されてしまわないよう、インデントされないよう愚直に文字列結合
+      let open;
       if (title) {
         // タイトルも Markdown として描く。`code` やリンクを本文と同じ書き方で
         // 使えるようにするため。1行なので描画結果の <p> を外して中身だけ使う
@@ -82,19 +77,27 @@ hexo.extend.filter.register('before_post_render', function (data) {
           .trim()
           .replace(/^<p>/, '')
           .replace(/<\/p>$/, '');
-        return (
+        open =
           `<div class="note-container note-${className} note-has-title">` +
           `<div class="note-title"><span class="note-icon"></span>${renderedTitle}</div>` +
-          `<div class="note-body">${renderedContent.trim()}</div>` +
-          `</div>`
-        );
+          `<div class="note-body">`;
+      } else {
+        open =
+          `<div class="note-container note-${className}">` + `<span class="note-icon"></span><div>`;
       }
-      return (
-        `<div class="note-container note-${className}">` +
-        `<span class="note-icon"></span>` +
-        `<div>${renderedContent.trim()}</div>` +
-        `</div>`
-      );
+
+      // 本文はここで描かず、Markdown のまま囲みの中に置く。開きタグと本文の間、
+      // 本文と閉じタグの間に空行を入れるのが要点で、CommonMark の HTML ブロックは
+      // 空行で終わる。本文は本体と同じ経路で描かれる。
+      //
+      // 以前はここで renderSync していた。この時点の本文はコードフェンスが
+      // すでに backtick_code に HTML へ置き換えられた後で、その HTML を
+      // もう一度 Markdown として解釈していた。コードの中の `Identity[T any](T) T` が
+      // リンク記法として `Identity<a href="T">T any</a> T` になる、Go の raw string を
+      // 含むコードでハイライト用の HTML 自体が再エスケープされる、素の URL が
+      // 勝手にリンクになる、コードブロックが note の中でだけ <p> に包まれる、
+      // といった壊れ方をしていた (#2547)
+      return `${open}\n\n${unindentedContent.trim()}\n\n</div></div>`;
     },
   );
 


### PR DESCRIPTION
closes #2547

`::: note` の中のコードブロックが壊れていた件。

## 原因

`note_container.js` は note の本文を `before_post_render` の中で `hexo.render.renderSync` して
HTML にしていた。ところがこの位置ではコードフェンスがすでに hexo の `backtick_code` に
HTML（`figure.highlight`）へ置き換えられた後で、**その HTML をもう一度 Markdown として
解釈**していた。note の外のコードブロックは1回しか通らないので、note の中だけが壊れる。

| 記事 | ソース | 出ていたもの |
| --- | --- | --- |
| [20260730a](https://future-architect.github.io/articles/20260730a/) | `Identity[T any](T) T` | `Identity<a href="T">T any</a> T`（角括弧・丸括弧が消える） |
| [20240722a](https://future-architect.github.io/articles/20240722a/) | Go の raw string を含むコード | ハイライト用の HTML が再エスケープされ `&lt;/span&gt;&lt;br&gt;…` が本文に露出 |
| [20250828a](https://future-architect.github.io/articles/20250828a/) | `irm https://…` | URL が勝手に `<a>` になる |
| 全16件 | コードフェンス | note の中でだけ `<p><figure class="highlight">…</figure></p>` と段落に包まれる |

## 直し方

本文をここで描かず、Markdown のまま囲みの中に置く。開きタグと本文の間、本文と閉じタグの間に
空行を入れるのが要点で、CommonMark の HTML ブロックは空行で終わるため、本文は note の外と
同じ経路で描かれる。二重描画そのものが無くなるので、この系統の壊れ方はまとめて消える。

タイトル（24件）は従来どおりこの場で描く。1行のテキストで、フェンスを含まないため。

## 確認

`::: note` を含む記事111本を、修正前後で hexo の描画パイプライン
（before_post_render → render → after_post_render）に通して突き合わせた。

- タグ間の空白を潰した比較で差が出たのは **12本**。すべて上記の壊れ方が直ったもの
- 残り99本はバイト単位で同一
- 差分の内訳: `<p><figure>` の解消 12本 / コード内容の復旧 3本 / 段落先頭の余分な空白の解消 1本

`scripts/` のフィルタを変えているので、手元で見るときは `make clean` してからビルドが必要（CLAUDE.md）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
