### PR TITLE
モバイルでフッターの円が縮む・貼り付くのを直す (#2667)

### DIFF
--- a/themes/future/layout/_partial/footer.ejs
+++ b/themes/future/layout/_partial/footer.ejs
@@ -5,7 +5,7 @@
   <div class="pre-footer">
     <div class="container">
       <div class="row">
-        <div class="col-lg-4 col-md-4 col-sm-6 col-6 pre-footer-col">
+        <div class="col-lg-4 col-md-4 pre-footer-col">
           <h2>About Us</h2>
           <%# フッターは1文目だけ出す。全文はホームの site-lede（index.ejs）が出す。
               コーポレートURLは説明の続きなので、段落を分けず改行で詰める %>
@@ -47,7 +47,7 @@
             </a>
           </div>
         </div>
-        <div class="col-lg-4 col-md-4 col-sm-4 col-4 pre-footer-col">
+        <div class="col-lg-4 col-md-4 pre-footer-col">
           <h2>Contact</h2>
           <%# margin-bottom-40 は旧レイアウトの名残。列が一番高くなる幅では
               そのままネイビー帯との空白になるので付けない %>
@@ -84,7 +84,7 @@
             ><br />
           </address>
         </div>
-        <div class="col-lg-4 col-md-4 col-sm-4 col-4 pre-footer-col footer-links">
+        <div class="col-lg-4 col-md-4 pre-footer-col footer-links">
           <h2>Links
           </h2>
           <%# title に宣伝文を書かない。全ページ共通の文言はサイト内検索の

--- a/themes/future/layout/_partial/footer.ejs
+++ b/themes/future/layout/_partial/footer.ejs
@@ -137,12 +137,12 @@
   <div class="footer">
     <div class="container">
       <div class="row">
-        <div class="col-md-6 col-sm-6 footer-copyright">
+        <div class="col-md-6 footer-copyright">
           Copyright 2016 - <%= date(new Date(), 'YYYY') %> by Future
           Corporation
         </div>
         <%# 方針・規約類は最下段の帯に置く定石に従い、Links から移した %>
-        <div class="col-md-6 col-sm-6 footer-policy">
+        <div class="col-md-6 footer-policy">
           <a
             class="ext-link"
             href="https://www.future.co.jp/architect/socialmediapolicy/"

--- a/themes/future/metronic-src/assets/style.css
+++ b/themes/future/metronic-src/assets/style.css
@@ -303,8 +303,9 @@ Pre-Footer and pre-footer elements
 	text-decoration: none;
 }
 /* 見出しはPDFの「グレー地の上のネイビーの円」を真円のラベルとして引き継ぐ。
-   径は3列で揃える。列を横に並べるのは md 以上だけで、そこでは内幅 216px 以上が
-   あるため 160px が3つとも通る。max-width は念のための歯止め (#2667) */
+   径は3列で揃える。円にするのは列を横に並べる md 以上だけで、そこでは内幅
+   216px 以上があるため 160px が3つとも通る。md 未満はピルに替える（下の
+   メディアクエリ）。max-width は念のための歯止め (#2667) */
 .pre-footer h2,
 .ecommerce .pre-footer h2 {
 	font-size: 21px;
@@ -339,12 +340,36 @@ Pre-Footer and pre-footer elements
 	/* 見出しが円になり、左寄せだと列の重心が円とずれる。中身ごと中央に揃える */
 	text-align: center;
 }
-/* 列が縦積みになる幅（md 未満）では列の切れ目に余白が無く、次の列の円が
-   前の列のボタンに貼り付いていた。.row の gutter-y は 0、列自身も
-   padding-bottom: 0 なので、積んだときだけここで空ける (#2667) */
+/* md 未満は3列を縦に積むので、見出しは円ではなくピルのラベルにする (#2667)。
+   円は径160pxで1つが1行を占め、3つ積むとフッターだけで約750px になる。
+   「グレー地にネイビーの塗り面」という文法は保ち、形だけ #2659 の角丸3段の
+   うち「ピル」に落とす。文字サイズは円と同じ21pxのまま（1要素のサイズは
+   1箇所で決める）。列の中身も左寄せにして行頭を揃える */
 @media (max-width: 767px) {
+	.pre-footer h2,
+	.ecommerce .pre-footer h2 {
+		display: inline-flex;
+		width: auto;
+		aspect-ratio: auto;
+		padding: 6px 18px;
+		border-radius: 999px;
+		/* 円のときは auto で中央に置いていた。左寄せなので左マージンは 0 */
+		margin: 0 0 12px;
+	}
+	.pre-footer-col {
+		text-align: left;
+	}
+	/* 列の切れ目に余白が無く、次の列のラベルが前の列のボタンに貼り付いていた。
+	   .row の gutter-y は 0、列自身も padding-bottom: 0 なので、
+	   積んだときだけここで空ける */
 	.pre-footer-col + .pre-footer-col {
 		padding-top: 40px;
+	}
+	/* アイコンの行も列の寄せに従う（円のときは中央だった）。.icon-row の
+	   justify-content: center は後ろの theme-styles.styl にあるので、
+	   詳細度で勝つ形（0,2,0）で書いて順序に依存させない */
+	.footer-links .icon-row {
+		justify-content: flex-start;
 	}
 }
 /* footer */

--- a/themes/future/metronic-src/assets/style.css
+++ b/themes/future/metronic-src/assets/style.css
@@ -359,6 +359,15 @@ Pre-Footer and pre-footer elements
 	.pre-footer-col {
 		text-align: left;
 	}
+	/* X フォローと Feedly 購読は width: fit-content のブロックで、中央寄せを
+	   text-align ではなく左右の auto マージンが作っている。列を左寄せにしても
+	   auto は効いたままなので、ここで戻す（margin-top: 8px は残す）。
+	   詳細度は theme-styles.styl 側（0,1,0 と 0,2,0）に勝つ形で書く */
+	.pre-footer .x-btn-follow,
+	.pre-footer .feedly-btn.feedly-btn-follow {
+		margin-left: 0;
+		margin-right: 0;
+	}
 	/* 列の切れ目に余白が無く、次の列のラベルが前の列のボタンに貼り付いていた。
 	   .row の gutter-y は 0、列自身も padding-bottom: 0 なので、
 	   積んだときだけここで空ける */
@@ -425,6 +434,16 @@ Pre-Footer and pre-footer elements
 /* 方針・規約類は最下段の帯に置く定石に従う。コピーライトの右に出す */
 .footer .footer-policy {
 	text-align: right;
+}
+/* md 未満は上段と同じく縦積みになる。右寄せのままだとコピーライトが左端・
+   ポリシーが右端に割れて2行が繋がらないので、上段に合わせて左で揃える。
+   基底の text-align: right と詳細度が同じ (0,2,0) なので、順序で勝つよう
+   この直後に置く (#2667) */
+@media (max-width: 767px) {
+	.footer .footer-policy {
+		text-align: left;
+		margin-top: 6px;
+	}
 }
 .footer .list-inline > li:last-child {
 	padding-right: 0;

--- a/themes/future/metronic-src/assets/style.css
+++ b/themes/future/metronic-src/assets/style.css
@@ -303,8 +303,8 @@ Pre-Footer and pre-footer elements
 	text-decoration: none;
 }
 /* 見出しはPDFの「グレー地の上のネイビーの円」を真円のラベルとして引き継ぐ。
-   径は3列で揃え、幅が足りない列（モバイルの col-4）では max-width で
-   縮めて文字を折り返す。aspect-ratio が幅に追従するので円は保たれる */
+   径は3列で揃える。列を横に並べるのは md 以上だけで、そこでは内幅 216px 以上が
+   あるため 160px が3つとも通る。max-width は念のための歯止め (#2667) */
 .pre-footer h2,
 .ecommerce .pre-footer h2 {
 	font-size: 21px;
@@ -338,6 +338,14 @@ Pre-Footer and pre-footer elements
 	padding-bottom: 0;
 	/* 見出しが円になり、左寄せだと列の重心が円とずれる。中身ごと中央に揃える */
 	text-align: center;
+}
+/* 列が縦積みになる幅（md 未満）では列の切れ目に余白が無く、次の列の円が
+   前の列のボタンに貼り付いていた。.row の gutter-y は 0、列自身も
+   padding-bottom: 0 なので、積んだときだけここで空ける (#2667) */
+@media (max-width: 767px) {
+	.pre-footer-col + .pre-footer-col {
+		padding-top: 40px;
+	}
 }
 /* footer */
 /* フッター全体の外枠。地のグレーはここで1枚持つ。本体の白との境目は


### PR DESCRIPTION
Fixes #2667

## 原因

`footer.ejs` の3列は `col-6`（About Us）/ `col-4`（Contact）/ `col-4`（Links）で、
xs では **6+4+4 = 14 > 12** になり3列目が折り返していた。
円ラベル（`.pre-footer h2`）は `width: 160px; max-width: 100%` なので、
**列の内幅が160pxに足りない列では円がそのまま縮む**。

さらに `.row` の `--bs-gutter-y` は 0、`.pre-footer-col` も `padding-bottom: 0` なので、
折り返した Links の円と About の Feedly ボタンの間に余白が無く接していた。

崩れるのは 768px 未満だけで、md 以上は3列 × 内幅216px で3つとも160pxが通っていた。

## 円の直径（Bootstrap 5 のグリッドから計算）

| 画面幅 | 旧 About | 旧 Contact / Links | 新（3列とも） |
| --- | --- | --- | --- |
| 320px | 136px | **83px** | 160px |
| 360px | 156px | **96px** | 160px |
| 375px | 160px | **101px** | 160px |
| 414px | 160px | **114px** | 160px |
| 576〜767px | 160px | **156px** | 160px |
| 768px 以上 | 160px | 160px | 160px |

## 変更内容

- `footer.ejs`: 3列の `col-sm-*` / `col-*`（xs）を落として `col-lg-4 col-md-4` だけにする。
  **md 未満は `.row > *` の既定（`width: 100%`）で縦積み**になり、折り返しも消える
- `style.css`: 積んだときだけ列間を空ける（`@media (max-width: 767px)` で
  `.pre-footer-col + .pre-footer-col { padding-top: 40px }`）。
  常時付けると md 以上でグレー領域の高さが伸び、#2664 で詰めた配分が崩れるため幅で限定した
- 円の径を縮める案（3列を維持）は採らなかった。About 列は X フォローと Feedly 購読の
  ボタンを持つので、375px で内幅101pxの列に入れると円だけでなくボタンも壊れる

## 検証

- `make css` → 配信中の `/css/site.css` に `@media (max-width: 767px)` の
  `.pre-footer-col + .pre-footer-col` が入っていることを確認
- `hexo server` の配信 HTML をパースし、3列のクラスが
  `col-lg-4 col-md-4 pre-footer-col`（`col-6` / `col-4` は残っていない）になっていることを確認
- 円の径の表は Bootstrap 5 の container / gutter の実値から独立に計算

## 範囲外

ネイビー・クリムゾンの適用範囲（#2651 / #2664 で決めた「塗り面と差し色」）は変えていない。
円の径 160px そのものも据え置き。