### PR TITLE
JDK24 のアップデート記事に Java24 タグを付ける

### DIFF
--- a/source/_posts/2025/20250922b_JDK24.md
+++ b/source/_posts/2025/20250922b_JDK24.md
@@ -4,6 +4,7 @@ date: 2025/09/22 00:00:01
 postid: b
 tags:
   - Java
+  - Java24
   - JEP
 categories:
   - Programming


### PR DESCRIPTION
## やったこと

`20250922b`（「Java25リリース連載：JDK24のアップデート」）に `Java24` タグを追加しました。
Java25リリース連載4記事のうち、この記事だけ版タグが無い状態でした（#2595 で他3記事に付与済み）。

## 確認

- ローカルビルドで `/tags/Java24/` が3本（`20250922a` / `20250922b` / `20250924a`）になる
- `node .claude/skills/tag-maintenance/check.mjs` は ERROR なし（exit 0）
- textlint はこの記事でエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
