### PR TITLE
段落末のバックスラッシュが本文に出ている2件を直す (#2525)

### DIFF
--- a/source/_posts/2023/20230531a_Great_ExpectationsでBigQueryのデータ品質を監視する.md
+++ b/source/_posts/2023/20230531a_Great_ExpectationsでBigQueryのデータ品質を監視する.md
@@ -404,7 +404,7 @@ JSONファイルの直接編集もできますが、複雑なため、Notebook�
 
 ### GCPにおける構成例は？
 
-[公式Docs](https://docs.greatexpectations.io/docs/deployment_patterns/how_to_use_great_expectations_with_google_cloud_platform_and_bigquery)によると、GCPを利用する場合、以下のような構成で動かす一例が挙げられています。\
+[公式Docs](https://docs.greatexpectations.io/docs/deployment_patterns/how_to_use_great_expectations_with_google_cloud_platform_and_bigquery)によると、GCPを利用する場合、以下のような構成で動かす一例が挙げられています。
 
 設定のための初回実行はローカル環境で行い、定期実行する際はCloud Composerを利用します。
 

--- a/source/_posts/2023/20230913a_LLM開発のためにMLOpsチームがやるべきこと.md
+++ b/source/_posts/2023/20230913a_LLM開発のためにMLOpsチームがやるべきこと.md
@@ -168,7 +168,7 @@ AWSやAzure、GCPなどのクラウドサービスでは、「大量なデータ
 
 ### \[2\] Argilla
 
-[Argilla](https://docs.argilla.io/en/latest/)は、RLHF用に「人力で集めるデータの入力・出力の評価」を円滑にするための管理をしてくれるプラットフォームです。\
+[Argilla](https://docs.argilla.io/en/latest/)は、RLHF用に「人力で集めるデータの入力・出力の評価」を円滑にするための管理をしてくれるプラットフォームです。
 
 例えば、人力で集めるデータとは、[こちら](https://huggingface.co/datasets/kunishou/databricks-dolly-15k-ja)にあるような指示文(instruction)、参考情報(input)、理想の回答(output)がセットになったものや、複数のLLMからの出力にランク付けをした結果等です。
 


### PR DESCRIPTION
Close #2525

## やったこと

段落の最終行の `\` を2件削除した。

| ファイル | 行 |
| --- | --- |
| `source/_posts/2023/20230531a_Great_ExpectationsでBigQueryのデータ品質を監視する.md` | 407 |
| `source/_posts/2023/20230913a_LLM開発のためにMLOpsチームがやるべきこと.md` | 171 |

CommonMark では行末 `\` は hard break だが、**段落の最終行**では改行する相手がいないためリテラルの `\` として出力される。

## 走査結果

`source/_posts/**/*.md` 1,449本を、フロントマターとコードフェンス（``` / ~~~ の入れ子も追跡）を除いて走査した。

| | 修正前 | 修正後 |
| --- | ---: | ---: |
| 行末が `\` の行（フェンス外） | 53 | 51 |
| うち段落末（＝リテラル出力） | **2** | **0** |

残る51行はいずれも段落の途中で、改行として正しく機能しているので触っていない。

## 検証

`hexo.post.render` に実際のパイプライン（`scripts/` のフィルタ込み）を通して、修正前後の HTML を比較した。

```
# 修正前
<p>…以下のような構成で動かす一例が挙げられています。\</p>   → 1件
<p>…管理をしてくれるプラットフォームです。\</p>              → 1件

# 修正後
両ファイルとも 0件
```

textlint も2ファイルとも指摘なし（exit 0）。

## `/doctor/` に入れるかの判断 → 入れない

issue の2つ目のチェックボックス。**検出対象にしない**と判断した。

- 誤検知ゼロで機械判定できる欠陥ではあるが、1,449記事・7年ぶんで該当が2件しか出ていない
- `/doctor/` は既に13セクションあり、いずれもメタデータ（タグ・カテゴリ・著者・EJS の外部リンク）の検査。**記事本文を走査するチェックは1つも無い**ため、この1件のために本文走査の仕組みを新設することになる
- 常に0件のセクションが1つ増えるだけになり、運営が見るべき候補が薄まる

再発したら改めて入れることにして、今回は2件の修正で打ち止めにする。

## この PR の範囲外

Markdown 記法が意図と違って描画される他の類型（#2517 のキャプション等）には触っていない。