### PR TITLE
表ヘッダの地を面の変数 surface-tint に寄せる (#2743)

### DIFF
--- a/themes/future/css-src/_variables.styl
+++ b/themes/future/css-src/_variables.styl
@@ -24,8 +24,8 @@ rule-strong = #ccc    // focus / hover でひとつ強める
 
 // 面は白地との差だけで意味を出す。濃くすると文字のコントラストが動くため、
 // 白に近い2段に留める
-surface-tint = #f5f5f5 // hover・チップの地
-surface-mute = #eee    // 空のプレースホルダ・focus の地
+surface-tint = #f5f5f5 // hover・チップ・表のヘッダの地
+surface-mute = #eee    // 空のプレースホルダ・focus の地・インラインコードの地
 
 // Colors
 // 元テーマ由来のグレー（color-default #555 / color-grey #999 /
@@ -138,6 +138,6 @@ mq-normal = "screen and (min-width: 768px)"
 //
 // 倍率は joshwcomeau.com の --color-*-100 → *-200 の実測値から取った (#2482)。
 // 明度だけでなく彩度も少し下げるのは、明度を落とすと同じ彩度でも色が強く
-// 出るため。無彩色（テーブルヘッダの #f2f2f2）では彩度が 0 なので明度だけが効く
+// 出るため。無彩色（テーブルヘッダの surface-tint）では彩度が 0 なので明度だけが効く
 code-bg(bg)
   hsl(hue(bg), saturation(bg) * 0.94, lightness(bg) * 0.94)

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1223,7 +1223,6 @@ button.share-btn {
   縞が効く長さの表はそもそも少ない。
 */
 table-border = #ccc
-table-header-bg = #f2f2f2
 
 table {
   table-layout: auto;
@@ -1238,17 +1237,21 @@ th, td {
 th {
   // 900 は Hiragino / Yu Gothic に該当ウェイトが無く、ブラウザの合成太字になって輪郭が濁る
   font-weight: 700;
-  // 従来のゼブラと同じ中立グレー。Zenn は青みのある #edf2f7 だが、
-  // 本ブログの配色では水色に寄って浮くため、見慣れた無彩色をそのまま使う。
+  // 地は面の段（surface-*）から選び、表のための専用の値は持たない。
+  // #f2f2f2 のような中間の値は surface-tint との相互比が 1.027 で、
+  // 区別できない差に別の役割を割り当てることになる（ink の #616161 /
+  // #6e6e6e を1つにまとめたのと同じ理由 #2534 / #2743）。
+  // ヘッダは静止した面なので、状態を表す surface-mute ではなく tint 側。
+  // Zenn は青みのある #edf2f7 だが、本ブログの配色では水色に寄って浮く。
   // 中のインラインコードの地はこの値から code-bg() で導く (#2487)
-  background-color: table-header-bg;
+  background-color: surface-tint;
 }
 // インラインコードの地色 #eee はヘッダの地色とほぼ同じ明度で、そのままだと溶ける。
 // ヘッダ内では一段暗くして、本文セル（白地に #eee）と同じ「浮いて見える」関係を保つ。
 // 濃さの決め方は note の中と同じ規則（code-bg）に寄せた。以前は #e2e2e2 の
 // 固定値で、狙いは同じなのに導き方が2つに分かれていた (#2487)
 .article-entry th code {
-  background: code-bg(table-header-bg);
+  background: code-bg(surface-tint);
 }
 .highlight .pre {
   margin-bottom: 50px;
@@ -3689,7 +3692,7 @@ note-alert-bg = #ffdbdb
 
    ヘッダは同じ note のインラインコードと同じ規則（code-bg）で導く。
    「note の中の一段濃い面」が1つの規則で説明でき、値を個別に決めずに済む。
-   地との差は 1.07〜1.22 で、白地の表（#f2f2f2 と白で 1.06）と同程度。
+   地との差は 1.07〜1.22 で、白地の表（ヘッダの surface-tint と白で 1.09）と同程度。
 
    罫線 #ccc は共通のまま変えない。線が示すのは表の構造で、地の色に
    染めると表ごとに濃さが変わり構造の読み取りが不安定になる。


### PR DESCRIPTION
表のヘッダだけが専用の値 `#f2f2f2` を持っていて、面の段から外れていた。面の変数 `surface-tint` に寄せて、面の段を3つに戻す。

## 変えたもの

| | before | after |
| --- | --- | --- |
| `th` の地 | `table-header-bg` = #f2f2f2（`theme-styles.styl` のローカル変数） | `surface-tint` = #f5f5f5 |
| `th` 内のインラインコードの地 | #e3e3e3 | #e6e6e6（`code-bg()` が追従） |

`table-header-bg` は消した。

## なぜ surface-tint か

- `#f2f2f2` と `surface-tint` の相互比は **1.027**。#2534 が「並べても判別できず、区別できない差に2つの役割を割り当てていた」として統合した `#616161` / `#6e6e6e` の 1.215 よりさらに小さい
- もう一方の `surface-mute`（#eee）は「空のプレースホルダ・focus の地」で、**状態**を表す段。表のヘッダは静止した面なので `surface-tint`（hover・チップの地）側に置いた
- `#eee` にすると本文セルのインラインコードの地と同値になり、コードだけのセルがヘッダ行と同じ濃さで並ぶ

## 数字

| | 白セルとの差 | ヘッダ内 code と地の差 | 本文 #424242 とのコントラスト |
| --- | --- | --- | --- |
| before #f2f2f2 | 1.119 | 1.146 | 8.98 |
| after #f5f5f5 | 1.090 | **1.145** | 9.22 |

ヘッダ内のインラインコードは `code-bg()`（明度 ×0.94）で導いているので、地を動かしても「浮いて見える」関係（#2487）は 1.146 → 1.145 でそのまま保たれる。

## 検証

`make css` で出た `public/css/site.css` を機械で確認した。

- `th { background-color: #f5f5f5 }` / `.article-entry th code { background: #e6e6e6 }`
- `#f2f2f2` の残存は **0件**
- note の中の `th`（#dfe1e6 / #d1f1cc / #faf2c9 / #fdc0c0）は**変化なし**。note の地から導いているため（#2520）

コメント内の数値を1つ直した。`note` の表のコメントにあった「白地の表（#f2f2f2 と白で 1.06）」は、同じコメント中の他の数値（1.07〜1.22 / 1.25〜1.52 / 1.61）を再計算すると全て一致するのに対しここだけ合わず、正しくは 1.119 だった。値の変更に合わせて「ヘッダの surface-tint と白で 1.09」にした。

## 範囲外

- #2746（色を CSS カスタムプロパティへ寄せる）… この PR は Stylus 変数の中での寄せ直しに留める
- #2747（フラット化）・#2732（グレー地）… 面の**役割**を変える話なので触らない

Closes #2743
