### PR TITLE
KVS を NoSQL に寄せ、検索・NoSQL 系のタグを登録する (#2612)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -156,7 +156,7 @@ alias:
   tags/SQLLite/: tags/SQLite/ # 誤記の修正
   tags/OpenCensus/: tags/OpenTelemetry/ # OpenCensus は OpenTelemetry に統合された旧規格
   tags/ClaudeCode/: tags/Claude/
-  tags/NoSQL/: tags/Cassandra/
+  tags/KVS/: tags/NoSQL/ # 「RDBでないデータストア」の意味で使っていた語を一般名へ (#2612)
   tags/Grafana-Alloy/: tags/Grafana/ # タグ名「Grafana Alloy」のスラッグ
   tags/Zuora/: tags/サブスクリプション/
   tags/TechBlog/: tags/運営/ # ブログ論一般と当ブログ運営の使い分けを説明できず統合 (#2292)

--- a/source/_data/tag_ontology.yml
+++ b/source/_data/tag_ontology.yml
@@ -186,8 +186,14 @@ DB:
   broader: []
 SQL:
   broader: [DB]
+# 当ブログは KVS を「RDB でないデータストア」の意味で使ってきたので、
+# その6記事をこちらに寄せた (#2612)
 NoSQL:
   broader: [DB]
+Cassandra:
+  broader: [NoSQL]
+Redis:
+  broader: [NoSQL]
 # SQL は言語としての記事群で、PostgreSQL の読者が求めるものとは別（#2292 の議論）
 PostgreSQL:
   broader: [DB]
@@ -206,6 +212,13 @@ uroboroSQL:
   broader: []
 データマネジメント:
   broader: []
+# 検索エンジンの記事も PostgreSQL の全文検索機能の記事も入るので、DB の子にはしない
+全文検索:
+  broader: []
+Elasticsearch:
+  broader: [全文検索]
+OpenSearch:
+  broader: [全文検索]
 
 # --- AI・機械学習 ---
 AI:

--- a/source/_posts/2019/20190718-kvs.md
+++ b/source/_posts/2019/20190718-kvs.md
@@ -4,7 +4,7 @@ date: 2019/07/18 09:11:12
 postid: ''
 tags:
   - データモデル
-  - KVS
+  - NoSQL
   - Cassandra
 categories:
   - DB

--- a/source/_posts/2019/20190821-redis.md
+++ b/source/_posts/2019/20190821-redis.md
@@ -4,7 +4,7 @@ date: 2019/08/21 08:53:57
 postid: ""
 tags:
   - Redis
-  - KVS
+  - NoSQL
   - Java
 categories:
   - DB

--- a/source/_posts/2019/20191113-gocloud3.md
+++ b/source/_posts/2019/20191113-gocloud3.md
@@ -6,7 +6,7 @@ tags:
   - Go
   - GoCDK
   - DynamoDB
-  - KVS
+  - NoSQL
 categories:
   - Programming
 series: "Go Cloud"

--- a/source/_posts/2020/20200703-scalable-rdb.md
+++ b/source/_posts/2020/20200703-scalable-rdb.md
@@ -3,7 +3,7 @@ title: スケーラブルデータベース ～クラウドにおける後悔し
 date: 2020/07/03 10:34:11
 postid: ''
 tags:
-  - KVS
+  - NoSQL
   - 技術選定
   - 要件定義
   - Redshift

--- a/source/_posts/2020/20201005_TiKVに触れる.md
+++ b/source/_posts/2020/20201005_TiKVに触れる.md
@@ -3,7 +3,7 @@ title: "TiKVに触れる"
 date: 2020/10/05 00:00:00
 postid: ""
 tags:
-  - KVS
+  - NoSQL
   - CNCF
 categories:
   - DB

--- a/source/_posts/2021/20210412a_KVSと二年間向き合って得たナレッジを還元する時がきた.md
+++ b/source/_posts/2021/20210412a_KVSと二年間向き合って得たナレッジを還元する時がきた.md
@@ -3,7 +3,7 @@ title: KVSと二年間向き合って得たナレッジを還元する時がき�
 date: 2021/04/12 00:00:00
 postid: a
 tags:
-  - KVS
+  - NoSQL
   - Cassandra
   - 排他制御
 categories:


### PR DESCRIPTION
Closes #2612

## issue と逆向きにした

issue は「`NoSQL` を消して `KVS` に寄せる」案でしたが、**逆にしました**。

- `KVS` の6記事の中身は Cassandra（ワイドカラム）2本 / Redis 1本 / Go CloudDocStore（ドキュメント）1本 / TiKV 1本 / DB選定 1本。issue の「決めたいこと」が書くとおり、この語は当ブログでは「RDB でないデータストア」の意味で使われていて、それは **NoSQL の語義そのもの**
- `SQL: [DB]` と `NoSQL: [DB]` が対になる。`KVS` を DB の直下に置くと `SQL` と釣り合わない
- `DynamoDB: [AWS, NoSQL]` を書き換えずに済む（KVS 案では22記事のタグの親を差し替えることになる）

## issue の前提の訂正

issue は「`NoSQL` タグは1記事だけ」と書いていますが、**現在は0記事**です。9日前の 22b5a3e2（ClaudeCode・NoSQL・Grafana Alloy・Zuora のタグを統合する）で3記事から `NoSQL` を外し、`_config.yml` に `tags/NoSQL/: tags/Cassandra/` の転送を入れています。issue の数字はその統合前のものです。

そのため今回は転送を**逆向きに張り替え**ました。`NoSQL` が実体のあるタグページになる以上、Cassandra への転送を残すとタグページが転送に上書きされます。

```diff
-  tags/NoSQL/: tags/Cassandra/
+  tags/KVS/: tags/NoSQL/ # 「RDBでないデータストア」の意味で使っていた語を一般名へ (#2612)
```

## 変更

| | before | after |
| --- | --- | --- |
| 記事のタグ | `KVS` 6記事 | `NoSQL` 6記事（`KVS` は0） |
| `/tags/KVS/` | 実体ページ | `/tags/NoSQL/` へ転送 |
| `/tags/NoSQL/` | `/tags/Cassandra/` へ転送 | 実体ページ（6記事） |

オントロジーに5ノード追加（140 → 145）。タグの総数は697のまま（`KVS` が `NoSQL` に入れ替わっただけ）。

```yaml
NoSQL:      # 既存。broader: [DB] のまま
Cassandra:  { broader: [NoSQL] }   # 3記事
Redis:      { broader: [NoSQL] }   # 4記事
全文検索:    { broader: [] }        # 6記事
Elasticsearch: { broader: [全文検索] }  # 4記事
OpenSearch:    { broader: [全文検索] }  # 3記事
```

`全文検索` を根に置いたのは、6記事のカテゴリが Programming / Infrastructure / DevOps / Cloud / DB に散っていて、`DB` の子にすると半分が合わないためです。`OpenSearch`（3記事）は issue に書かれていない範囲ですが、Elasticsearch のフォークで3記事とも全文検索エンジンの話なので、隣を空けずに同時に入れました。

## 検証

- `.claude/skills/tag-maintenance/check.mjs`: **エラー0**（ノード145 / タグ697 / 情報33。情報の件数は変更前と同じ）
- `hexo generate` 後の生成 HTML をパースして確認
  - `/tags/NoSQL/` = 6件（20190718 / 20190821 / 20191113 / 20200703 / 20201005 / 20210412a）、`meta refresh` なしの実体ページ
  - `/tags/KVS/` = `<meta http-equiv="refresh" content="0; url=.../tags/NoSQL/">`
  - Cassandra 3 / Redis 4 / 全文検索 6 / Elasticsearch 4 / OpenSearch 3 / DynamoDB 22 で、フロントマターの直接集計と一致
- 関連記事（`scripts/related_posts.js` の broader 展開）のトークンが変わった記事は **1,473本中14本**。増: `NoSQL` +9 / `DB` +8 / `全文検索` +4、減: `KVS` -6
- 変更した6記事に textlint: 既存の `sentence-length` 2件のみ（今回触っていない本文行）。reviewdog は `-filter-mode=added` で追加行 `- NoSQL` しか見ないためコメントは出ません

## タグページの見え方は変わりません

`related_tags.js` の「もっと広いタグで探す」は、オントロジーの辺に加えて**親が子の記事を全部含む**ことを条件にしています（#2597）。Cassandra 3記事のうち NoSQL タグと共通なのは2本なので上位集合にならず、`/tags/Cassandra/` では従来どおり「隣接するタグを探す」に NoSQL が出ます。今回の辺が効くのは記事下の関連記事と /doctor/ の提案です。

## 範囲外

`tag_ontology.yml` を触る #2611（ライブラリを言語の子にする）/ #2613 は、同じファイルなのでこの PR では扱いません。`Elastic{ON}`（4記事、カンファレンス）と `Kibana`（4記事）も未登録のままです。