### PR TITLE
短いページでフッターが浮くのを直す (#2590)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2,6 +2,30 @@
 @import "_variables"
 @import "highlight"
 
+/* 短いページでフッターが画面の中ほどに浮くのを防ぐ (#2590)。
+
+   .wrap（ヘッダー＋本文＋フッターの外枠）を縦のフレックスにして、
+   フッターだけ auto マージンで下へ寄せる。ページが画面より高ければ
+   これまでどおり本文のあとに続く。
+
+   露出したのは /specials/ を作ってから。中身が h1 と段落とリンク3本しか
+   無く、サイトで最も短いページになった。それまではサイドバーの
+   カテゴリ一覧（18件）がどのページでも高さを作っていた。
+
+   フッターの後ろにあるのは GA の <script> だけ（display: none）なので、
+   auto マージンの余りはフッターの上に入る */
+.wrap {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  /* モバイルの 100vh はアドレスバーを含む高さなので、短いページで
+     わずかにスクロールが出る。対応ブラウザでは表示領域ぶんに直す */
+  min-height: 100dvh;
+}
+.wrap > footer {
+  margin-top: auto;
+}
+
 /* Paginator styles */
 .pagination > a,
 .pagination > span {


### PR DESCRIPTION
Close #2590

## 原因

サイトに**フッターを下端へ寄せる仕組みが無い**のが原因でした。`.wrap`（ヘッダー＋本文＋フッターの外枠）は素のブロックで `min-height` も持たないため、本文が短いページではフッターが本文のすぐ後ろに来て、そこから下が空白になります。

`/specials/` の本文は h1 と段落1つとリンク3本だけで、**サイトで最も短いページ**です。それまではサイドバーのカテゴリ一覧（18件）がどのページでも高さを作っていたので表に出ていませんでしたが、#2559 で `/specials/` 配下のサイドバーからカテゴリ一覧を外したことで露出しました。404 ページも同じ条件です。

## 直し方

```styl
.wrap {
  display: flex;
  flex-direction: column;
  min-height: 100vh;
  min-height: 100dvh;
}
.wrap > footer {
  margin-top: auto;
}
```

- ページが画面より高ければこれまでどおり本文のあとにフッターが続きます
- フッターの後ろにあるのは GA の `<script>` だけ（`display: none`）なので、auto マージンの余りはフッターの上に入ります
- `100dvh` を重ねているのは、モバイルの `100vh` がアドレスバーを含む高さで、短いページでわずかにスクロールが出るためです

CSS だけの変更で、HTML もテンプレートも触っていません。

## 確認

- 全2,840ページ（alias リダイレクト72件を除く）で、最後の `</footer>` の後ろが `</div></body></html>` だけであることを機械確認しました。つまり `footer` はどのページでも `.wrap` の直下・最後の可視要素で、`margin-top: auto` が効く形になっています
- `.container` の中央寄せは維持されます（`width: 100%` ＋ `max-width` ＋ 左右 `auto` マージンで、フレックスアイテムでも auto マージンが余白を吸って中央に来ます）
- `make css` で生成を確認（`hexo generate` は不要）

**見た目の最終確認はお願いします。** この環境ではブラウザが動かず、レンダリング結果を私が目で確かめられません。特に `/specials/` と 404、それと画面より高い通常の記事ページで、フッターの位置が意図どおりか見てください。

## 補足：#2589 のフックが効きました

この修正のコミット時、`git checkout -b` と `git push` を1つのコマンドに繋いだところ、**フックが評価した時点のブランチが main だったため拒否**されました。想定どおりの動作ですが、ブランチ作成と push を同じ Bash 呼び出しに繋ぐと止まる、という運用上の注意点です（分けて実行すれば通ります）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)