### PR TITLE
脚注をコードフェンスの外だけで処理する (#2654)

### DIFF
--- a/scripts/footnotes.js
+++ b/scripts/footnotes.js
@@ -98,10 +98,15 @@ function renderFootnotes(text) {
   return text;
 }
 
-// Hexoフィルターに登録
-hexo.extend.filter.register('before_post_render', function (data) {
-  if (data.layout === 'post' || data.layout === 'page') {
-    data.content = renderFootnotes(data.content);
-  }
-  return data;
-});
+// Hexo 本体の backtick_code_block（優先度10）より先に走らせる。後だとフェンスが
+// <figure class="highlight"> に変わっていて、フェンスの中の見本まで脚注にしてしまう
+hexo.extend.filter.register(
+  'before_post_render',
+  function (data) {
+    if (data.layout === 'post' || data.layout === 'page') {
+      data.content = renderFootnotes(data.content);
+    }
+    return data;
+  },
+  9,
+);

--- a/scripts/footnotes.js
+++ b/scripts/footnotes.js
@@ -6,6 +6,8 @@ var md = require('markdown-it')({
   linkify: true, // URLのようなテキストを自動でリンクに変換
 });
 
+const { replaceOutsideFences } = require('./lib/fence');
+
 /**
  * 記事内の脚注をレンダリングする関数
  * @param {String} text 記事のコンテンツ
@@ -25,20 +27,20 @@ function renderFootnotes(text) {
   const reFootnoteIndex = /\[\^([\w-]+)\]/g;
 
   // 1. インライン形式の脚注 [^name](content) を処理
-  text = text.replace(reInlineFootnote, function (match, name, content) {
+  text = replaceOutsideFences(text, reInlineFootnote, function (match, name, content) {
     footnotesByName[name] = { content: content.trim() };
     return '[^' + name + ']'; // 本文からは内容を削除し、参照のみ残す
   });
 
   // 2. 脚注の定義部分 [^name]: content を処理
-  text = text.replace(reFootnoteContent, function (match, name, content) {
+  text = replaceOutsideFences(text, reFootnoteContent, function (match, name, content) {
     footnotesByName[name] = { content: content.trim() };
     return ''; // 本文から脚注定義を削除
   });
 
   // 3. 本文中の脚注参照をスキャンし、出現順のリストを作成
   const seen = {};
-  text.replace(reFootnoteIndex, function (match, name) {
+  replaceOutsideFences(text, reFootnoteIndex, function (match, name) {
     // 未処理かつ定義が存在する脚注のみをリストに追加
     if (!seen[name] && footnotesByName[name]) {
       orderedFootnotes.push({
@@ -56,7 +58,7 @@ function renderFootnotes(text) {
   }
 
   // 4. 本文中の脚注参照 [^name] をHTMLタグに置換
-  text = text.replace(reFootnoteIndex, function (match, name) {
+  text = replaceOutsideFences(text, reFootnoteIndex, function (match, name) {
     let index = -1;
     for (let i = 0; i < orderedFootnotes.length; i++) {
       if (orderedFootnotes[i].name === name) {


### PR DESCRIPTION
`#2654`

## 症状

記法ガイド `/specials/markdown/` の「脚注」の見本が、コードブロックとして出るはずのところですでにレンダリングされていた。

`scripts/footnotes.js` は `before_post_render` で生の Markdown に正規表現を当てるだけで、コードフェンスを見ていない。見本の ```` ```markdown ```` フェンスの中にある定義行 `[^1]: 脚注の中身です。…` が削除され、残った `[^1]` が上付きの脚注リンクに置き換わっていた。結果、見本が

- 1行だけ（`本文の途中に脚注を置けます[^1]。`）
- しかも `[^1]` がリンク

になり、**脚注の書き方が読み取れない**状態だった。

## 直し方

`scripts/lib/fence.js` の `replaceOutsideFences` を通す。#2549 でまさにこの問題のために用意した部品で、独自記法のフィルタ5本（`csv_column_highlight` / `diff_language_highlight` / `mermaid` / `figure_caption` / `note_container`）は既に使っており、footnotes.js だけが使っていなかった。

当てている正規表現3本すべてを対象にした。

| 正規表現 | 役割 |
| --- | --- |
| `reInlineFootnote` | インライン形式 `[^name](content)` |
| `reFootnoteContent` | 定義行 `[^name]: content` |
| `reFootnoteIndex` | 参照 `[^name]`（出現順のスキャンと HTML 置換の2箇所） |

参照のスキャン（出現順リストの作成）も外した。フェンスの中の参照を数えると、同じ脚注が本文より先にフェンスに出てくる記事で番号の順序が本文の並びとズレる。

記法ガイドだけを回避する手（見本を全角にする、HTML エスケープする）は採らなかった。ガイドの見本が実物と違う書き方になるうえ、脚注の書き方を説明する記事を書いたら同じことが起きる。

## 検証

`replaceOutsideFences` はフェンスの範囲を呼び出しごとに計算し直すので、定義行を削除して長さが変わった後の参照置換でも範囲がズレない。

- **全記事で before/after を比較**（`source/_posts` + `source/specials` の **1,477件**に旧版と新版の `renderFootnotes` を当てて比較）。差が出たのは `source/specials/markdown/index.md` の1件のみ。既存記事の脚注の出力は変わっていない
- `hexo clean` してからフルビルド（フィルタの変更は `db.json` のキャッシュに阻まれて既存記事に効かない #2517）
- 記法ガイドの生成 HTML で、見本が `<pre><code>` の中に3行そろって出ること・実際の表示例側の脚注リンクと記事末の脚注一覧が従来どおり出ることを確認
- `npx prettier --check "scripts/**/*.js" "*.mjs"` → パス

## 範囲外

`fence.js` は4字下げのコードブロックを見ない（#2549 の判断のまま）。独自記法の正規表現は行頭の空白を許すので、下げる書き方で見本を作ることは元からできない。