### PR TITLE
タブの切り替えに動きを付ける (#2728)

### DIFF
--- a/themes/future/css-src/_variables.styl
+++ b/themes/future/css-src/_variables.styl
@@ -105,6 +105,11 @@ img-width-small = 360px
 // ハードカットだと切り替わる瞬間が硬い
 hover-speed = 0.05s
 
+// タブの切り替え（#2728）。反応ではなく状態の変化なので hover-speed とは別に持つ。
+// details の開閉（0.18s）に合わせた。中身が入れ替わったことが分かる程度で、
+// 待たされない長さ
+tab-speed = 0.18s
+
 // Layout
 block-margin = 50px
 article-padding = 20px

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -3061,6 +3061,33 @@ a.article-award:focus {
 input[name="tab_item"] {
   display: none;
 }
+/* 中身の切り替えに動きを付ける (#2728)。タブ帯（ラベル）の hover と選択は
+   すでに hover-speed で送っているが、中身は瞬時に入れ替わるので、押した結果が
+   同じ場所で差し替わったことに気づきにくかった。
+
+   こちらのタブは display で出し入れしているため transition が効かない。
+   表示された瞬間に動く animation を使う。ランキング（.tab-stack）は
+   重ねてあるので透明度の遷移側で送る */
+@keyframes tab-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+.chart-tabs input:checked + .tab_item + .tab_content,
+.year-tabs input:checked + .tab_item + .tab_content {
+  animation: tab-fade-in tab-speed ease;
+}
+/* 動きを減らす設定では切り替えを瞬時に戻す。0.05秒の色や面の送りは
+   動きではないので止めない（#2686 と同じ線引き） */
+@media (prefers-reduced-motion: reduce) {
+  .chart-tabs input:checked + .tab_item + .tab_content,
+  .year-tabs input:checked + .tab_item + .tab_content {
+    animation: none;
+  }
+}
 /* 選択されているタブ。上辺にブランドネイビーのアクセントを置いて
    所在をはっきりさせる（選択状態＝インタラクションなので --brand-navy の
    守備範囲。ページャーの選択色と同じ扱い）。
@@ -3099,10 +3126,27 @@ input[name="tab_item"] {
   grid-area: 1 / 1;
   display: block;
   visibility: hidden;
+  /* 切り替えに動きを付ける (#2728)。ここは display で出し入れせず同じマスに
+     重ねてあるので、透明度を送れる */
+  opacity: 0;
 }
+/* **transition は表示される側に書く。** 基底（上）に置くと消える側も
+   0.18秒かけて薄くなり、同じマスに重ねてある2枚が同時に見えて文字が重なる。
+   「出るときだけ送る」形にしたいので、#2686 の「transition は基底側」の
+   原則をここでは意図して外す */
 #monthly:checked ~ .tab-stack > #popular_monthly,
 #yearly:checked ~ .tab-stack > #popular_yearly {
   visibility: visible;
+  opacity: 1;
+  transition: opacity tab-speed ease;
+}
+/* 動きを減らす設定では瞬時に切り替える。詳細度が同じなので、打ち消しは
+   必ず上のルールより後ろに置く（メディアクエリは詳細度を上げない） */
+@media (prefers-reduced-motion: reduce) {
+  #monthly:checked ~ .tab-stack > #popular_monthly,
+  #yearly:checked ~ .tab-stack > #popular_yearly {
+    transition: none;
+  }
 }
 /* 隠れている側は「畳んだ状態」の高さで数える。開いたまま切り替えると、
    開いた分の空白がもう片方の下に残ってしまう */


### PR DESCRIPTION
#2728

## 現状の切り分け

タブ帯（ラベル）**には既に動きがあります**。hover で地が `surface-mute`・上辺が `rule-strong`・文字が `ink-strong` に変わり、選択タブは白地＋ネイビーの上辺になる。いずれも `hover-speed`（0.05s）で送っています。

**止まっているのは中身の切り替えでした。** 押した瞬間に同じ場所で内容が差し替わるので、何が起きたのか掴みにくい。ここに動きを足します。

## 時間

`tab-speed = 0.18s` を `_variables.styl` に置きました。反応（`hover-speed` 0.05s）ではなく**状態の変化**なので、`details` の開閉（0.18s）に合わせています。

## 送り方はタブの作りで2つに分かれる

| タブ | 出し入れの仕組み | 送り方 |
| --- | --- | --- |
| チャート（年・全期間・`/tags/`）、年（`/authors/`） | `display: none` / `block` | `animation: tab-fade-in`（display では transition が効かない） |
| ランキング（ホームの「よく読まれている記事」） | 同じ grid のマスに2枚重ねて `visibility`（#2683） | `opacity` の transition |

**ランキング側は transition を「表示される側」に書いています。** 基底に置くと消える側も 0.18秒かけて薄くなり、重ねてある2枚が同時に見えて文字が重なります。#2686 の「transition は基底側に書く」の原則をここでは意図して外しました（コメントに理由を残しています）。

`prefers-reduced-motion: reduce` では瞬時に戻します。打ち消しは詳細度が同じなので、対象のルールより**後ろ**に置いています（メディアクエリは詳細度を上げないので、前に置くと効きません。書いた直後に順序を間違えていて気づきました）。

## 確認

- `make css` で、`animation: tab-fade-in 0.18s ease` → その直後に reduced-motion の `animation: none`、`transition: opacity 0.18s ease` → その直後に reduced-motion の `transition: none` の順で出ることを確認（打ち消しが後ろにある）
- 動作確認
  - ホームの「よく読まれている記事」のトレンド / 年間人気: http://localhost:4010/
  - チャートのタブ（カテゴリ別 / 週別）: http://localhost:4010/articles/2025/
  - 年のタブ: http://localhost:4010/authors/
- 実機で見てほしいのは、0.18s が長すぎないか（連続で切り替えたときのもっさり感）と、ランキングの切り替えで文字が重なって見えないかです

🤖 Generated with [Claude Code](https://claude.com/claude-code)
