### PR TITLE
ホームと他ページでヘッダーの高さが違うのを直す (#2585)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -455,9 +455,19 @@ body.page-header-fixed .header {
    Avenir Next（macOS/iOS の幾何学グロテスク）と Segoe UI Variable Display
    （Win11 の見出し用）を優先し、無い環境は従来のシステムスタックに落ちる。
    サイト名は固定の英字なので絵文字フォントは要らない */
+/* サイト名。ホームでは h1、それ以外のページでは div で出している
+   （ホームではここがページの見出しそのものなので）。見た目は同じにしたい。
+
+   line-height を書いていなかったため、ホームは Bootstrap の
+   h1〜h6（1.2）が効き、それ以外のページは body から継いだ normal で
+   出ていた。normal はフォント依存（Avenir Next は約1.36）なので、
+   ヘッダーの高さがホームと他ページで違い、しかも環境によって差が変わる。
+   大きな見出しなので詰まった 1.2 を明示して両方揃える (#2585)。
+   letter-spacing を詰めているのと同じ理由 */
 .header-title {
   margin: 1px 0 0;
   font-size: 80px;
+  line-height: 1.2;
   font-family: "Avenir Next", "Segoe UI Variable Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
   font-weight: 800;
   /* 大型の見出しは字間を詰めると締まる */


### PR DESCRIPTION
Close #2585

## 原因

サイト名は**ホームでは `h1`、それ以外のページでは `div`** で出しています（ホームではここがページの見出しそのものなので）。

```ejs
<% if (is_home()) { %>
<h1 class="header-title"><a href="/">Future Tech Blog</a></h1>
<% } else { %>
<div class="header-title"><a href="/">Future Tech Blog</a></div>
<% } %>
```

`.header-title` に `line-height` の指定が無いため、**要素の違いがそのまま行の高さの違いになっていました**。

- ホーム（`h1`）… Bootstrap の `h1〜h6 { line-height: 1.2 }` が効く
- それ以外（`div`）… `body` から継いだ `normal`

`normal` はフォント依存です。`.header-title` の書体は Avenir Next / Segoe UI Variable Display で、Avenir Next の `normal` は約 1.36。**差の量が環境によって変わる**という厄介さもありました。

| 幅 | font-size | 変更前 ホーム | 変更前 その他 | 変更後（両方） |
| --- | ---: | ---: | ---: | ---: |
| 1205px 以上 | 80px | 96.0px | 108.8px | 96.0px |
| 559〜1204px | 65px | 78.0px | 88.4px | 78.0px |
| 558px 以下 | 36px | 43.2px | 49.0px | 43.2px |

（その他の値は Avenir Next の `normal` を 1.36 として計算したものです）

## 直し方

`.header-title` に `line-height: 1.2` を明示しました。1行だけの変更です。

**1.2（詰まった側）に寄せた理由**は2つです。

- 大きな見出しなので詰まった行送りが合う。同じ理由で `letter-spacing: -0.02em` を入れている
- ホームの見え方が変わらず、他のページがホームに揃う。ホームはバナーが主役のページで、この見た目に合わせて調整されてきた

`line-height` を書かずブラウザとフォントの既定に任せると実効値が追えなくなる、というのは `.lede` でも同じ理由でコメント付きで明示されています。CLAUDE.md の「ブラウザ既定のサイズに頼らない」にも沿います。

## 確認

- 生成物で、ホームだけ `<h1 class="header-title">`、記事・タグ一覧・特設は `<div class="header-title">` であることを確認（マークアップは変えていません。ホームの h1 は見出しとして必要なので残します）
- `site.css` で `.header-title` が `line-height: 1.2` を持つこと
- CSS だけの変更なので `make css` で確認（`hexo generate` は不要）

**見た目の最終確認はお願いします。** この環境ではブラウザが動かないため、レンダリング結果を私が目で確かめられません。ホームと記事ページを行き来して、ヘッダーの高さが変わらないか見てください。

## 触っていないもの

`.header-title-sub`（「フューチャー技術ブログ」）も `line-height` を持たず `normal` に依存していますが、こちらは全ページ `div` なので**ページ間の差は生みません**。ヘッダー全体の高さがフォントによって多少変わる点は残ります。揃えるべきなら別途どうぞ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)