### PR TITLE
ランキングの順位の丸を hover で白抜きにし、サイドバーの more-link を左寄せにする (#2717 / #2718)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2456,6 +2456,17 @@ a.series-nav-item:hover .series-nav-item-title {
   /* 桁によって字幅が変わると円の中で数字が動く */
   font-variant-numeric: tabular-nums;
   line-height: 1;
+  /* 行の面と同じ速さで送る。transition は基底側に書く (#2686) */
+  transition: background-color hover-speed ease;
+}
+/* 行の hover で面が surface-mute になると、塗りを持たない4位以下の丸が
+   同じ色なので面に溶けて消える (#2717)。hover の間だけ白抜きにする。
+   数字のコントラストも 5.34 から 6.19 に上がる。
+   1位（クリムゾン）と2〜3位（ネイビー）は塗りを自分で持つので、
+   :not() で外す。付けないとこの規則（0,2,1）が
+   .post-list-rank-first（0,1,0）に勝って塗りを潰す */
+.featured-posts-item:hover .post-list-rank:not(.post-list-rank-first):not(.post-list-rank-high) {
+  background: #fff;
 }
 /* 1位はコンセプトブックの差し色（クリムゾン。白抜きで 5.35 = AA）。
    「差し色は画面内で1箇所」の文法に従うので、2位以下には広げない (#2681) */
@@ -3225,6 +3236,12 @@ input[name="tab_item"] {
   text-align: right;
   font-size: 12px;
   margin-top: 8px;
+}
+/* サイドバーでは左寄せにする (#2718)。本文列（約813px）なら行末に置いた
+   「すべて見る」が効くが、サイドバー（約210px）は文字がほぼ幅いっぱいで、
+   右寄せの意図が出ないまま端に貼り付いて見える */
+.blog-sidebar .more-link {
+  text-align: left;
 }
 
 /* /tags/ の「人気のタグ」2列パネル（直近1年/累計 #2358）。


### PR DESCRIPTION
#2717 / #2718

どちらも CSS 数行なので1つの PR にまとめました。

## #2717 ランキングの4位以下の順位が hover で消える

`.post-list-rank`（順位の丸）の地が `surface-mute`（#eee）で、行の hover の面（`.featured-posts-item:hover`）も同じ `surface-mute`。同色なので丸が面に溶けていました。1位（クリムゾン）と2〜3位（ネイビー）は塗りを持つので見え、**塗りを持たない4位以下だけ**が消えていました。

hover の間だけ丸を白抜きにします。数字（`ink-mute`）のコントラストも地が白になる分 5.34 → 6.19 に上がります。

```styl
.featured-posts-item:hover .post-list-rank:not(.post-list-rank-first):not(.post-list-rank-high) {
  background: #fff;
}
```

`:not()` を2つ付けるのは、付けないとこの規則（0,2,1）が `.post-list-rank-first`（0,1,0）に勝って1位のクリムゾンと2〜3位のネイビーを白で潰すためです。あわせて `.post-list-rank` の基底に `transition: background-color hover-speed ease` を入れ、行の面と同じ 0.05s で送るようにしました（transition は基底側に書く #2686）。

行の反応（面）は #2686 の規則どおりそのままです。

## #2718 サイドバーの「歴代の一覧を見る」が右寄せ

`.more-link { text-align: right }` を本文列の「すべての連載を見る」「すべてのタグを見る」と共用していたためです。本文列（約813px）なら行末に置く形が効きますが、サイドバー（約210px）は文字がほぼ幅いっぱいで、右寄せの意図が出ないまま端に貼り付いて見えます。

`.blog-sidebar .more-link { text-align: left }` でサイドバーだけ左寄せにします。サイドバー内の `.more-link` はこのアドベントカレンダー枠だけなので、影響範囲はここに限られます。

**文字色は触っていません。** `.blog-sidebar a { color: ink-strong }` で黒く出ているのは #2699 で決めた規則どおり（青は本文中のリンク専用、サイト内の導線は ink 系）です。

## 確認

- `make css` で2つのルールが期待どおり出ることを確認（`.blog-sidebar .more-link` は 0,2,0 で `.more-link` に勝つ）
- 順位の丸が出るのはランキング（`featured-posts-item`）だけで、関連記事・被参照記事の行には無いことを確認（`scripts/popular_posts.js` の `rankMark` はランキングのみに渡す）
- 動作確認: http://localhost:4010/ （ホームの「よく読まれている記事」で4位以下にカーソルを乗せる、サイドバーのアドベントカレンダー枠）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
