### PR TITLE
issue-workflow の検証手順を「1ページの描画結果」中心に書き換える

### DIFF
--- a/.claude/skills/issue-workflow/SKILL.md
+++ b/.claude/skills/issue-workflow/SKILL.md
@@ -44,12 +44,35 @@ gh issue view <n>
 
 ## 4. 検証
 
-| 変えたもの | 回すもの |
-| --- | --- |
-| CSS（`css-src/*.styl`） | `make css`（0.3秒）だけ |
-| `.ejs` / `scripts/` / 記事 | `npx hexo generate`（1分半。`run_in_background` で投げて他の作業を進める） |
-| `scripts/` のフィルタ | `make clean` してから `hexo generate`（`db.json` のキャッシュが効いて既存記事に反映されない） |
+回すものは**変えたもの**ではなく**確かめたいものの範囲**で決める。
+サイトを作り直すのではなく、変わった出力を見る。
 
+| 確かめたいもの | 回すもの |
+| --- | --- |
+| CSS の見え方 | `make css`（0.3秒）だけ |
+| フィルタ・ヘルパーを通した**1ページの描画結果** | `hexo.post.render` を叩くスクリプト（10秒） |
+| 一覧・集計・複数ページにまたがる出力 | `npx hexo generate`（`run_in_background` で投げる） |
+
+- **`hexo generate` は生成物そのものが要るときだけ。** 何も変えていなくても記事1,449本の
+  処理と画像1.2GB のコピーが走る。1ページの描画結果を見たいだけなら 10 秒で済む
+
+  ```js
+  const hexo = new Hexo(process.cwd(), { silent: true });
+  await hexo.init(); // scripts/ と Hexo 本体のフィルタが両方載る
+  const data = { content: src, source: 'specials/markdown/index.md', layout: 'page' };
+  await hexo.post.render(null, data);
+  ```
+
+- **フィルタチェーンを自分で組んで再現しない**（#2654）。`scripts/` の登録だけ集めて
+  優先度順に呼ぶと、Hexo 本体が登録するフィルタ（`backtick_code_block` など）が抜ける。
+  **通ったように見えて実際は直っていない**という最悪の外し方をする。
+  実パイプラインを回すのと手間は変わらないので、必ず `hexo.post.render` を使う
+- **`hexo generate` と `hexo server` を同じ worktree で同時に走らせない**（#2654）。
+  server は終了時に `db.json` を書き戻すので、古いコードで描いた結果が `hexo clean` の
+  後から復活する。**自分の検証を自分で汚す**。並行して走っている server を先に落とす
+- **1ページだけ描き直すなら `db.json` から該当行を落とす。** `hexo clean` は全記事の
+  再描画（数分）を招く。`models.Cache` の `_id`（`source/…`）と `models.Page` /
+  `models.Post` の該当行を消せば、次の起動でそのページだけ再処理される
 - **生成 HTML を機械で確かめる。** `grep` の一致だけで「反映されました」と報告して
   誤報を出したことがある。python で該当セクションを切り出して中身を出す
 


### PR DESCRIPTION
#2654 の作業中に、この skill の検証手順に従って無駄な待ちを2回作ったので直します。コードには触りません（skill のみ）。

## 何が悪かったか

検証の表が「**変えたもの**」で回すものを決めていた。

```
| `.ejs` / `scripts/` / 記事 | `npx hexo generate`（1分半） |
| `scripts/` のフィルタ | `make clean` してから `hexo generate` |
```

`scripts/footnotes.js` を数行直した #2654 で、確かめたいのは **1ページ（`/specials/markdown/`）の描画結果**だけだったのに、この表に従って `hexo clean` + フル生成（記事1,449本の処理 ＋ 画像1.2GB のコピー）に入った。表は「全ページの生成物が要るとき」と「1ページの描画結果を見たいとき」を区別していない。

さらに悪いことが2つ起きた。

1. **フル生成と `hexo server` を同じ worktree で同時に走らせた。** 旧コードを積んだ server が終了時に `db.json` を書き戻し、`hexo clean` の後から古い描画結果が復活して、**修正が効いていないページを自分の検証対象にしてしまった**
2. 待ち時間を避けようとして**フィルタチェーンを自分で組んで再現した。** `scripts/` が登録する `before_post_render` 7本を優先度順に呼んだが、**Hexo 本体が登録する `backtick_code_block` が抜けていた**。手元では「フェンスの中が守られている」と出て、実際のサイトでは直っていない。この誤りのまま「検証完了」と報告した

## 直したこと

- 表の軸を「**確かめたいものの範囲**」に変えた。1ページの描画結果は `hexo.post.render` で **10秒**
- **フィルタチェーンの自作再現を禁じた。** 本体のフィルタが抜けて「通ったように見えて直っていない」になる。実パイプラインを回すのと手間は変わらない
- **`hexo generate` と `hexo server` の同時実行を禁じた。** server の終了時 `db.json` 書き戻しで古い描画結果が復活する
- **1ページだけ描き直す手**を書いた（`db.json` の `models.Cache` / `models.Page` の該当行を落とす）。`hexo clean` の全記事再描画を避けられる

## 範囲外

CLAUDE.md の「コマンド」節にも同じ粗さ（`hexo generate` は必要なときだけ、という一般論しか無い）があります。#2654 で見つけた「フェンスを見る `before_post_render` フィルタは本体の `backtick_code_block` より前＝優先度9で登録する」という規則も CLAUDE.md 側の話なので、この PR には入れていません。