### PR TITLE
月ページの記事一覧をカード表示にする (#2702)

### DIFF
--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -158,7 +158,25 @@
     <%# 見出しの語彙は他の一覧ページに合わせる。ここは全記事の時系列リストなので
         「新着記事」ではなく常に「記事一覧」 %>
     <%- partial('_partial/section-heading', {id: 'posts', text: '記事一覧'}) %>
+    <%# 月だけカード（ホーム・タグ・カテゴリ・著者と同じ _partial/archive-post）で、
+        年と全期間はテキストの年表のまま (#2702)。月は中央値13件・最大40件で
+        他の一覧の1ページ（25件）と同じ規模なので、カードにしても長さが破綻しない。
+        年（100〜186件）と全期間（1,474件）は per_page: 0 でページ分割していないため、
+        カードにすると1ページに数百枚並ぶ。ページャーを入れれば収まるが、
+        「その期間の全記事を1ページで見渡す」というこのページの役割が変わる %>
+    <% if (is_month()) { %>
+    <div class="row">
+      <main class="blog-posts">
+        <div class="archives">
+          <% page.posts.each(function(post){ %>
+          <%- partial('_partial/archive-post', {post: post, index: true}) %>
+          <% }) %>
+        </div>
+      </main>
+    </div>
+    <% } else { %>
     <%- partial('_partial/archive-all', {pagination: config.archive}) %>
+    <% } %>
     <%# 前後の期間へのページャー (#2228)。連載ナビと同じ型（前が左・
         対象明示型のラベル＋行き先名）で、一覧を読み終えた位置に置く。
         端では連載ナビと同じく、行き先が無いことを明示する %>


### PR DESCRIPTION
Closes #2702

月ページの記事一覧を `_partial/archive-post`（ホーム・タグ・カテゴリ・著者と同じ `.article-card`）に変え、
**年と全期間はテキストの年表のまま**にしました。

## 決めたこと

「一覧の見せ方は1つに揃える」ではなく、**件数に応じて密度を変える**を規則として認める形です。
年をカード化するにはページャー（25件）が前提になりますが、年・全期間は `per_page: 0` で
ページ分割していないので、ページングの仕組みと噛み合いません。
「その期間の全記事を1ページで見渡す」というページの役割も変わります。

| ページ | 件数 | 見せ方 |
| --- | --- | --- |
| `/articles/<年>/<月>/` | 中央値13件・最大40件（120ヶ月の実測。**25件を超えるのは5ヶ月だけ**） | **カード**（変更） |
| `/articles/<年>/` | 100〜186件 | テキスト（従来） |
| `/articles/` | 1,474件 | テキスト（従来） |

判断の理由は `archive.ejs` の分岐のところにコメントで残しました。CLAUDE.md には足していません
（決定の場所がその1箇所で、他のページを書くときに参照する規則ではないため）。

## 確認

`hexo server` の出力を curl して数えています。

| URL | `.article-card` | テキスト行 |
| --- | --- | --- |
| `/articles/2026/08/` | **11** | 0 |
| `/articles/2021/04/`（最大の月） | **40** | 0 |
| `/articles/2016/02/`（サムネ無し2件・lede 無し1件を含む月） | **3**（うち2件がサムネ無しの `col-xs-12` 型） | 0 |
| `/articles/2026/` | 0 | 100 |
| `/articles/` | 0 | 1,474 |

**カードのマークアップがホームと完全に一致することを確かめました。**
`/articles/2026/08/` の11枚とホーム1ページ目の同じ記事のカードを突き合わせて、11/11 が一致です
（サムネイル・タイトル・概要文・日付・タグ・シェアボタンすべて）。

`lede` を持たない記事は全1,474本中2本（2016年の2件）ですが、どちらも `<!-- more -->` があるので
`excerpt` が使われ、本文が丸ごと出ることはありません（実測33文字）。

構造は見出し → `.row > main.blog-posts > .archives` → カード → 前後の月のナビで、
差し替え前の `archive-all` と同じ入れ物です（`main.blog-posts` を保つのは `.blog-posts p` の
両端揃えなど、他ページのカードと同じ地の上に置くため）。

## 範囲外

- `/articles/`（全期間）と `/articles/<年>/` の見せ方
- ページ分割（`per_page`）の変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)
