### PR TITLE
ライブラリ・フレームワークのタグを言語の子にする (#2611)

### DIFF
--- a/source/_data/tag_ontology.yml
+++ b/source/_data/tag_ontology.yml
@@ -87,14 +87,53 @@ net/netip:
   broader: [Go]
 text/template:
   broader: [Go]
+# context / testing / slog / slices は一般名詞と同じ綴りだが、当ブログでは
+# 全記事が Go の標準ライブラリの話（Go タグの無い1本も Go1.24 連載）(#2611)
+context:
+  broader: [Go]
+testing:
+  broader: [Go, テスト]
 testing/synctest:
   broader: [Go, テスト]
+slog:
+  broader: [Go]
+slices:
+  broader: [Go]
+"go:embed":
+  broader: [Go]
+GoModules:
+  broader: [Go]
+Vet:
+  broader: [Go]
 jackc/pgx:
   broader: [Go, PostgreSQL]
+GORM:
+  broader: [Go, ORM]
+go-chi:
+  broader: [Go]
+GoCDK:
+  broader: [Go]
+go-swagger:
+  broader: [Go, OpenAPI]
+sqlc:
+  broader: [Go, SQL]
 Python:
   broader: []
+pandas:
+  broader: [Python]
+FastAPI:
+  broader: [Python]
+Mypy:
+  broader: [Python]
+Pyright:
+  broader: [Python]
 Java:
   broader: []
+SpringBoot:
+  broader: [Java]
+# Java Enhancement Proposal
+JEP:
+  broader: [Java]
 Rust:
   broader: []
 Dart:
@@ -103,17 +142,33 @@ JavaScript:
   broader: []
 TypeScript:
   broader: [JavaScript]
+Vite:
+  broader: [JavaScript]
 Node.js:
   broader: [JavaScript]
+npm:
+  broader: [Node.js]
 Vue.js:
   broader: [JavaScript]
+Vuetify:
+  broader: [Vue.js]
 React:
   broader: [JavaScript]
+Next.js:
+  broader: [React]
+Redux:
+  broader: [React]
+Recoil:
+  broader: [React]
+サーバーコンポーネント:
+  broader: [React]
 ShellScript:
   broader: []
 # iOS との関係は文脈次第（サーバーサイド Swift 等）。必要なら筆者が iOS タグを直接打つ
 Swift:
   broader: []
+SwiftUI:
+  broader: [Swift]
 Flutter:
   broader: [Dart, モバイル]
 iOS:
@@ -153,8 +208,16 @@ VPC:
   broader: []
 Docker:
   broader: [コンテナ]
+DockerCompose:
+  broader: [Docker]
+Dev Containers:
+  broader: [Docker]
 Kubernetes:
   broader: [コンテナ]
+Minikube:
+  broader: [Kubernetes]
+Istio:
+  broader: [Kubernetes]
 CNCF:
   broader: []
 OS:
@@ -179,6 +242,11 @@ GitHubActions:
   broader: []
 # 災害対策。クラウド固有でも保守運用の包含でもないので根に置く
 DR:
+  broader: []
+# ジョブ実行基盤。DAG は Python で書くが、記事は MWAA / Cloud Composer の運用と
+# ジョブ設計で、Python の群に繋げても読者の次の一歩にならない。バッチ処理タグとも
+# 8本中1本しか重ならないため根に置く (#2611)
+Airflow:
   broader: []
 
 # --- DB・データ ---
@@ -227,6 +295,9 @@ AI:
   broader: []
 機械学習:
   broader: [AI]
+# Python タグとの併記は0だが、6記事すべて機械学習（推薦・画像識別・Kaggle・MLOps）
+TensorFlow:
+  broader: [機械学習]
 生成AI:
   broader: [AI]
 LLM:


### PR DESCRIPTION
Closes #2611

`source/_data/tag_ontology.yml` に **32ノード**を追加します（148 → 180）。**記事のタグは1本も変えていません。**辺を足すだけです。

## issue の「決めたいこと」は実データで片付きました

- **`context` / `testing`**（各7記事）: `Go` タグが無い1本は「Go 1.24リリース連載 testing.Context」で `Go1.24` が付いています。`version_tags.js` がこれを `Go` に寄せるので**実質7/7が Go**。生成後の `/tags/testing/` でも `Go` が「もっと広いタグで探す」（＝親が子の記事を全部含む）側に出ました
- **`Next.js`**（9記事）: React 併記の無い3本は Go 併記の BFF 記事（go:embed / WebAssembly / MDX）。Next.js が React のフレームワークであることは記事によらないので `[React]`。`JavaScript` へは `React → JavaScript` で届きます
- **`TensorFlow`**（6記事）: `Python` 併記は**0**ですが、6本すべて機械学習（Transformer推薦 / TFLite画像識別 / Kaggle 2本 / embedding / MLOps）。`[機械学習]`
- **`Airflow`**（8記事）: **根（`broader: []`）**に置きました。DAG は Python で書きますが、記事は MWAA・Cloud Composer の運用、Step Functions との比較、バッチ設計ガイドラインで、`Python`（60記事）の群に繋げても読者の次の一歩になりません。`バッチ処理`（6記事・未登録）とも8本中1本しか重ならず親になりません。issue 案の `DataEngineering` はカテゴリ名でタグではなく、カテゴリと同名の概念ノードを立てるのはこのファイルに無いパターンなので見送りました

issue の表と件数が違ったものがあります: **GoCDK 8 → 9**、**Airflow 5 → 8**、**pandas の Python 併記 3 → 2**。

## 追加した32件

| 親 | 子 |
| --- | --- |
| `Go` | GoCDK / context / testing（＋`テスト`） / go-swagger（＋`OpenAPI`） / sqlc（＋`SQL`） / GORM（＋`ORM`） / go-chi / go:embed / slog / slices / Vet / GoModules |
| `Java` | SpringBoot / JEP |
| `Python` | pandas / FastAPI / Mypy / Pyright |
| `React` | Next.js / Redux / Recoil / サーバーコンポーネント |
| `JavaScript` / `Node.js` / `Vue.js` | Vite / npm / Vuetify |
| `Swift` | SwiftUI |
| `Docker` / `Kubernetes` | DockerCompose / Dev Containers / Minikube / Istio |
| `機械学習` | TensorFlow |
| 根 `[]` | Airflow |

`context` / `testing` / `slog` / `slices` は既登録の `net/http` / `encoding/json` / `testing/synctest` と同じ Go 標準ライブラリの並びに置きました。`GORM: [Go, ORM]` と `sqlc: [Go, SQL]` は既存の `jackc/pgx: [Go, PostgreSQL]` に形を揃えています。

選んだ基準は **#2292 の「A の記事に B タグを打つのは冗長で打ちたくない」だけで、共起の多さでは選んでいません。** 未登録・3記事以上で言語系タグが半数以上に併記されるタグは125件ありますが、そのほとんどは `エラーハンドリング`（Go 6/7）や `JSON`（Go 5/6）のように、Go の記事が多いから共起しているだけの一般概念です。名前がその言語・基盤を含意するものだけを採りました。

## 範囲外

IDE（GoLand / PyCharm / Xcode）とクラウドサービス（GKE / CloudRun / StepFunctions / Anthos）は入れていません。IDE 系は `check.mjs` が `JetBrains ⊆ GoLand`・`IDE ⊆ GoLand` を統合候補に挙げていて、親子より先に名寄せの議論が要ります。

`tag_ontology.yml` を触る #2613 も同じファイルなのでこの PR では扱いません。

## 検証

- `check.mjs` の出力は**ノード数の行以外1文字も変わりません**（`sort` して diff を取った結果が1行だけ）

  ```console
  < ノード 148 / タグ 698 / エラー 0 / 情報 33
  > ノード 180 / タグ 698 / エラー 0 / 情報 33
  ```

- `hexo generate` 後の生成 HTML をパースし、32件すべてのタグページで関連タグ群を確認。**20件で親が「もっと広いタグで探す」に出ました**（GoCDK / context / testing / SpringBoot / SwiftUI / sqlc / GORM / go-chi / go:embed / slog / slices / Vet / JEP / Mypy / Pyright / FastAPI / Redux / サーバーコンポーネント / Vuetify / Istio）
  - 残り12件（Next.js / go-swagger / DockerCompose / TensorFlow / pandas / GoModules / Recoil / npm / Vite / Dev Containers / Minikube / Airflow）は親が上位集合にならないため従来どおり「隣接するタグを探す」に出ます。`related_tags.js` は辺に加えて「親が子の記事を全部含む」ことを条件にしているためで（#2597）、想定どおりです
- 関連記事（`scripts/related_posts.js` の broader 展開）のトークンが増えた記事は **1,474本中26本**（`コンテナ` +5 / `OpenAPI` +4 / `React` +4 / `JavaScript` +4 / `WebAPI` +3 / `Go` +3 / `Docker` +3 / `機械学習` +3 / `AI` +3 / `Python` +3 / `Node.js` +2 / `Kubernetes` +2 / `SQL`・`ORM`・`DB`・`テスト` 各 +1）。少ないのは、これまで筆者が言語タグを手で打ってきたからで、辺の効き目は主にこれから書く記事に出ます