### PR TITLE
角丸を3段（4px / 8px / ピル・円）に統一する

### DIFF
--- a/themes/future/css-src/_variables.styl
+++ b/themes/future/css-src/_variables.styl
@@ -61,7 +61,12 @@ sidebar = hexo-config("sidebar")
 // カードの影と角丸。記事カードとランキングで同じものを使う。
 // 値が散ると片方だけ調整されて素材感がずれるため、ここで1箇所にまとめる
 card-shadow = 0 2px 5px 0 rgba(0,0,0,0.16), 0 2px 10px 0 rgba(0,0,0,0.12)
+// 角丸は3段だけ: 小物（チップ・サムネイル・操作部品）= radius-small、
+// 箱（カード・コードブロック・note・details）= card-radius、
+// ピル = 999px・円 = 50%。中間の段（3/5/6/10px）は置かない。
+// 段が増えると「どれを使うか」の判断ができなくなる（ink の3段と同じ理屈 #2534）
 card-radius = 8px
+radius-small = 4px
 
 // Layout
 block-margin = 50px

--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -35,8 +35,8 @@ $code-block
   padding: 15px article-padding
   // 角丸はここで持つ。以前は .highlight table だけに付いていたため、
   // 言語指定の無いコードブロック（figure を作らない素の pre）だけ角が立っていた (#2456)。
-  // 値は Astro（Expressive Code）の --ec-brdRad: 0.375rem に合わせた
-  border-radius: 6px
+  // 値はサイトの角丸3段のうち「箱」の段（_variables.styl の card-radius）
+  border-radius: card-radius
   // 枠線は持たない。Astro（Expressive Code）は 1.5px の枠を持つが、
   // あちらはタブバーが全幅でブロックと一体の箱になっているため枠が輪郭として働く。
   // 当サイトはタブを内容幅に縮めているので、枠を入れるとタブと本体の間に
@@ -61,7 +61,7 @@ $line-numbers
   code
     background: surface-mute
     // 角を丸めて、地色の矩形ではなく「札」として読めるようにする (#2456)
-    border-radius: 4px
+    border-radius: radius-small
     // text-shadow: 0 1px #fff を外した。字の下に白い縁が出て輪郭が二重になり、
     // 等幅の細い字ほど滲んで見えていた。#eee 地に #424242 でコントラスト比 8.7 あり、
     // 縁取りで字を起こす必要がない
@@ -113,7 +113,7 @@ $line-numbers
       margin: 0
       padding: 6px article-padding
       background: highlight-caption-background
-      border-radius: 6px 6px 0 0
+      border-radius: card-radius card-radius 0 0
       color: highlight-foreground
       // ファイル名はコードではなくブロックのラベルなので、本文と同じ書体にする。
       // Astro（Expressive Code）も UI と中身で書体を分けている
@@ -368,4 +368,4 @@ pre
         border-radius: 0
       // タブは内容幅のまま。左は画面端に接するので落とし、右上だけ残す
       figcaption
