### PR TITLE
ホームのランキングでタブを切り替えても下が動かないようにする (#2683)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2268,7 +2268,10 @@ a.series-nav-item:hover .series-nav-item-title {
 .post-list-icon {
   flex-shrink: 0;
 }
+/* ::before は隠れているランキングでサムネの代わりに置く空の箱。
+   content が無いと生成されないので、ここでは寸法だけ相乗りさせる */
 .post-list-icon img,
+.post-list-icon::before,
 .post-list-icon-empty {
   display: block;
   width: 48px;
@@ -2777,10 +2780,45 @@ input[name="tab_item"] {
   padding: 18px 22px;
 }
 
-/*選択されているタブのコンテンツのみを表示*/
-#monthly:checked ~ #popular_monthly,
-#yearly:checked ~ #popular_yearly {
+/* トレンドと年間人気を同じマスに重ね、枠の高さを常に両者の最大にする (#2683)。
+   以前はタブを切り替えるたびに枠の高さが変わり、下の「連載から探す」以降が
+   上下に動いていた。差は件数（どちらも10本）ではなくタイトルの折り返し数で、
+   幅が狭いほど開く（実測で 1280px 幅 12px・375px 幅 34px）。
+
+   隠す側を display: none にすると箱ごと消えて高さを取れないので、
+   grid の同じマスに重ねて visibility で隠す。visibility なら
+   display: none と同じく読み上げ・タブ移動からも外れる */
+.tab-stack {
+  display: grid;
+  clear: both;
+}
+.tab-stack > .tab_content {
+  grid-area: 1 / 1;
   display: block;
+  visibility: hidden;
+}
+#monthly:checked ~ .tab-stack > #popular_monthly,
+#yearly:checked ~ .tab-stack > #popular_yearly {
+  visibility: visible;
+}
+/* 隠れている側は「畳んだ状態」の高さで数える。開いたまま切り替えると、
+   開いた分の空白がもう片方の下に残ってしまう */
+#monthly:checked ~ .tab-stack > #popular_yearly .ranking-more > :not(summary),
+#yearly:checked ~ .tab-stack > #popular_monthly .ranking-more > :not(summary) {
+  display: none;
+}
+/* 隠れている側のサムネは読み込ませない。見えないのに初期表示で8枚・321KB
+   増える（残り2枚は両方のランキングに載っている記事で、どちらでも読む）。
+   ただし行の高さはサムネが決めるので、img を落とすだけだと折り返し数が
+   変わって高さが合わなくなる。同じ寸法の空の箱に差し替える。
+   寸法は .post-list-icon img と同じ1箇所で持つ（a 側の padding も効いたまま） */
+#monthly:checked ~ .tab-stack > #popular_yearly .post-list-icon img,
+#yearly:checked ~ .tab-stack > #popular_monthly .post-list-icon img {
+  display: none;
+}
+#monthly:checked ~ .tab-stack > #popular_yearly .post-list-icon::before,
+#yearly:checked ~ .tab-stack > #popular_monthly .post-list-icon::before {
+  content: '';
 }
 
 .github-edit-icon {

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2316,6 +2316,13 @@ a.series-nav-item:hover .series-nav-item-title {
 .ranking-more > summary:hover {
   color: ink-strong;
 }
+/* 全体指定の details { padding-bottom: 24px } を打ち消す（本文中の折りたたみ
+   ブロック向けの余白で、.article-entry details と .toc-mobile も同じ理由で
+   外している）。畳んだ状態だと「残り N本を表示」の下に24pxの空きが残り、
+   枠の下辺との間が開いて見えていた。下の余白は枠（.tab_content）が持つ */
+.ranking-more {
+  padding-bottom: 0;
+}
 /* 畳んだ側の ul は details 側で余白を持つので、二重に付けない */
 .reference-post-more .reference-post-link,
 .related-posts-more .related-post-link {

--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -11,11 +11,15 @@
         <label tabindex="0" class="tab_item" for="monthly">トレンド</label>
         <input id="yearly" type="radio" name="tab_item">
         <label tabindex="0" class="tab_item" for="yearly">年間人気</label>
-        <div class="tab_content" id="popular_monthly">
-          <%- popular_posts('monthly') %>
-        </div>
-        <div class="tab_content" id="popular_yearly">
-          <%- popular_posts('yearly') %>
+        <%# 2枚を同じマスに重ねて、枠の高さを常に両者の最大にする。
+            タブを切り替えると下のセクションが上下に動いていた (#2683) %>
+        <div class="tab-stack">
+          <div class="tab_content" id="popular_monthly">
+            <%- popular_posts('monthly') %>
+          </div>
+          <div class="tab_content" id="popular_yearly">
+            <%- popular_posts('yearly') %>
+          </div>
         </div>
       </div>
   </section>
@@ -56,8 +60,8 @@
   <%# 特設ページへの入口 (#2295 / #2421)。テキスト1行では視線が滑るため
       パネルにする (#2343)。外部サイトへ直接飛ばさず、サイト内のポータルを
       紹介する（説明と外部サイトへの分岐はポータル側が担う）。
-      ページが増えたらここに列を足す。3枚を超えたら /specials/ への
-      導線1本にまとめる %>
+      全件は /specials/ が持つので、ここに並べるのは2枚まで。
+      連載枠と同じく、残りは下の全件導線から辿る %>
   <section class="series-panels">
     <%- partial('section-heading', {id: 'specials', text: '特設ページ'}) %>
     <div class="row g-4">
@@ -85,6 +89,8 @@
         </div>
       </div>
     </div>
+    <%# 記法ガイドはパネルに出していない。全件は /specials/ が持つ %>
+    <p class="more-link"><a href="/specials/">すべての特設ページを見る</a></p>
   </section>
   <section class="popular-articles">
     <div class="blog-tags margin-bottom-20">


### PR DESCRIPTION
Closes #2683

## 1. タブを切り替えるとレイアウトが上下にずれる

ランキングの2枚は同じ10本だが、タイトルの折り返し数が違うぶん枠の高さが違っていた。
切り替えるたびに枠の高さが変わり、下の「連載から探す」以降が動いていた。

トレンドと年間人気を **grid の同じマスに重ね**、枠の高さを常に両者の最大にする。
隠す側は `display: none` だと箱ごと消えて高さを取れないので `visibility: hidden` にする
（読み上げ・タブ移動から外れるのは `display: none` と同じ。ヘッドレス Chrome で
隠れている側のリンクに `focus()` が通らないことを確認済み）。

「連載から探す」見出しの位置を実測した（ヘッドレス Chrome 152）。

| 幅 | 修正前 トレンド→年間人気 | 修正後 |
| --- | --- | --- |
| 1280px | 1205 → 1193（-12px） | 1205 → 1205（0px） |
| 1024px | 1201 → 1189（-12px） | 1201 → 1201（0px） |
| 900px | 1268 → 1278（+10px） | 1278 → 1278（0px） |
| 768px | 1268 → 1278（+10px） | 1278 → 1278（0px） |
| 414px | 1514 → 1524（+10px） | 1524 → 1524（0px） |
| 375px | 1624 → 1590（-34px） | 1624 → 1624（0px） |

重ねたことで出てくる副作用を2つ抑えている。

- **「残り 15本を表示」を開いたまま切り替えると、開いた分の空白が残る。**
  隠れている側の `details` の中身を落とし、畳んだ高さで数える。
  実測：トレンドで開く（枠 1802px）→ 年間人気へ切替（770px、空白なし）→ 戻す（1802px、開いたまま）
- **見えない側のサムネが読み込まれる。** `visibility: hidden` は箱が残るので
  遅延読み込みが走ってしまう（年間人気の上位10件のうち8枚・321KB。残り2枚は
  両方に載っている記事）。`img` を落として同じ寸法の空の箱に差し替えた。
  実測で 10枚 → 2枚。行の高さはサムネが決めるので、寸法を揃えないと
  折り返し数が変わって高さが合わなくなる（375px で 34px ずれたままになる）

## 2. 「すべての特設ページを見る」

パネルの下に、連載枠・タグ枠と同じ `more-link` で置いた。
`/specials/` には記法ガイド・ガイドライン・HACK TO THE FUTURE の3件があり、
パネルに出しているのは後ろ2件なので、全件への導線が要る。

「3枚を超えたら /specials/ への導線1本にまとめる」というコメントは、
導線が付いた以上「並べるのは2枚まで、残りは全件導線から辿る」に書き換えた。

## 範囲外にしたもの

- **`.more-link { text-align: right }` は効いていない。** metronic の
  `.blog-posts p { text-align: justify }`（詳細度で勝つ）に負けていて、
  ホームの3つの全件導線はすべて左寄せで出ている。今回足した1本も既存2本と
  同じ見え方なので揃ってはいるが、CSS の意図とは食い違っている。
  直すと3箇所とも右へ動く見た目の変更になるため、この PR では触らない
- **著者一覧（/authors/）の年タブにも同じ上下のずれがある。** 別の部品
  （`year-tabs`）で、#2683 はホームの話なので触らない