### PR TITLE
一覧サムネイルの width / height のエスケープ壊れを直す (#2690)

### DIFF
--- a/themes/future/layout/_partial/archive-post.ejs
+++ b/themes/future/layout/_partial/archive-post.ejs
@@ -1,7 +1,9 @@
 <div class="row article-card">
   <% if (post.thumbnail) { %>
   <a href="<%- url_for(post.path) %>" title="<%= post.title %>" class="col-sm-4 col-md-4 thumb-link card-thumb">
-    <img src="<%= post.thumbnail %>" class="img-responsive" alt="" <%= image_size_attribute(post.thumbnail) %> loading="lazy">
+    <%# image_size_attribute は width="300" height="225" というタグの断片を返す。
+        エスケープする出力に渡すと引用符が &#34; になり、属性として壊れる (#2690) %>
+    <img src="<%= post.thumbnail %>" class="img-responsive" alt="" <%- image_size_attribute(post.thumbnail) %> loading="lazy">
   </a>
   <div class="col-sm-8 col-md-8">
   <% } else { %>


### PR DESCRIPTION
## やったこと

一覧カードのサムネイルの `width` / `height` が属性として壊れていたのを直した。`<%=` を `<%-` にする1文字。

```diff
- <img src="..." class="img-responsive" alt="" <%= image_size_attribute(post.thumbnail) %> loading="lazy">
+ <img src="..." class="img-responsive" alt="" <%- image_size_attribute(post.thumbnail) %> loading="lazy">
```

`image_size_attribute`（`scripts/thumbnail_image_size.js`）は `width="300" height="225"` という**タグの断片**を返すヘルパーなので、エスケープする出力に渡すと引用符が `&#34;` になる。次に触る人が同じ間違いをしないよう、ヘルパーの戻り値がタグの断片であることをコメントに書いた。

## 影響範囲（修正前の生成物を全走査）

| 指標 | 修正前 | 修正後 |
| --- | --- | --- |
| 壊れた属性の数 | 8,760 | 0 |
| 該当ページ数 | 1,203 | 0 |

壊れていた `img` は **8,760件すべてが `class="img-responsive"`**、つまり `archive-post.ejs` のこの1行だけが発生源だった。1,203ページに出るのは、この部品をホーム・タグ・カテゴリ・著者の一覧とそのページャー配下が共用しているため。

同じ書き方（HTMLを返すヘルパーをエスケープする出力に渡す）の残りは無い。`themes/` / `scripts/` を全走査して `<%= image_size_attribute` は0件、生成物側も `=&#34;` で出る属性は `width` / `height` の2種だけだった。

## 見た目は変わらない

`.card-thumb` の `aspect-ratio: 1200 / 630`（#2305）が枠を確保しているので、寸法指定が効いていなくても CLS にはなっていなかった。この修正で**表示は1pxも変わらない**。直す理由は、書いてある指定が1つも効いていない状態を残さないため（`aspect-ratio` を外した瞬間に効き出す種になる）。

## 経緯

#2566（サムネイルにカテゴリを重ねる）の実装中に同じ行を触って気づいたもの。#2566 はデザイン上成立しないと判断して没にしたため、こちらだけ切り出した。

Closes #2690

🤖 Generated with [Claude Code](https://claude.com/claude-code)
