### PR TITLE
関連カテゴリ・よく使われるカテゴリにカテゴリのアイコンを添える (#2737)

### DIFF
--- a/themes/future/layout/_partial/author-tendencies.ejs
+++ b/themes/future/layout/_partial/author-tendencies.ejs
@@ -12,7 +12,7 @@
   <% as.topCategories.forEach(function(c){ %>
   <li class="tendency-panel">
     <%# カテゴリはタグと誤認しないようチップにせず、記事メタデータと同じテキストリンク %>
-    <a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事へ"><%= c.name %></a>
+    <a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事へ"><%- partial('category-icon', {name: c.name}) %><%= c.name %></a>
     <span class="tendency-panel-count"><%= c.count %>本投稿</span>
   </li>
   <% }) %>

--- a/themes/future/layout/_partial/related-categories.ejs
+++ b/themes/future/layout/_partial/related-categories.ejs
@@ -13,7 +13,7 @@
     <ul class="tendency-panels">
       <% rc.forEach(function(c){ %>
       <li class="tendency-panel">
-        <a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事へ"><%= c.name %></a>
+        <a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事へ"><%- partial('category-icon', {name: c.name}) %><%= c.name %></a>
         <span class="tendency-panel-count"><%= c.tags.join('・') %>を共有</span>
       </li>
       <% }) %>

--- a/themes/future/layout/_partial/svg-icon.ejs
+++ b/themes/future/layout/_partial/svg-icon.ejs
@@ -1,7 +1,7 @@
 <%# インラインSVGアイコンの共通部品 (#2306 / #2336)。
     出典は Tabler Icons v3.31（MIT / https://tabler.io/icons ）の outline 系。
-    パスの辞書はここ1箇所で持ち、カテゴリ・タグとの対応付けは
-    category-icon.ejs / tag-icon.ejs が持つ。
+    パスの辞書はここ1箇所で持ち、カテゴリ名との対応付けは
+    category-icon.ejs が持つ。
     Webフォント・外部JSを増やさない方針のためインラインで埋め込む。
     stroke=currentColor で文字色を継承する。未知のアイコン名では何も出さない。
 

--- a/themes/future/layout/tag.ejs
+++ b/themes/future/layout/tag.ejs
@@ -97,7 +97,7 @@
     <ul class="tendency-panels">
       <% tc.topCategories.forEach(function(c){ %>
       <li class="tendency-panel">
-        <a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事へ"><%= c.name %></a>
+        <a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事へ"><%- partial('_partial/category-icon', {name: c.name}) %><%= c.name %></a>
         <span class="tendency-panel-count"><%= c.count %>本が所属</span>
       </li>
       <% }) %>


### PR DESCRIPTION
カテゴリのテキストリンクにカテゴリのアイコンを添えます。

Closes #2737

## 何が揃っていなかったか

カテゴリのアイコン（`_partial/category-icon.ejs`）は既に4箇所で出ているのに、`.tendency-panel` の中のカテゴリだけ素のテキストリンクでした。タグページでは**すぐ下に「関連タグ」のチップが並ぶ**ので、目印の無いカテゴリが余計に貧弱に見えていました。

| 場所 | アイコン |
| --- | --- |
| サイドバーのカテゴリ一覧（`_widget/category.ejs`） | あり |
| `/categories/` 一覧（`categories.ejs`） | あり |
| カテゴリページの h1（`category.ejs` / `category-without.ejs`） | あり |
| 関連カテゴリ・よく使われるカテゴリ・よく使うカテゴリ | **無し** ← これ |

## やったこと

同じ部品（`.tendency-panel` ＋ `.article-category-link`）を使っている**3箇所すべて**に付けました。`/categories/` 一覧と同じ形で、リンクテキストの前に置いています。

| 場所 | 見出し | ページ数 / パネル数 |
| --- | --- | --- |
| カテゴリページ | 関連カテゴリ | 32 / 116 |
| タグページ | よく使われるカテゴリ | 559 / 747 |
| 著者ページ | よく使うカテゴリ | 329 / 464 |

**著者ページは issue に挙がっていませんが、同じ部品なので揃えました。** 全体の3分の1のパネル数を持つので、外すとここだけアイコンの無い例外になります。

- **チップにはしません。** カテゴリをタグと同じ丸みのあるチップにすると「タグが1つ増えた」と誤認される（#2129）ので、記事メタデータと同じテキストリンクのまま、目印だけ足しています
- **アイコンが付かないカテゴリは出ません。** `source/_data/categories.yml` の18件と `category-icon.ejs` の18件が完全一致していることを確認しました（片側だけにある語はゼロ）。未知の名前では何も出さない作りなので、新カテゴリを足しても壊れません
- 絵柄は `_partial/svg-icon.ejs` の辞書が1箇所で持つ形をそのまま使っています（新しいアイコンは追加していません）

### ついでに直したもの

`svg-icon.ejs` のコメントが**存在しない `tag-icon.ejs`** を「タグとの対応付けを持つ」ものとして指していたので直しました（タグ側は `svg-icon` を直接呼んでいます）。

## 検証

- `hexo server` で配信中のHTMLを確認。`/tags/Go/`（よく使われるカテゴリ）・`/categories/Programming/`（関連カテゴリ）・`/authors/真野隼記/`（よく使うカテゴリ）の3ページで、パネルの `<a>` の中に `svg-icon` が入っていることを確認
- 出力されたマークアップが `/categories/` 一覧の `category-index-name` と**同じ形**（空白の入り方まで同じ）であることを確認。既存のアイコン付きリンクと見た目が揃います
- 変更した `.ejs` 4本に textlint

## 範囲外

- **パンくずのカテゴリ**にはアイコンを付けていません。#2705 / #2722 で「現在地は太さだけで示す・色は動かさない」と決めた 14px の帯で、アイコンを入れるかどうかは別の議論になります
- カテゴリの見せ方そのもの（チップ化・件数の出し方）は #2129 の判断を踏襲しています
