### PR TITLE
シェアボタンの数値をネイビーにする (#2723)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -898,9 +898,12 @@ ul.social-button li {
   width: 14px;
   height: 14px;
 }
-/* 数字は本文に添える属性なので ink-mute。日付・タグと同じ扱い */
+/* 数字はボタンと同じネイビー (#2723)。#2716 では「本文に添える属性」として
+   日付・タグと同じ ink-mute にしていたが、それだと枠の外に置いた数字が
+   ボタンと切れて見えた。同じ色にすると円と数字が1つの部品として読める。
+   押せる部分ではないので hover では動かさない（反応はボタンが持つ #2686） */
 .share-count {
-  color: ink-mute;
+  color: var(--brand-navy);
   font-size: 11px;
   line-height: 1;
   font-weight: bold;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -906,7 +906,9 @@ ul.social-button li {
   color: var(--brand-navy);
   font-size: 11px;
   line-height: 1;
-  font-weight: bold;
+  /* 太字にしない。ネイビーは ink-mute の2.6倍濃い（6.19 → 16.34）ので、
+     11px で bold にすると線が潰れて数字が太って見えた */
+  font-weight: normal;
   /* 桁が変わってもアイコンの中心からずれないように等幅の数字にする */
   font-variant-numeric: tabular-nums;
 }


### PR DESCRIPTION
Closes #2723

シェア数の色を `ink-mute`（#616161）から `--brand-navy`（#0A1461）に変えます。

| | 変更前 | 変更後 |
| --- | --- | --- |
| シェア数（`.share-count`） | `ink-mute` #616161 / 白地 6.19 | **`--brand-navy` #0A1461 / 白地 16.34** |
| ボタンの円（`.share-btn`） | ネイビー（変更なし） | 〃 |

## なぜ変えるか

#2716 でこの数字は「本文に添える属性」として日付・タグと同じ `ink-mute` にしていました。
数字は押す対象ではなく、円の外（ボタンの下）に置いているためです。

ただ**弱くした結果、数字がボタンと切れて見え、どのボタンの実績なのかが色から読めません**でした。
円と同じネイビーにすると、円と数字が1つの部品として読めます。issue の「シェアボタンの一部という
意味を含ませたい」がこれに当たります。

`ink-mute` → ネイビーは弱める方向ではなく**役割を変える**変更なので、#2716 のコメントも
上書きして理由を残しました。

## hover は動かさない

数字は押せる部分ではないので、hover では色を変えません。反応はボタン（円）が持ちます
（#2686 の「1部品1反応」）。円は hover でネイビー塗り＋白抜きに反転し、数字はそのまま残ります。

## 確認

CSS だけの変更なので `make css` で再生成し、配信中の `/css/site.css` を確認しました。

```css
.share-count {
  color: var(--brand-navy);
  font-size: 11px;
  ...
}
```

見え方は記事末と一覧カードの2箇所です（`_partial/social-button.ejs` はどちらからも呼ばれます）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
