### PR TITLE
関連タグ：詳しく見る群の版タグをバージョン降順で並べる (#2601)

### DIFF
--- a/scripts/related_tags.js
+++ b/scripts/related_tags.js
@@ -126,6 +126,16 @@ function byName(a, b) {
   return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
 }
 
+// versionOf で束ねたタグは名前に数字が無いこともある。順序を決められないので先頭
+function withVersion(r) {
+  return { ...r, version: VERSIONED.test(r.name) ? versionKey(r.name) : Infinity };
+}
+
+// 新しいバージョンを先に
+function byVersionDesc(a, b) {
+  return b.version - a.version || byName(a, b);
+}
+
 // site.tags は毎回同じなので、共起の集計は一度だけ行って使い回す
 let cache = null;
 
@@ -219,9 +229,8 @@ hexo.extend.helper.register('related_tags', function (tagName) {
   const versions = (stem === tagName ? [] : relatives)
     .filter((name) => name !== stem)
     .map(member)
-    // versionOf で束ねたタグは名前に数字が無いこともある。順序を決められないので先頭
-    .map((r) => ({ ...r, version: VERSIONED.test(r.name) ? versionKey(r.name) : Infinity }))
-    .sort((a, b) => b.version - a.version); // 新しいバージョンを先に
+    .map(withVersion)
+    .sort(byVersionDesc);
 
   // 移動先に新しい記事が1本しか無い相手を出すかどうか。1ページに収まるタグでは
   // スクロールすれば全部見えるので、読者が求めるのは新しい記事に出会えるタグの方。
@@ -249,7 +258,13 @@ hexo.extend.helper.register('related_tags', function (tagName) {
           .sort((a, b) => b.posts - a.posts || byName(a, b))
           .slice(0, MAX_NARROWING_TAGS)
       : [];
-  const detail = narrowing.concat(children).sort((a, b) => b.posts - a.posts || byName(a, b));
+  // 版の子はバージョン降順で先、共起由来の絞り込みは記事数降順で後に置く (#2601)。
+  // 版どうしの記事数の差は「その年の連載が何本だったか」でしかなく、読者が探す
+  // 順序とは関係が無い。記事数で1本に並べると最新版が末尾に沈み（インターン2026 が
+  // 1本で最後）、共起の相手と交互に混ざって版の列として流し読みできない。
+  // 版をひとかたまりにすると「別の版へ」群と同じ規則になり、同じ関係がページに
+  // よって並び順を変えることも無くなる
+  const detail = children.map(withVersion).sort(byVersionDesc).concat(narrowing);
 
   const score = (r) => r.co * Math.log(1 + r.lift);
   const adjacent = candidates


### PR DESCRIPTION
issue #2601。論点の **1（版の子をバージョン降順で先、続けて共起の絞り込みを記事数降順）** で実装しました。

## 変更

`scripts/related_tags.js` の detail 群の組み立て1行と、`versions` 群と共通化した2関数。

```js
- const detail = narrowing.concat(children).sort((a, b) => b.posts - a.posts || byName(a, b));
+ const detail = children.map(withVersion).sort(byVersionDesc).concat(narrowing);
```

`withVersion` / `byVersionDesc` は `versions` 群がインラインで持っていた処理をそのまま切り出したものです。同じ「新しい版が先」の規則を2箇所で持たないようにしています。`byVersionDesc` に名前順の同点処理を足したのは、`versionOf` で束ねたタグ（`version` が `Infinity` になる）が複数出たときに順序が決まらないためです。現状の該当は `Vue3` の1件だけで、いまの出力は変わりません。

## 実データでの前後（全697タグでヘルパーを直接叩いて突き合わせ）

**変わったのは6ページだけ**です。メンバーの増減、および detail 以外の群（隣接 / もっと広い / 他のバージョン / 他の年）の並びは1件も変化していません。

| ページ | before | after |
| --- | --- | --- |
| **Go** | net/http(10) / Go1.22 / Go1.27 / GoCDK / Go1.16 / Go1.18 / Go1.20 / Go1.23 / Go1.17 / … 全24件 | **Go1.27 / Go1.26 / Go1.25 / Go1.24 / Go1.23 / Go1.22 / Go1.21 / Go1.20 / Go1.19 / Go1.18 / Go1.17 / Go1.16** / net/http / GoCDK / GoConference / … |
| **インターン** | インターン2022 / 2020 / 2021 / 2023 / 2024 / Dataflow / IoT / **インターン2026(1本)** | **インターン2026 / 2024 / 2023 / 2022 / 2021 / 2020** / Dataflow / IoTプラットフォーム |
| **Java** | SpringBoot / Java23 / JEP / Java24 / GraalVM / Java25 / Tomcat | **Java25 / Java24 / Java23** / SpringBoot / JEP / GraalVM / Tomcat |
| **NLP** | YANS(4) / NLP2024 / NLP2025 | **NLP2025 / NLP2024** / YANS |
| **Terraform** | tfstate(5) / Terraform1.4 / TerraformCloud / マルチリージョン | **Terraform1.4** / tfstate / TerraformCloud / マルチリージョン |
| **GoogleCloudNext** | 2025 / **2019** / 2024 | 2025 / **2024** / 2019 |

Go の24件が「版12件 → 共起12件」に自然に割れるため、issue の論点3（群を分けてラベルを付ける）は不要と判断しました。群を増やさずに版の列として流し読みできます。

### issue の記載との差分

- **PostgreSQL と Vue.js は変化なし**でした。PostgreSQL は既に 18 → 17 の降順、Vue.js は子が `Vue3` 1件で元から先頭だったためです
- かわりに issue に挙がっていなかった **NLP**（`NLP2025` / `NLP2024` ＋ 共起の `YANS`）が対象でした。語幹ページは7つではなく **8つ**です

## 検証

- 全697タグでヘルパーを before / after 実行し、差分が上記6ページの detail の並びだけであることを確認（メンバー集合の一致もアサート）
- 配信中の HTML（`localhost:4001`）で6ページすべての「もっと詳しいタグで探す」を抽出し、ヘルパーの出力と一致することを確認
- 版ページ（`/tags/Go1-27/`）の「他のバージョン」群が Go1.26 → Go1.16 の降順のままであることを確認
- `npx prettier --check scripts/related_tags.js` 通過

## 範囲外

- 群を分ける案（論点3）は採っていません
- 隣接群の並び（`co × log(1 + lift)`）には触れていません
