### PR TITLE
折りたたみの中の note が切れるのを直す (#2568)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2963,12 +2963,25 @@ note-alert-bg = #ffdbdb
 @media (max-width: 767px) {
   .article-entry .note-container {
     display: block;
-    margin-inline: calc(50% - 50vw);
     padding-left: 12px;
     padding-right: 12px;
+    position: relative;
+  }
+  /* 端まで伸ばすのは .article-entry の直下にある note だけ (#2568)。
+
+     calc(50% - 50vw) の 50% は「その note を包む箱」の幅を指すので、
+     入れ子になると包む箱のぶんだけ余分に外へ出る。折りたたみの中では
+     details::details-content の overflow: hidden（開閉のアニメーション #2522）が
+     はみ出しを切り落とし、絵柄と文字が欠けていた。
+     幅375pxでは note が左右に27pxずつ出て、絵柄（左から12px）は
+     切り取られる側に落ちる。
+
+     入れ子の中では帯を伸ばさず、囲みのままにする。構えと絵柄の位置は
+     上の共通指定が持つので、入れ子でも見え方は揃う */
+  .article-entry > .note-container {
+    margin-inline: calc(50% - 50vw);
     /* 画面端まで伸びた帯に角丸は掛からない */
     border-radius: 0;
-    position: relative;
   }
   /* 絵柄のぶんの空きは、絵柄を単独で持つタイトル無しの note だけに掛ける。
      タイトル付き（24件）は絵柄がタイトル行の中に収まっていて上に帯が要らない。


### PR DESCRIPTION
Close #2568

## 原因

モバイルの note は地の色を画面端まで伸ばしています（#2521）。

```styl
margin-inline: calc(50% - 50vw);
```

この `50%` は**その note を包む箱**の幅を指すので、入れ子になると包む箱のぶんだけ余分に外へ出ます。折りたたみの中では `details::details-content` の `overflow: hidden`（開閉のアニメーション #2522）がはみ出しを切り落とすため、絵柄と文字が欠けていました。

幅375pxでの計算:

| | 幅 |
| --- | ---: |
| 本文カラム | 351px |
| 折りたたみの中身（`padding 0 14px` + `border 1px`） | **321px** |
| note の `margin-inline` = 160.5 - 187.5 | **-27px**（左右とも） |
| note の幅 = 321 + 54 | 375px（＝ちょうど 100vw） |

切り取られるのは外に出た左右27pxです。絵柄は note の左から12pxの位置にあるので**まるごと消え**、右端も15px分の文字が落ちます。PC で出ないのは、この帯を伸ばす指定が `@media (max-width: 767px)` の中だけにあるためです。

## 直し方

帯を伸ばすのを **`.article-entry` の直下にある note だけ**に限りました。入れ子の中では囲みのままにし、角丸も残します。

```styl
/* 構えと絵柄の位置は入れ子でも同じ */
.article-entry .note-container { display: block; padding-left: 12px; padding-right: 12px; position: relative; }
/* 端まで伸ばすのは直下だけ */
.article-entry > .note-container { margin-inline: calc(50% - 50vw); border-radius: 0; }
```

`display: block` と絵柄の左上配置は共通指定に残したので、**入れ子でもモバイルの見え方は揃います**（2列に戻って本文が狭くなる #2521 の状態には戻りません）。

## 影響範囲

生成物の全記事を HTML パーサで辿り、各 note の親要素を数えました。

| note の位置 | 件数 | この PR での変化 |
| --- | ---: | --- |
| `.article-entry` の直下 | **227件** | なし |
| `<details>` の中 | **1件**（20260615a） | 切れなくなる |

`<blockquote>` / `<li>` / `<td>` の中にある note は現時点で0件ですが、同じ理由で将来も壊れません（直下でなければ帯を伸ばさないため）。

## 確認

- CSS の生成結果に2つの規則が意図どおり出ていること（`.article-entry .note-container` に `margin-inline` が無く、`.article-entry > .note-container` にあること）
- 全記事のパースで直下227件・入れ子1件と数えたこと
- CSS だけの変更なので `make css` で確認（`hexo generate` は不要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