-        border-radius: 0 6px 0 0
+        border-radius: 0 card-radius 0 0

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -31,7 +31,7 @@
 .pagination > span {
   display: inline-block;
   margin-left: 5px;
-  border-radius: 25px !important;
+  border-radius: 999px !important;
   border: none;
   color: #868c93;
   padding: 6px 12px;
@@ -179,7 +179,7 @@ h4 {
   /* 全体指定の details { padding-bottom: 24px } もここで上書きする */
   padding: 0 14px;
   border: 1px solid rule-base;
-  border-radius: 6px;
+  border-radius: card-radius;
   /* 本文の大きさは p / li にしか指定が無く、折りたたみの中身は
      <div>（62件）や <dd>（18件）で書かれることが多い。それらは指定から
      漏れて body の 13px に落ち、本文より小さく出ていた。中身の入れ物が
@@ -352,7 +352,7 @@ blockquote p {
   max-width: 100%;
   height: auto;
   margin: 16px 0px;
-  border-radius: 5px;
+  border-radius: radius-small;
 }
 .blog-item .img-middle-size {
   width: 65%;
@@ -382,7 +382,7 @@ blockquote p {
 }
 .thumb-link img {
   transition-duration: 0.3s;
-  border-radius: 4px;
+  border-radius: radius-small;
   display: block;
   max-width: 100%;
 }
@@ -562,7 +562,7 @@ body.page-header-fixed .header {
 .hiring-card-thumb img {
   width: 88px;
   height: auto;
-  border-radius: 4px;
+  border-radius: radius-small;
 }
 .hiring-card-body {
   min-width: 0;
@@ -611,7 +611,7 @@ body.page-header-fixed .header {
   width: 88px;
   height: 59px;
   object-fit: cover;
-  border-radius: 4px;
+  border-radius: radius-small;
 }
 /* 特設ページの本文 (#2345)。1.2em は .article-entry 配下にしか効かないので、
    記事本文と同じ実効サイズ（15.6px）をここで明示する。
@@ -741,7 +741,7 @@ ul.social-button li a {
   font: normal normal normal 11px/18px 'Helvetica Neue',Arial,sans-serif;
   position: relative;
   box-sizing: border-box;
-  border-radius: 3px;
+  border-radius: radius-small;
 }
 .social-btn i {
   top: 2px;
@@ -1207,7 +1207,7 @@ code {
   padding-inline-start: 16px;
 }
 .inline-code-color {
-  border-radius: 3px;
+  border-radius: radius-small;
   border: 1px solid rule-base;
   display: inline-block;
   height: .8em;
@@ -1315,7 +1315,7 @@ ul.tag-list {
      しづらかった。面は白に近い2段（#2534）の例外として、コンセプト
      ブックのライトグレーで一段濃くする。文字 ink-mute と 4.82 で AA */
   background-color: var(--brand-gray);
-  border-radius: 14px;
+  border-radius: 999px;
   font-weight: bold;
   font-size: 12px;
   color: ink-mute;
@@ -1337,7 +1337,7 @@ ul.tag-list {
   padding: 2px 8px 1px 8px;
   /* .tag-list-link と同じ地。理由もそちらのコメントを参照 */
   background-color: var(--brand-gray);
-  border-radius: 14px;
+  border-radius: 999px;
   font-size: 12px;
   color: ink-mute;
   line-height: 1.4;
@@ -1386,6 +1386,7 @@ ul.tag-list {
   top: 0;
   bottom: 0;
   width: 4px;
+  /* 幅4pxのバーの端を半円にする値（幅の半分）。箱の角丸の段ではない */
   border-radius: 2px;
   background: rule-base;
 }
@@ -1497,7 +1498,7 @@ ul.tag-list {
   color: ink-strong;
   text-decoration: none;
   line-height: 1.6;
-  border-radius: 3px;
+  border-radius: radius-small;
 }
 .toc-section a:hover, .toc-section a:focus {
   background-color: surface-mute;
@@ -1535,7 +1536,7 @@ ul.tag-list {
   display: block;
   margin-bottom: 20px;
   border: 1px solid rule-base;
-  border-radius: 3px;
+  border-radius: radius-small;
   /* details には全体で padding-bottom: 24px が掛かっている（本文中の折りたたみ
      ブロック向け）。枠で囲む目次では最後の項目の下だけ余白が空くので打ち消す */
   padding-bottom: 0;
@@ -2022,7 +2023,7 @@ ul.tag-list {
   padding: 0 4px;
   background-color: transparent;
   border: 1px solid rule-base;
-  border-radius: 3px;
+  border-radius: radius-small;
   color: ink-mute;
   font-size: 10px;
   font-weight: normal;
@@ -2218,7 +2219,7 @@ a.series-nav-item:hover .series-nav-item-title {
      余白と合わせて、ここで両方とも打ち消す */
   margin: 0;
   object-fit: cover;
-  border-radius: 3px;
+  border-radius: radius-small;
 }
 .post-list-icon-empty {
   background: surface-mute;
@@ -2395,7 +2396,7 @@ a.series-nav-item:hover .series-nav-item-title {
   max-width: 400px;
   padding: 18px 22px;
   border: 1px solid #e8dcb0;
-  border-radius: 10px;
+  border-radius: card-radius;
   /* 淡い金のグラデーション。単色より奥行きが出て、賞状の紙の質感に寄る */
   background: linear-gradient(135deg, #fdf9ec, #f7edcf);
   box-shadow: 0 2px 10px rgba(122,95,22,0.12);
@@ -2748,7 +2749,7 @@ input[name="tab_item"] {
   box-sizing: border-box;
   background-color: transparent;
   border: 1px solid rule-base;
-  border-radius: 3px;
+  border-radius: radius-small;
   font-weight: normal;
   font-size: 10px;
   line-height: 1.6;
@@ -2770,7 +2771,7 @@ input[name="tab_item"] {
   padding: 6px 12px;
   font-size: 16px; /* 16px 未満だと iOS がフォーカス時に画面をズームする */
   border: 0;
-  border-radius: 6px 0 0 6px;
+  border-radius: radius-small 0 0 radius-small;
   background: rgba(255,255,255,0.92);
 }
 .header-search button {
@@ -2783,7 +2784,7 @@ input[name="tab_item"] {
   font-size: 16px; /* アイコン（.svg-icon = 1em）の実寸を決める */
   color: ink-strong;
   background: rgba(255,255,255,0.92);
-  border-radius: 0 6px 6px 0;
+  border-radius: 0 radius-small radius-small 0;
 }
 .header-search button .svg-icon {
   margin-right: 0;
@@ -2938,7 +2939,7 @@ input[name="tab_item"] {
   width: 88px;
   height: 59px;
   background: surface-mute;
-  border-radius: 4px;
+  border-radius: radius-small;
 }
 
 /* カテゴリページの見出し行（#2294）。RSS購読アイコンを見出しの右端に置く */
@@ -3040,7 +3041,7 @@ note-alert-bg = #ffdbdb
   align-items: flex-start; /* アイコンとテキストを上揃えにする */
   padding: 16px 20px;
   margin: 24px 0;
-  border-radius: 5px;
+  border-radius: card-radius;
 }
 .note-container > div > :last-child {
   margin-bottom: 0;
@@ -3330,7 +3331,7 @@ note-alert-bg = #ffdbdb
   width: 16px;
   height: 16px;
   margin-right: 6px;
-  border-radius: 2px;
+  border-radius: radius-small;
 }
 
 .link-preview-card-image {

--- a/themes/future/metronic-src/assets/style.css
+++ b/themes/future/metronic-src/assets/style.css
@@ -201,7 +201,7 @@ Header and header elements
 .pagination > li > a, .pagination > li > span,
 .pagination > li:first-child > a, .pagination > li:first-child > span,
 .pagination > li:last-child > a, .pagination > li:last-child > span {
-	border-radius: 25px !important;
+	border-radius: 999px !important;
 	border: none;
 	color: #868c93;
 }
@@ -453,7 +453,7 @@ aside h2 {
 .featured-post,
 .related-post {
   padding: 20px 0px 0px 10px;
-  border-radius: 0.5rem;
+  border-radius: 8px; /* theme の card-radius と同値。素の CSS なので直書き */
 }
 .featured-post h2,
 .related-post h2{


### PR DESCRIPTION
トンマナ整理の続き（#2651 / #2658 の次）。「角丸は残すが中間の段を減らす」の実装。

## 現状の問題

角丸の値が10種（2 / 3 / 4 / 5 / 6 / 8 / 10 / 14 / 25px / 0.5rem）混在しており、新しい部品を作るとき「どれを使うか」を判断できない。ink の3段（#2534）と同じ整理を角丸にも入れる。

## 新しい体系（`_variables.styl` に定義とコメント）

| 段 | 値 | 対象 |
| --- | --- | --- |
| 小物 | `radius-small` = 4px | チップ（NEW札・連載キッカー）・サムネイル各種・記事内画像・目次・SNSボタン・検索ボックス・favicon |
| 箱 | `card-radius` = 8px | カード・コードブロック（＋キャプションのタブ）・note・details・殿堂カード |
| ピル / 円 | 999px / 50% | タグチップ・ページャー・アワード各種 / ランキングの順位円 |

- タグチップ（14px→999px）とページャー（25px→999px）は**見た目の変化なし**（高さの半分を既に超えているため）。表記だけの統一
- 例外はブロック引用の縦バーの 2px のみ（幅4pxのバーの端の半円で、箱の角丸ではない。コメントで明記）
- bootstrap-subset 内の `.card`（0.25rem）と `kbd`（0.2rem）はベンダー由来のまま（それぞれ 4px 相当・使用箇所ほぼ無し）

## 見た目が変わる箇所（いずれも 1〜4px の微差）

- コードブロック・note・details・殿堂カード: 5〜10px → 8px
- 目次・SNSボタン・チップ類: 3px → 4px
- 記事内画像・サムネイル: 3〜5px → 4px
- 検索ボックス: 6px → 4px

## 確認ポイント

- 記事ページ: コードブロック（ファイル名タブ付き）・note・details・記事内画像
- トップ: カード・タグチップ・ページャー・検索ボックス
- /awards/ の殿堂カード

🤖 Generated with [Claude Code](https://claude.com/claude-code)