### PR TITLE
<br> に付いていた loading="lazy" を img へ移す (#2632)

### DIFF
--- a/source/_posts/2019/20191008-openapi.md
+++ b/source/_posts/2019/20191008-openapi.md
@@ -52,7 +52,7 @@ https://stoplight.io/studio/
 
 `Design APIs 10x faster` の謳い文句どおり、Stoplight Studioを使えばGUIで直感的に、高速にAPI仕様を記述できます。
 
-<img src="/images/2019/20191008/photo_20191008_01.png" alt="Stoplight StudioのGUI" width="1000" height="504" loading="lazy" style="border:solid 1px #000000" loading="lazy">
+<img src="/images/2019/20191008/photo_20191008_01.png" alt="Stoplight StudioのGUI" width="1000" height="504" loading="lazy" style="border:solid 1px #000000">
 
 ### 主な特徴
 
@@ -501,7 +501,7 @@ complete: Tests took 44ms
 
 標準的な設計・開発プロセスにご紹介したツールを統合すると次のような形になります。
 
-<img src="/images/2019/20191008/photo_20191008_02.png" alt="ツールの相互利用イメージ" width="960" height="540" loading="lazy" style="border:solid 1px #000000" loading="lazy">
+<img src="/images/2019/20191008/photo_20191008_02.png" alt="ツールの相互利用イメージ" width="960" height="540" loading="lazy" style="border:solid 1px #000000">
 
 みなさんもクライアントサイドとサーバサイドの結合テストにおいてインターフェースの齟齬による苦労をした経験はあるかと思います。
 

--- a/source/_posts/2020/20200708-zuora-2.md
+++ b/source/_posts/2020/20200708-zuora-2.md
@@ -93,7 +93,7 @@ https://www.zuora.com/developer/api-reference/#section/Authentication/OAuth-v2.0
 
 1. **クレデンシャルを発行**: Zuora Central Platform 管理ページよりクレデンシャルを作成します。
    * 1.1. メニューより、「管理者」を選択
-   <img src="/images/2020/20200708/2.png" class="img-small-size" style="border:solid 1px #000000" width="456" height="808"><br loading="lazy">
+   <img src="/images/2020/20200708/2.png" class="img-small-size" style="border:solid 1px #000000" width="456" height="808" loading="lazy"><br>
    * 1.2. 「ユーザーの管理」を選択
    <img src="/images/2020/20200708/3.png" style="border:solid 1px #000000" width="2472" height="986" loading="lazy">
    * 1.3. 「OAuth クライアント」から新規クライアントを作成し、 `client_id` と `client_secret` を保存します。

--- a/source/_posts/2020/20200720_Zuora連載_Vol.4_Workflowの話.md
+++ b/source/_posts/2020/20200720_Zuora連載_Vol.4_Workflowの話.md
@@ -41,16 +41,16 @@ Workflowの概要は[Workflow - Zuora](https://knowledgecenter.zuora.com/Central
 3. Workflow編集画面: Workflowは**Task**と呼ばれる個々の機能を繋げ合わせることで完成する。
 <img src="/images/2020/20200720/workflow_settings3.png" width="900" height="462" loading="lazy">
 4. ▶ボタンがあるTaskが開始Taskとなっている`+`ボタンをクリックすることで後続Taskを追加することができる。<br>
-<img src="/images/2020/20200720/workflow_settings5.png" class="img-small-size" width="386" height="165"><br loading="lazy">
+<img src="/images/2020/20200720/workflow_settings5.png" class="img-small-size" width="386" height="165" loading="lazy"><br>
 5. 開始Task移行のTask
 
 * `🖊`ボタン：Taskの設定・編集
 * `x`ボタン：Taskの削除
 * `+`ボタン：後続Taskを追加<br>
-<img src="/images/2020/20200720/workflow_settings6.png" class="img-small-size" width="401" height="177"><br loading="lazy">
+<img src="/images/2020/20200720/workflow_settings6.png" class="img-small-size" width="401" height="177" loading="lazy"><br>
 
 6. Taskの追加:   各Taskの`+`をクリック後、Task成功時は`On Success`、Taskエラー時は`On Failure`を選択して追加したいTaskを選択する。各Taskの機能については[Workflow - Zuora](https://knowledgecenter.zuora.com/Central_Platform/Workflow)を参照。
-<img src="/images/2020/20200720/workflow_settings7.png" class="img-middle-size" width="738" height="667"><br loading="lazy">
+<img src="/images/2020/20200720/workflow_settings7.png" class="img-middle-size" width="738" height="667" loading="lazy"><br>
 
 ## Workflow設定
 
@@ -138,7 +138,7 @@ https://knowledgecenter.zuora.com/Central_Platform/Workflow/Workflow_tasks/AB_Qu
 Zuoraオブジェクトを選択してデータを取得するTaskです。
 
 * 選択
-<img src="/images/2020/20200720/workflow_task4.png" class="img-middle-size" style="border:solid 1px #000000" width="498" height="254"><br loading="lazy">
+<img src="/images/2020/20200720/workflow_task4.png" class="img-middle-size" style="border:solid 1px #000000" width="498" height="254" loading="lazy"><br>
 <img src="/images/2020/20200720/workflow_task5.png" class="img-middle-size" style="border:solid 1px #000000" width="900" height="455" loading="lazy">
 * ```FIELDS```タブで、選択したオブジェクトで取得したいフィールドを選択<br>
 <img src="/images/2020/20200720/workflow_task6.png" class="img-middle-size" style="border:solid 1px #000000" width="900" height="453" loading="lazy">
@@ -219,7 +219,7 @@ Workflow開発時にデバッグをしたい場合に利用する機能です。
 * Workflow内で扱うパラメータ値。選択したTask時点のパラメータが表示される。
 <img src="/images/2020/20200720/workflow_swimlane4.png" width="782" height="749" loading="lazy">
 * エラーが発生しているTaskは赤い表示<br>
-<img src="/images/2020/20200720/workflow_swimlane5.png" class="img-small-size" style="border:solid 1px #000000" width="221" height="112"><br loading="lazy">
+<img src="/images/2020/20200720/workflow_swimlane5.png" class="img-small-size" style="border:solid 1px #000000" width="221" height="112" loading="lazy"><br>
 * エラーの内容はInfoで確認できる。```Workflow Task Config```や```Instance Config```で設定変更して```Rerun```で、そのTaskから再実行ができる。
 <img src="/images/2020/20200720/workflow_swimlane6.png" style="border:solid 1px #000000" width="800" height="351" loading="lazy">
 * Data QueryやCalloutによるWorkflow内でのAPI実行の結果は、```API Calls```でRequestやResponse内容が確認できる。


### PR DESCRIPTION
close #2632

## やったこと

`loading="lazy"` が `<br>` に付いていた**6箇所**を直し、直前の img に移しました。

```html
- <img src="/images/2020/20200720/workflow_settings5.png" class="img-small-size" width="386" height="165"><br loading="lazy">
+ <img src="/images/2020/20200720/workflow_settings5.png" class="img-small-size" width="386" height="165" loading="lazy"><br>
```

| ファイル | 箇所 |
| --- | --- |
| `source/_posts/2020/20200720_Zuora連載_Vol.4_Workflowの話.md` | 5 |
| `source/_posts/2020/20200708-zuora-2.md` | 1 |

**この6枚は実際に遅延読み込みが効いていませんでした。** `loading="lazy"` を自動で付ける処理は
どこにも無く（`scripts/` で `loading` を触るのは `lcp_image_priority.js` だけで、こちらは
**先頭画像から lazy を外す**方向の処理）、生成 HTML を確認しても img 側に属性が無く
`<br loading="lazy">` がそのまま出ていました。

## 追加で直した2箇所（issue 本文には無い分）

同じ移行の残骸として、**`loading="lazy"` が同じタグに2回書かれた img が2箇所**ありました。
`source/_posts/2019/20191008-openapi.md` の55行目と504行目です。

```html
- <img src="…" alt="Stoplight StudioのGUI" width="1000" height="504" loading="lazy" style="border:solid 1px #000000" loading="lazy">
+ <img src="…" alt="Stoplight StudioのGUI" width="1000" height="504" loading="lazy" style="border:solid 1px #000000">
```

重複した属性は HTML として不正（ブラウザは先頭だけ使う）で、表示上の影響はありません。
`lcp_image_priority.js` のコメントが「同じタグに `loading="lazy"` が2回書かれている記事がある」と
言っているのはこの2箇所のことです。**issue の範囲を少し出ますが、同じ一括置換の事故で
2箇所しかなく、別 issue を立てるより一緒に落とす方が妥当**と判断しました。

## 再発防止は入れていません

issue で「ルールを足すか」を論点にしていましたが、**直して閉じる**方針にしました。
全記事6,039箇所の img と `<br>` を数えた結果、この種の誤付与は上記8箇所で打ち止めで、
**残りは0件**です（`<br>` 等への `loading` 誤付与 0 / 2重指定 0）。
書き手が手で書く型ではなく、一括置換の事故なので、ルールで守り続ける価値は薄いと考えます。

## 検証

- **`<br ...loading` の残り0件、img の `loading` 2重指定も0件**（全11年・6,039箇所を数え直し）
- 触った3ファイルに本番設定の textlint → 指摘0
- `hexo generate` して生成 HTML を確認。6枚とも `<img … loading="lazy"><br>` で出ており、
  `<br loading=` は生成物から消えています
- diff は8行のみ（6 + 2）。変更行はすべて img / `<br>` の行

## 見つけた所見（この PR では触らない）

**2枚目以降の画像で `loading="lazy"` が無いものが41箇所**（14ファイル）あります。
先頭画像で無いものは303箇所ですが、`lcp_image_priority.js` が先頭画像から lazy を外す仕様なので
そちらは正しい状態です。画面外の画像が先読みされるので、直せば表示速度に効きます。
別 issue にします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
