### PR TITLE
main への直接 push をフックで止める

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git *)",
+            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); echo \"$cmd\" | grep -Eq 'git( +-[^ ]+)* +push' || exit 0; br=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if echo \"$cmd\" | grep -Eq 'push[^;&|]*(origin +(main|master)( |$)|:(main|master)( |$))' || [ \"$br\" = main ] || [ \"$br\" = master ]; then printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"main へ直接 push しない。作業ブランチを切って PR を出す。意図的に main を触るとき（revert 等）は .claude/settings.json のこのフックを一時的に外す。現在のブランチ: '\"$br\"'\"}}'; fi",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
#2559 の作業で、**ブランチを切る前にコミットしてしまい、そのまま main へ push して PR を飛ばしました**（`e15a44ab` / `399ef30f`。main は `322b0aed` で revert 済み、作業は #2588 で出し直し）。手順書に書くだけでは同じことが起きるので、仕組みで止めます。

## 中身

`.claude/settings.json`（プロジェクト設定、コミット対象）に PreToolUse フックを1つ追加します。`git push` を見て、次のいずれかなら**拒否**します。

- 現在のブランチが `main` / `master`
- コマンドが `origin main` / `HEAD:main` のように main を明示している

`"if": "Bash(git *)"` を付けているので、git 以外の Bash では起動しません。

## 動作確認

`jq` でスキーマを検証したうえで、フックが受け取る JSON を実際に流して確かめました。

| 状況 | コマンド | 結果 |
| --- | --- | --- |
| **main で引数なし push**（今回の事故） | `git push` | **拒否** |
| main を明示 | `git push origin main` | **拒否** |
| refspec で明示 | `git push origin HEAD:main` | **拒否** |
| 作業ブランチで引数なし push | `git push` | 許可 |
| 作業ブランチで upstream 設定 | `git push -u origin <branch>` | 許可 |
| push 以外の git | `git status` | 許可 |
| credential helper 付き | `git -c credential.helper=x push origin feature` | 許可 |

拒否時は現在のブランチ名を添えたメッセージを返します。

## 外し方

意図的に main を触るとき（今回の revert のような場合）は、このフックを一時的に外します。理由が説明できるときだけ外す、という運用の想定です。`/hooks` からも確認・無効化できます。

なお `.claude/settings.local.json` は gitignore 済みで、こちらは各自の permissions が入っています。今回の追加は**チーム共有の設定**なので `settings.json` 側に置きました。他の設定は含めていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)