### PR TITLE
note タイトルのインラインコードが前後で改行される崩れを直す (#2600)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -3079,9 +3079,15 @@ note-alert-bg = #ffdbdb
 .note-container.note-has-title {
   display: block;
 }
+/* flex にしない (#2600)。フレックスコンテナ直下ではテキストが匿名アイテムに割れ、
+   タイトル内のインラインコードが独立のアイテムになる。幅が足りないと各テキストが
+   自分の狭い幅の中で個別に折り返し、コードの前後で改行された縦割りの表示になる。
+   アイコンを絶対配置にしてテキストを1つのインライン整形文脈に保つ。
+   padding-left はアイコンの幅 18px + 従来の margin-right 0.8em で、
+   折り返した行がアイコンの右端に揃う位置（flex のときと同じ）*/
 .note-title {
-  display: flex;
-  align-items: center;
+  position: relative;
+  padding-left: calc(18px + 0.8em);
   /* 本文（.article-entry p の 1.2em）と同じ大きさ。太字だけで見出しと分かるので、
      サイズは上げない。上げると note が節の見出しのように強く見える */
   font-size: 1.2em;
@@ -3092,8 +3098,13 @@ note-alert-bg = #ffdbdb
 }
 /* 共通指定の 2.1em は「.note-container の 13px × 本文1行分」で決めた値。
    タイトル行は font-size が 1.2em なので、同じ 2.1em だと枠が行より高くなる。
-   タイトルの行ボックス（1.75em）に合わせ直す */
+   タイトルの行ボックス（1.75em）に合わせ直す。top: 0 で1行目に付くので、
+   タイトルが複数行でも絵柄は1行目の中央に乗る（flex の align-items: center は
+   ブロック全体に対して中央で、2行のタイトルでは行間に浮いていた） */
 .note-title .note-icon {
+  position: absolute;
+  top: 0;
+  left: 0;
   height: 1.75em;
 }
 .note-body > :last-child {


### PR DESCRIPTION
close #2600

## やったこと

タイトル付き note（#2490）のタイトルにインラインコードがあると、モバイルでコードの前後が改行されて縦割りになる崩れを直しました。CSS のみの変更で、HTML（`note_container.js` の出力）は触っていません。

## 原因と直し方

`.note-title` が `display: flex` だったため、フレックスコンテナ直下のテキストが匿名フレックスアイテムに割れ、`<code>` が独立のアイテムになっていました。`flex-wrap` は既定の nowrap なので全アイテムが1行に押し込まれ、幅が足りないと**各テキストアイテムが自分の狭い幅の中で個別に折り返す** —— これが「コードの前後で改行」の正体です。

flex はアイコンとテキストの縦位置合わせにしか使っていなかったので、flex をやめてアイコンを絶対配置にし、テキストを1つのインライン整形文脈に保ちました。

```styl
.note-title {
  position: relative;
  padding-left: calc(18px + 0.8em);  /* アイコン幅 18px + 従来の margin-right 0.8em */
  ...
}
.note-title .note-icon {
  position: absolute;
  top: 0;
  left: 0;
  height: 1.75em;
}
```

- **字下げの幅は flex のときと同一**（18px + 0.8em = 30.5px）。折り返した行がアイコンの右端に揃う位置も変わりません
- 1行のタイトルでは絵柄の位置は完全に同じ（アイコン枠 1.75em = 行ボックス 1.75em で、center も top:0 も同値）
- **複数行のタイトルでは絵柄が1行目の中央に乗るようになります。** flex の `align-items: center` はブロック全体に対する中央だったので、2行のタイトルでは絵柄が行間に浮いていました。副作用ではなく改善です
- タイトル無しの note（225件）の2列レイアウトと、モバイルの絶対配置アイコン（`.note-container > .note-icon` 直下限定のセレクタ）には影響しません

## 影響範囲

タイトル付き note は29件。うちタイトルにインラインコードを含むのは2件（20250325a、20250805a）ですが、崩れの本質は「テキストが割れる」ことなので、コード無しでも長いタイトル＋狭い幅で同じ現象が起きえました。

## 検証

- `make css` して `public/css/site.css` に `position: relative` / `calc(18px + 0.8em)` / 絶対配置のアイコンが出ていることを確認
- `calc()` は Stylus が中身を評価せずそのまま通すことを生成 CSS で確認（`clamp()` と違い unquote 不要。既存の `calc(50% - 50vw)` と同じ扱い）
- 生成 HTML は変更なし（20250325a の note マークアップが従来どおりであることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
