### PR TITLE
JDK23 タグを Java23 に改名し、Java24 / Java25 を付ける

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -146,6 +146,7 @@ alias:
   tags/GCP/: tags/GoogleCloud/
   tags/画像認識/: tags/画像処理/
   tags/icon: categories/アイコン/
+  tags/JDK23/: tags/Java23/ # 版タグの表記を語幹（Java）＋数字に揃えた
 
   # 同義タグの統合
   tags/自然言語処理/: tags/NLP/

--- a/source/_data/tag_ontology.yml
+++ b/source/_data/tag_ontology.yml
@@ -343,5 +343,3 @@ OSS:
 # 名前規則に誤爆する名前（数字込みで別概念）が現れたら notVersion: true で除外する
 Vue3:
   versionOf: Vue.js
-JDK23:
-  versionOf: Java

--- a/source/_posts/2024/20240930a_Java連載2024：_JDK_23リリース記念連載スタートします.md
+++ b/source/_posts/2024/20240930a_Java連載2024：_JDK_23リリース記念連載スタートします.md
@@ -4,7 +4,7 @@ date: 2024/09/30 00:00:00
 postid: a
 tags:
   - Java
-  - JDK23
+  - Java23
   - インデックス
 categories:
   - Programming

--- a/source/_posts/2024/20240930b_JDK_23_リリース記念連載スタートします_＆_JDK_21_新機能紹介.md
+++ b/source/_posts/2024/20240930b_JDK_23_リリース記念連載スタートします_＆_JDK_21_新機能紹介.md
@@ -4,7 +4,7 @@ date: 2024/09/30 00:00:01
 postid: b
 tags:
   - Java
-  - JDK23
+  - Java23
 categories:
   - Programming
 series: "Java23リリース"

--- a/source/_posts/2024/20241001a_JDK_23_リリース記念連載_|_第2回_JDK_22_新機能紹介.md
+++ b/source/_posts/2024/20241001a_JDK_23_リリース記念連載_|_第2回_JDK_22_新機能紹介.md
@@ -4,7 +4,7 @@ date: 2024/10/01 00:00:00
 postid: a
 tags:
   - Java
-  - JDK23
+  - Java23
 categories:
   - Programming
 series: "Java23リリース"

--- a/source/_posts/2024/20241002a_JDK_23_リリース記念連載_|_第3回_JDK_23_新機能紹介.md
+++ b/source/_posts/2024/20241002a_JDK_23_リリース記念連載_|_第3回_JDK_23_新機能紹介.md
@@ -4,7 +4,7 @@ date: 2024/10/02 00:00:00
 postid: a
 tags:
   - Java
-  - JDK23
+  - Java23
   - GC
 categories:
   - Programming

--- a/source/_posts/2025/20250922a_Java25リリース記念ブログ連載.md
+++ b/source/_posts/2025/20250922a_Java25リリース記念ブログ連載.md
@@ -5,6 +5,8 @@ postid: a
 tags:
   - インデックス
   - Java
+  - Java24
+  - Java25
 categories:
   - Programming
 series: "Java25リリース"

--- a/source/_posts/2025/20250924a_Java_24_&_25_連載：_Java_24におけるパフォーマンス周りのアップデート.md
+++ b/source/_posts/2025/20250924a_Java_24_&_25_連載：_Java_24におけるパフォーマンス周りのアップデート.md
@@ -4,6 +4,7 @@ date: 2025/09/24 00:00:00
 postid: a
 tags:
   - Java
+  - Java24
   - JEP
 categories:
   - Programming

--- a/source/_posts/2025/20251002a_Java_24_&_25：_連載_JDK25のアップデート.md
+++ b/source/_posts/2025/20251002a_Java_24_&_25：_連載_JDK25のアップデート.md
@@ -4,6 +4,7 @@ date: 2025/10/02 00:00:00
 postid: a
 tags:
   - Java
+  - Java25
   - JEP
 categories:
   - Programming


### PR DESCRIPTION
## やったこと

版タグの表記を語幹＋数字に揃える名寄せです。

- `JDK23` → `Java23`（2024年の Java23リリース連載 4記事）
- `_config.yml` の `alias` に `tags/JDK23/: tags/Java23/` を追記（旧URLの転送）
- `tag_ontology.yml` の `JDK23: versionOf: Java` を削除（`Java23` は名前規則で語幹 `Java` に繋がるため例外が不要）
- Java25リリース連載（2025年）に版タグが無かったので、記事が扱う版に合わせて付与
  - `20250922a`（索引）: `Java24` `Java25`
  - `20250924a`: `Java24`
  - `20251002a`: `Java25`

## なぜ

- 連載名（`series`）は既に「Java23リリース」「Java25リリース」で、タグ側だけ `JDK23` とズレていた。CLAUDE.md の「バージョン番号はタグの表記に合わせる」に沿える
- 表記が語幹＋数字（`Go1.27` / `PostgreSQL18` と同じ型）になると、`scripts/version_tags.js` の名前規則で自動的に語幹と同義になり、`versionOf` の例外を1つ減らせる
- 版タグが2件以上そろうと、関連タグの系列表示（#2569）が Java 系列でも働く

## 確認

- `node .claude/skills/tag-maintenance/check.mjs` は ERROR なし（exit 0）。バージョン同義に `Java ⇐ Java23、Java24、Java25` が出る
- ローカルビルドで `/tags/Java23/`（4本）・`/tags/Java24/`（2本）・`/tags/Java25/`（2本）が生成され、`/tags/JDK23/` は `/tags/Java23/` へ転送される

textlint は変更した7記事のうち2記事で既存のエラー（本文の句点・アルファベット）が出ますが、
いずれも今回の変更行とは無関係な既存箇所なので触っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
