### PR TITLE
構造化データを JSON-LD に置き換える (#2462)

### DIFF
--- a/scripts/author_profile.js
+++ b/scripts/author_profile.js
@@ -9,6 +9,10 @@ const loadYamlFile = (filename) => {
 
 const profile = loadYamlFile('./_profile.yml');
 
+// JSON-LD 用の生データ (#2462)。get_profile は HTML を組み立てて返すため、
+// 構造化データ側からは値そのものを取れない
+hexo.extend.helper.register('get_profile_data', (authorName) => profile[authorName] || null);
+
 hexo.extend.helper.register('get_profile', (authorName) => {
   const authorProfile = profile[authorName];
   if (!authorProfile) {

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -28,13 +28,10 @@
         サイドバーを持つ他のページ（/tags/ /categories/ /authors/ /specials/）は
         いずれも h1 を本文列の中に置いており、記事ページだけが例外だった。
 
-        <article itemprop="blogPost"> の中には入れない。itemprop="name" は
-        ページ全体の TechArticle（layout.ejs）の性質として読ませたいため。
-
         カテゴリは記事タイトルより重要ではないので、タイトル下のメタ情報の行に置く %>
     <%- partial('post/title', {class_name: 'article-title', post: post, index: false}) %>
     <% } %>
-    <article id="<%= post.layout %>-<%= post.slug %>" class="article article-type-<%= post.layout %> blog-item" itemscope itemprop="blogPost">
+    <article id="<%= post.layout %>-<%= post.slug %>" class="article article-type-<%= post.layout %> blog-item">
       <div class="article-inner">
         <% if (post.link || post.title){ %>
         <header class="article-header">
@@ -77,7 +74,7 @@
         </details>
         <% } %>
         <% } %>
-        <div class="article-entry" itemprop="articleBody">
+        <div class="article-entry">
           <% if (post.excerpt && index){ %>
             <%- post.excerpt %>
             <% if (theme.excerpt_link){ %>

--- a/themes/future/layout/_partial/breadcrumb.ejs
+++ b/themes/future/layout/_partial/breadcrumb.ejs
@@ -11,10 +11,11 @@
  * 末尾がリンクかどうかで「そこにいるか」が分かれる。人にはリンクの有無、
  * 機械には itemprop="item" の有無として同じ違いが伝わる。
  *
- * schema.org は microdata で書く。JSON-LD だと <script> が増えるうえ、
- * このサイトは元から TechArticle / blogPost を microdata で持っている。
- * BreadcrumbList は itemprop を持たないので、TechArticle の中に
- * 置かれていても独立した item として読まれる。
+ * ここだけ microdata で書く。項目の並び・現在地・位置がマークアップと
+ * 一体で、リンクの有無がそのまま itemprop="item" の有無になるため、
+ * JSON-LD に写すと同じ順序を2箇所で保つことになる。
+ * 記事・一覧の構造化データは head の JSON-LD が持つ (#2462)。
+ * BreadcrumbList は itemprop を持たない独立した item なので混在してよい。
  */
 %>
 <%# data-nosnippet: パンくずの定型文をスニペットに出さない (#2359) %>

--- a/themes/future/layout/_partial/head.ejs
+++ b/themes/future/layout/_partial/head.ejs
@@ -70,6 +70,11 @@
       title = (title ? title + ' ' : '') + page.current + 'ページ目';
     }
 
+    // 構造化データのページ名はサイト名を付ける前の名乗り (#2462)。
+    // <title> は「〜 | フューチャー技術ブログ」だが、JSON-LD の name は
+    // そのページ自身の名前で、サイト名は isPartOf の Blog が持つ
+    const pageName = title || config.title;
+
     if (title) {
       title = title + ' | ' + config.title
     } else {
@@ -122,6 +127,7 @@
   }
   %>
   <%- open_graph(options) %>
+  <%- partial('json-ld', {pageName: pageName, pageDescription: description, ogpImage: options['image']}) %>
   <%
     // ページパスのリストを定義
     const noindexPaths = [

--- a/themes/future/layout/_partial/json-ld.ejs
+++ b/themes/future/layout/_partial/json-ld.ejs
@@ -1,0 +1,124 @@
+<%
+/**
+ * 構造化データ (#2462)。ページ種ごとに1つの JSON-LD を出す。
+ *
+ * microdata ではなく JSON-LD で書く。microdata は DOM の入れ子に縛られ、
+ * 全ページ共通の layout.ejs に itemscope を置いた結果、タグ・カテゴリ・
+ * 著者一覧まで TechArticle を名乗り（トップは datePublished を25個持っていた）、
+ * 記事をその中に入れるために schema.org に存在しない blogPost を使っていた。
+ * JSON-LD なら「このページは記事1本」「このページは一覧」を独立して宣言できる。
+ * パンくずの BreadcrumbList だけは microdata のまま残す（_partial/breadcrumb.ejs）。
+ *
+ * dateModified は出さない。フロントマターに updated を持つ記事は0件で、
+ * Hexo の既定値はファイルの mtime になり CI のチェックアウトで動く（scripts/feed.js と同じ判断）。
+ */
+const SITE = String(config.url).replace(/\/$/, '');
+
+// タグ名・著者名・連載名は日本語をそのまま URL に含む。encodeURI は / と : を保つ
+const abs = (p) => {
+  const clean = String(p || '')
+    .replace(/^\//, '')
+    .replace(/index\.html$/, '');
+  return encodeURI(`${SITE}/${clean}`);
+};
+
+const BLOG = { '@type': 'Blog', '@id': `${SITE}/#blog` };
+
+// ロゴはラスタ画像を渡す。Google の Article ガイドラインが寸法を求めるため、
+// サイトのシンボルである logo.svg ではなく apple-touch-icon.png を使う
+const PUBLISHER = {
+  '@type': 'Organization',
+  name: 'フューチャー株式会社',
+  url: 'https://www.future.co.jp/',
+  logo: {
+    '@type': 'ImageObject',
+    url: abs('apple-touch-icon.png'),
+    width: 152,
+    height: 152,
+  },
+};
+
+const personOf = (name) => {
+  const person = { '@type': 'Person', name: name, url: abs(`authors/${name}/`) };
+  const p = get_profile_data(name);
+  if (p) {
+    if (p.about) {
+      person.description = String(p.about)
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+    }
+    const sameAs = [];
+    if (p.twitter_id) sameAs.push(`https://x.com/${p.twitter_id}`);
+    if (p.github_id) sameAs.push(`https://github.com/${p.github_id}`);
+    if (sameAs.length) person.sameAs = sameAs;
+  }
+  return person;
+};
+
+const namesOf = (collection) =>
+  collection && collection.toArray ? collection.toArray().map((e) => e.name) : [];
+
+const COLLECTION_PATHS = [
+  'tags/index.html',
+  'categories/index.html',
+  'authors/index.html',
+  'series/index.html',
+];
+
+let jsonld;
+if (is_post()) {
+  // 画像は OGP と同じものを出す。同じページの「代表画像」が2箇所で割れないようにする
+  const image = Array.isArray(ogpImage) ? ogpImage[0] : ogpImage;
+  const keywords = namesOf(page.tags);
+  const section = namesOf(page.categories)[0];
+  jsonld = {
+    '@type': 'TechArticle',
+    headline: page.title,
+    url: abs(page.path),
+    mainEntityOfPage: { '@type': 'WebPage', '@id': abs(page.path) },
+    // date_xml は UTC に寄せるため、JST 0:00 公開の記事が前日になる。
+    // 表示している日付と一致させたいので、オフセット付きで出す
+    datePublished: page.date.format(),
+    author: personOf(page.author),
+    publisher: PUBLISHER,
+    isPartOf: BLOG,
+    inLanguage: 'ja',
+  };
+  if (page.lede) jsonld.description = page.lede;
+  if (image) jsonld.image = abs(image);
+  if (keywords.length) jsonld.keywords = keywords;
+  if (section) jsonld.articleSection = section;
+} else if (is_home()) {
+  jsonld = {
+    ...BLOG,
+    name: config.title,
+    description: config.description,
+    url: abs(''),
+    inLanguage: 'ja',
+    publisher: PUBLISHER,
+  };
+} else if (page.author && String(path).indexOf('authors/') === 0) {
+  jsonld = {
+    '@type': 'ProfilePage',
+    name: pageName,
+    url: abs(page.path),
+    isPartOf: BLOG,
+    inLanguage: 'ja',
+    mainEntity: personOf(page.author),
+  };
+} else {
+  const isCollection =
+    is_category() || is_tag() || is_archive() || COLLECTION_PATHS.includes(page.path);
+  jsonld = {
+    '@type': isCollection ? 'CollectionPage' : 'WebPage',
+    name: pageName,
+    url: abs(page.path),
+    isPartOf: BLOG,
+    inLanguage: 'ja',
+  };
+  if (pageDescription) jsonld.description = pageDescription;
+}
+%>
+<%# JSON の中の < を退避する。本文が </script> を含んでもスクリプトが閉じない %>
+<script type="application/ld+json"><%- JSON.stringify({ '@context': 'https://schema.org', ...jsonld }).replace(/</g, '\\u003c') %></script>

--- a/themes/future/layout/_partial/post/date.ejs
+++ b/themes/future/layout/_partial/post/date.ejs
@@ -1,1 +1,1 @@
-<a href="/articles/<%= date(post.date, "YYYY") %>/" class="publish-date"><time datetime="<%= date_xml(post.date) %>" itemprop="datePublished"><%= date(post.date, date_format) %></time></a>
+<a href="/articles/<%= date(post.date, "YYYY") %>/" class="publish-date"><time datetime="<%= date_xml(post.date) %>"><%= date(post.date, date_format) %></time></a>

--- a/themes/future/layout/_partial/post/title.ejs
+++ b/themes/future/layout/_partial/post/title.ejs
@@ -1,6 +1,6 @@
 <%# 記事ページではタイトルがページの主見出しなので h1、一覧ページでは記事が並ぶので h2 にする %>
 <% const titleTag = is_post() ? "h1" : "h2" %>
-<<%= titleTag %> itemprop="name" class="<%= class_name %>"><%= post.title %>
+<<%= titleTag %> class="<%= class_name %>"><%= post.title %>
   <% if (is_post()) {%>
     <a href="https://github.com/future-architect/future-architect.github.io/edit/main/source/<%= encodeURIComponent(page.source) %>" title="Suggest Edits" aria-label="この記事をGitHubで編集する" class="github-edit"><i class="github-edit-icon"></i></a>
   <% } %>

--- a/themes/future/layout/_widget/tag.ejs
+++ b/themes/future/layout/_widget/tag.ejs
@@ -5,7 +5,7 @@
 <% const tags = recent_popular_tags(typeof limit !== 'undefined' ? limit : theme.tag_display_max_count); %>
 <% if (tags.length){ %>
 <div class="widget">
-  <ul class="tag-list" itemprop="keywords">
+  <ul class="tag-list">
     <% tags.forEach(function(t){ %>
     <%# Go はタグ名だけだと言語と分からないため表示だけ変える（旧実装から踏襲） %>
     <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.name %> の記事 <%= t.count %>本（直近1年 <%= t.recent %>本・<%= t.pv.toLocaleString() %> View）"><%= t.name === 'Go' ? 'Go言語' : t.name %><span class="tag-list-count"><%= t.count %></span></a></li>

--- a/themes/future/layout/layout.ejs
+++ b/themes/future/layout/layout.ejs
@@ -1,6 +1,8 @@
 <%- partial('_partial/head') %>
 <body class="corporate">
-  <div class="wrap" itemscope itemtype="https://schema.org/TechArticle">
+  <%# 構造化データは head の JSON-LD が持つ (#2462)。ここに itemscope を置くと
+      一覧ページまで TechArticle を名乗ってしまう %>
+  <div class="wrap">
   <%- partial('_partial/header', null, { path: path }) %>
   <%- body %>
   <%- partial('_partial/footer', null, {cache: !config.relative_link}) %>


### PR DESCRIPTION
## やったこと

構造化データを microdata から JSON-LD に置き換えました。`ld+json` は0件でしたが、microdata は入っていて、**それが壊れていました**。

### 直した4点

| 箇所 | 現状 | 問題 |
| --- | --- | --- |
| `layout.ejs:3` | 全ページの `.wrap` を `schema.org/TechArticle` で囲む | トップ・タグ・カテゴリ・著者一覧まで「1本の技術記事」を名乗る。**トップページは `datePublished` を25個持っていた**（カード25枚ぶんが直下にぶら下がる） |
| `_partial/article.ejs:37` | `itemprop="blogPost"` | `blogPost` は `Blog` のプロパティで **`TechArticle` には存在しない**。中の `articleBody` / `datePublished` は型なしの item に付き、記事に紐づいていなかった |
| `_widget/tag.ejs:8` | 「人気のタグ」に `itemprop="keywords"` | サイドバーの人気タグがページのキーワードとして読まれる。記事のタグではない |
| 全体 | `author` / `image` / `publisher` / `mainEntityOfPage` が無い | 著者330人・日付・サムネイルはフロントマターにあるのに出していなかった |

壊れ方には理由があって、**microdata は DOM の入れ子に縛られる**ためです。全ページ共通の `layout.ejs` に itemscope を置いた結果、一覧ページまで TechArticle になり、記事をその中に入れるために存在しない `blogPost` を使うしかなくなっていました。JSON-LD ならページ種ごとに独立して宣言できます。

パンくずの `BreadcrumbList`（`_partial/breadcrumb.ejs`）だけは microdata のまま残しました。項目の並び・現在地・位置がマークアップと一体で正しく書けており、JSON-LD に写すと同じ順序を2箇所で保つことになるためです。`BreadcrumbList` は itemprop を持たない独立した item なので混在できます。

### 出す内容（ページ種ごとに1つ）

| ページ種 | `@type` | 主なプロパティ |
| --- | --- | --- |
| 記事 | `TechArticle` | headline / description(lede) / image / datePublished / author / publisher / isPartOf / keywords / articleSection / inLanguage / mainEntityOfPage |
| トップ | `Blog` | name / description / url / publisher |
| 著者ページ | `ProfilePage` | mainEntity に `Person`（プロフィール文と X・GitHub の `sameAs`） |
| タグ・カテゴリ・アーカイブ・各一覧 | `CollectionPage` | name / description / url / isPartOf |
| 特設・techcasts・doctor | `WebPage` | name / url / isPartOf |

`scripts/author_profile.js` に `get_profile_data` を足しました。既存の `get_profile` は HTML を組み立てて返すため、構造化データ側から値そのものが取れませんでした。

### 出さなかったもの

- **`dateModified`**。フロントマターに `updated` を持つ記事は **0件**で、Hexo の既定値はファイルの mtime になり CI のチェックアウトで動きます。`scripts/feed.js` が同じ理由で `date` を使っている前例に合わせました
- **一覧ページの `ItemList`**。記事のタイトルと URL は HTML の中に既にあり、同じものを2箇所で保つ必要が出ます

### 判断が要ったところ

- **`datePublished` はオフセット付きで出す**（`2026-08-20T00:00:00+09:00`）。既存の `date_xml` は UTC に寄せるため、JST 0:00 公開の記事が **前日の日付**になり、ページに表示している日付とズレます
- **`publisher.logo` は `apple-touch-icon.png`（152×152）**。Google の Article ガイドラインが寸法を求めるため、サイトのシンボルである `logo.svg` は使えません
- **記事の `image` は OGP と同じ画像**（本文の先頭画像 → 無ければ `/ogp_techblog.jpg`）。同じページの「代表画像」が2箇所で割れないようにしています。サムネイル（`thumbnail.jpg`）は2026年の45枚すべてが幅300pxで、Google の推奨（1200px）に遠く届きません。本文の先頭画像は中央値1000px・33/97本が1200px以上です

## 検証

`hexo generate`（2,921ページ）した生成物を全ページパースしました。

| 項目 | 結果 |
| --- | --- |
| JSON-LD のパースエラー | 0件 |
| JSON-LD を持たないページ | 73件（すべて `alias` のリダイレクト用スタブ。正しい） |
| `TechArticle` | **1,474** — フロントマター直接集計の記事数と一致 |
| `CollectionPage` / `ProfilePage` / `Blog` / `WebPage` | 960 / 348 / 59 / 7 |
| `description` 欠落 | 2本のみ — `lede` を持たない記事2本と一致 |
| 旧 microdata の残存（`TechArticle` / `blogPost` / `articleBody` / `datePublished` / `keywords`） | 0件 |
| `BreadcrumbList` | 記事ページに残存（意図どおり） |

`ProfilePage` 348 = 著者ディレクトリ329 + ページング19、`Blog` 59 = トップ + ページング58 で一致します。

`npx prettier --check "scripts/**/*.js" "*.mjs"` と、変更した `.ejs` への textlint はいずれも通っています。

## この PR の範囲外

issue のもう一方のテーマ **`llms.txt` は見送り**ました。理由は #2462 にコメントで残します（要点: Google は非対応を明言、AIボットのアクセスのうち llms.txt は実測0.1%、AI に最も引用される50ドメイン中の設置は1つ）。

Closes #2462
