### PR TITLE
make fix が1行目で止まっていたのを直す (#2712)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ make g      # 静的ファイル生成（public/）
 make css    # public/css/site.css だけ再生成（0.3秒。CSSの確認用）
 make clean  # キャッシュ・生成物の削除
 make fix    # textlint --fix（source/_posts 配下）
-make fmt    # markdownlint-cli2 --fix（全 *.md。記事も対象なので、無関係な記事まで書き換わる）
+make fmt    # markdownlint-cli2 --fix（リポジトリ自身の *.md。node_modules と .claude は対象外 #2712）
             # ＋ prettier（scripts/**/*.js と *.mjs のみ #2307）
 make lint   # npx lint-staged（git add 済みの記事のみ textlint）
 make mermaid # mermaid 図のSVGキャッシュ更新（Docker必須、記事の図を追加・編集したら実行してコミット）
@@ -167,9 +167,12 @@ make mermaid # mermaid 図のSVGキャッシュ更新（Docker必須、記事の
 
 ## Lint ルール
 
-- `.textlintrc`: `preset-ja-technical-writing` + `spellcheck-tech-word`。一文200文字まで。感嘆符・疑問符と弱い表現は許容
+- `.textlintrc`: `preset-ja-technical-writing` + `prh` + `.textlint/` のローカルルール。一文200文字まで。感嘆符・疑問符と弱い表現は許容
   - 誤検知は `.textlintrc` の `filters.allowlist.allow` に単語を追加して黙らせる
-  - `spellcheck-tech-word` は「インターフェース→インタフェース」「% → ％」など表記統一を強制する
+  - **表記統一は `prh.yml` に書いた4件だけ**（`インタフェース` → `インターフェース`、
+    `プリフィックス` → `プレフィックス`、`Webブラウザ` → `ブラウザ`、掛け算の `x` → `×`）。
+    `spellcheck-tech-word` は個別の変換を止める手段が無く、誤検知のたびに allowlist へ
+    単語を足す運用になっていたので #2184 で外した。**辞書に無い表記は直されない**
   - **`no-mix-dearu-desumasu` は無効**（#2381）。文体は「である」「ですます」どちらでもよく、
     段落単位で切り替える書き方（数学の証明、脚注、エッセイ、分析メモ）を許容する。
     このルールは `です／ます／である` の明示マーカーしか数えず `〜だ。` `〜する。` を

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,12 @@ fmt:
 	node_modules/.bin/markdownlint-cli2 --fix "**/*.md"
 	node_modules/.bin/prettier --write "scripts/**/*.js" "*.mjs"
 
+# グロブはクォートして textlint に展開させる。裸で書くと bash が展開し、
+# globstar 無しの ** は1階層しか辿らない。以前は source/_posts/*.md の行が
+# 先にあり、記事は年ディレクトリの下にあって1件も一致しないため
+# SearchFilesNoTargetFileError で止まり、本命の行に到達していなかった (#2712)
 fix:
-	node_modules/.bin/textlint --fix source/_posts/*.md
-	node_modules/.bin/textlint --fix source/_posts/**/*.md
+	node_modules/.bin/textlint --fix "source/_posts/**/*.md"
 
 g:
 	node_modules/.bin/hexo g


### PR DESCRIPTION
#2714 のあとに `make fmt` / `make lint` / `make fix` を順に回して確かめたところ、
**`make fix` が #2712 とまったく同じ形で壊れていました**。その続きとして直します。

## 何が起きていたか

```console
$ make fix
... errors: [ { type: 'SearchFilesNoTargetFileError' } ],
    patterns: [ 'source/_posts/*.md' ]
make: *** [Makefile:12: fix] Error 2
```

記事は `source/_posts/<年>/` に置く規則なので、1行目の `source/_posts/*.md` は**構造上1件も一致しません**。
`.SHELLFLAGS := -eu -o pipefail` なので、そこで止まって**2行目（1,474件を処理する本命の行）に到達していませんでした**。

CLAUDE.md が「記事を書き換えたら `make fix`」と案内しているコマンドが、**一度も記事を処理していなかった**ことになります。

## 直し方

2行を1行にして、グロブをクォートします。

```make
fix:
	node_modules/.bin/textlint --fix "source/_posts/**/*.md"
```

クォートすると展開するのは bash ではなく textlint 自身になります。**裸で書くと globstar 無しの
`**` が1階層しか辿らない**ので、年ディレクトリの1段だけに依存した書き方になっていました。
クォートすれば深さに関係なく拾えるため、1行で足ります（`source/_posts/` 直下に置いた記事も拾える）。

## 確認

**通ること**（`make fix` が完走し、記事に diff が出ない）:

```console
$ make fix
（exit 0、出力なし）
$ git status --short
（Makefile と CLAUDE.md だけ）
```

**届いていること**（壊した記事が直る）: 2026年の記事の末尾に `このAPIのインタフェースを確認します。` を
足してから `make fix` を回すと、`インターフェース` に直りました。1行目で止まっていた頃は
この行が残ったままになります。

参考に、他のターゲットも確かめた結果:

| コマンド | 結果 | diff |
| --- | --- | --- |
| `make fmt` | exit 0（#2714 で0件になった） | 出ない |
| `make lint` | `No staged files found.` | 出ない |
| `make css` | `public/css/site.css` を書くだけ（gitignore 済み） | 出ない |
| `node normalize.mjs` | exit 0 | 出ない |
| **`make fix`** | **修正前は exit 2 / 修正後は exit 0** | 出ない |

`make mermaid`（Docker 必須）と `make update`（SNS・GA の外部コマンド）は回していません。

## CLAUDE.md の2箇所

実体とズレていたので、この PR で直します。

- **表記統一のルール名と向き。** `spellcheck-tech-word` は #2184 で外れていて、いまは `prh` です。
  辞書は `prh.yml` の4件だけで、「インターフェース→インタフェース」は**向きが逆**でした
  （`prh.yml` の `expected` は `インターフェース`）。逆を案内していると、寄稿者の原稿を
  直すときに間違った方向へ揃えてしまいます
- **`make fmt` の説明。** #2714 で走査対象が変わったので合わせました

🤖 Generated with [Claude Code](https://claude.com/claude-code)
