### PR TITLE
package-lock.json の重複キーを解消する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,23 +38,17 @@
         "prettier": "^3.9.6",
         "textlint": "^15.2.1",
         "textlint-filter-rule-allowlist": "^4.0.0",
-        "textlint-filter-rule-non-sentence": "file:.textlint/textlint-filter-rule-non-sentence",
         "textlint-filter-rule-comments": "^1.2.2",
         "textlint-filter-rule-legacy-articles": "file:.textlint/textlint-filter-rule-legacy-articles",
         "textlint-filter-rule-non-sentence": "file:.textlint/textlint-filter-rule-non-sentence",
         "textlint-rule-no-brackets-around-code": "file:.textlint/textlint-rule-no-brackets-around-code",
-        "textlint-rule-no-halfwidth-comma-in-japanese": "file:.textlint/textlint-rule-no-halfwidth-comma-in-japanese",
         "textlint-rule-no-glued-html-attributes": "file:.textlint/textlint-rule-no-glued-html-attributes",
+        "textlint-rule-no-halfwidth-comma-in-japanese": "file:.textlint/textlint-rule-no-halfwidth-comma-in-japanese",
         "textlint-rule-no-img-without-dimensions": "file:.textlint/textlint-rule-no-img-without-dimensions",
         "textlint-rule-no-mismatched-code-fence": "file:.textlint/textlint-rule-no-mismatched-code-fence",
         "textlint-rule-preset-ja-technical-writing": "^12.0.2",
         "textlint-rule-prh": "^6.1.0"
       }
-    },
-    ".textlint/textlint-filter-rule-non-sentence": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     ".textlint/textlint-filter-rule-legacy-articles": {
       "version": "1.0.0",
@@ -71,12 +65,12 @@
       "dev": true,
       "license": "MIT"
     },
-    ".textlint/textlint-rule-no-halfwidth-comma-in-japanese": {
+    ".textlint/textlint-rule-no-glued-html-attributes": {
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
     },
-    ".textlint/textlint-rule-no-glued-html-attributes": {
+    ".textlint/textlint-rule-no-halfwidth-comma-in-japanese": {
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
@@ -9465,10 +9459,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/textlint-filter-rule-non-sentence": {
-      "resolved": ".textlint/textlint-filter-rule-non-sentence",
-      "link": true
-    },
     "node_modules/textlint-filter-rule-legacy-articles": {
       "resolved": ".textlint/textlint-filter-rule-legacy-articles",
       "link": true
@@ -9685,12 +9675,12 @@
         "textlint-rule-helper": "^2.1.1"
       }
     },
-    "node_modules/textlint-rule-no-halfwidth-comma-in-japanese": {
-      "resolved": ".textlint/textlint-rule-no-halfwidth-comma-in-japanese",
-      "link": true
-    },
     "node_modules/textlint-rule-no-glued-html-attributes": {
       "resolved": ".textlint/textlint-rule-no-glued-html-attributes",
+      "link": true
+    },
+    "node_modules/textlint-rule-no-halfwidth-comma-in-japanese": {
+      "resolved": ".textlint/textlint-rule-no-halfwidth-comma-in-japanese",
       "link": true
     },
     "node_modules/textlint-rule-no-hankaku-kana": {


### PR DESCRIPTION
ローカルの textlint ルールを足すとき、`npm install` を回さずに `package-lock.json` を
手で編集していたため、**重複キーが3件**入っていました。

```
重複キー: textlint-filter-rule-non-sentence 2
重複キー: .textlint/textlint-filter-rule-non-sentence 2
重複キー: node_modules/textlint-filter-rule-non-sentence 2
```

#2622（`non-sentence` フィルタ）と #2633（`no-halfwidth-comma-in-japanese`）で入れた項目です。
JSON としては後勝ちで読めるため実害は出ていませんが、`npm install` するたびに
差分が出る状態でした。

`npm install` の出力に揃えます。重複が消え、`file:` 依存の並びがアルファベット順になります
（7行追加 / 17行削除）。

## 検証

- `json.loads` に `object_pairs_hook` を渡して重複キーを検査 → **なし**
- `npm install` 後に `git status` がクリーンになることを確認

## 再発防止

ローカルルールを足すときは lock を手で編集せず `npm install` を回す、という手順を
次に触るときに CLAUDE.md へ書きます（この PR では lock だけを直します）。