### PR TITLE
折りたたみの見出しの hover の背景色を surface-mute に揃える (#2749)

### DIFF
--- a/themes/future/css-src/_variables.styl
+++ b/themes/future/css-src/_variables.styl
@@ -24,8 +24,8 @@ rule-strong = #ccc    // focus / hover でひとつ強める
 
 // 面は白地との差だけで意味を出す。濃くすると文字のコントラストが動くため、
 // 白に近い2段に留める
-surface-tint = #f5f5f5 // hover・チップ・表のヘッダの地
-surface-mute = #eee    // 空のプレースホルダ・focus の地・インラインコードの地
+surface-tint = #f5f5f5 // 静止した面。チップ・タブ帯・表のヘッダ
+surface-mute = #eee    // hover / focus の面と、空・無効の面・インラインコードの地
 
 // Colors
 // 元テーマ由来のグレー（color-default #555 / color-grey #999 /

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -278,7 +278,7 @@ h4 {
   transform: rotate(90deg);
 }
 .article-entry details > summary:hover {
-  background-color: surface-tint;
+  background-color: surface-mute;
 }
 /* 中身との間隔も summary 側で持つ。子要素の margin-top では
    コードブロック（margin: 0）に負ける */
@@ -1237,13 +1237,8 @@ th, td {
 th {
   // 900 は Hiragino / Yu Gothic に該当ウェイトが無く、ブラウザの合成太字になって輪郭が濁る
   font-weight: 700;
-  // 地は面の段（surface-*）から選び、表のための専用の値は持たない。
-  // #f2f2f2 のような中間の値は surface-tint との相互比が 1.027 で、
-  // 区別できない差に別の役割を割り当てることになる（ink の #616161 /
-  // #6e6e6e を1つにまとめたのと同じ理由 #2534 / #2743）。
-  // ヘッダは静止した面なので、状態を表す surface-mute ではなく tint 側。
-  // Zenn は青みのある #edf2f7 だが、本ブログの配色では水色に寄って浮く。
-  // 中のインラインコードの地はこの値から code-bg() で導く (#2487)
+  // 地は面の段から選び、表のための専用の値は持たない (#2743)。
+  // Zenn は青みのある #edf2f7 だが、本ブログの配色では水色に寄って浮く
   background-color: surface-tint;
 }
 // インラインコードの地色 #eee はヘッダの地色とほぼ同じ明度で、そのままだと溶ける。
@@ -1815,6 +1810,10 @@ ul.tag-list {
   font-weight: bold;
   /* サイドバーの「目次」と同じ規格 (#2483) */
   font-size: 14px;
+  transition: background-color hover-speed ease;
+}
+.toc-mobile > summary:hover {
+  background-color: surface-mute;
 }
 /* 開いたときだけ見出しと中身を線で分ける */
 .toc-mobile[open] > summary {


### PR DESCRIPTION
「details の hover のグレーはサイト標準か」の確認結果と、外れていた2箇所の修正。

## 調べた結果

`theme-styles.styl` で hover に背景色を敷くルールは16件あり、**15件が `surface-mute`（#eee）、1件だけ `surface-tint`（#f5f5f5）**だった。その1件が本文の `details`。#2686 で行の背景色を `surface-tint` → `surface-mute` に揃えたときの取りこぼしにあたる（当時のコメントに「以前はここだけ surface-tint で一段薄かった」と残っている）。

折りたたみは3種類あり、同じ「開く」操作の反応が3通りに割れていた。

| 部品 | before | after |
| --- | --- | --- |
| 本文の `details`（60記事・195ブロック） | `surface-tint` の背景 | **`surface-mute`** |
| モバイル目次 `.toc-mobile`（全記事） | 反応なし | **`surface-mute`**（`:hover` を追加） |
| 「残り N本を表示」（参照記事・関連記事・ランキング） | 文字色 `ink-mute` → `ink-strong` | 変更なし |

## 「残り N本を表示」を変えなかった理由

枠の中に既に収まっていて背景色は要らない、という判断。文字色がサイト標準に沿っているかだけ確認した。

- 基底 `ink-mute` → hover `ink-strong` は #2686 の「単独のテキストリンクは基底が ink-mute なら ink-strong に一段濃く」どおり
- 同じ形のリンク（パンくず・日付・著者名・カテゴリ・著者一覧・連載ナビ等10箇所）はいずれも `text-decoration: underline` を伴うが、ここには無い。**下線は付けないままにした**。ページ遷移するリンクではなく開閉のスイッチで、下線を付けると「別ページへ行く」の合図と紛れる

## モバイル目次に `:hover` を足した根拠

`.toc-mobile` は幅1024px以下で出るが、対象はタッチ専用端末だけではない（ウィンドウを狭めたPC、ポインタを繋いだタブレット）。そのうえ**この枠の中の項目（`.toc-section a`）は既に `surface-mute` で反応する**ので、見出しの「目次」だけ反応が無い状態だった。同じ枠の中で挙動を揃える。

`transition` は基底側（`.toc-mobile > summary`）に置いた（hover 側に書くと往きだけ送られて戻りが瞬時になる）。

## 役割コメントの修正

`_variables.styl` の宣言が実装とズレていたので直した。tint 側に `hover`、mute 側に `focus` と書いてあったが、実装では hover も focus も `surface-mute` を使う。

```styl
surface-tint = #f5f5f5 // 静止した面。チップ・タブ帯・表のヘッダ
surface-mute = #eee    // hover / focus の面と、空・無効の面・インラインコードの地
```

## ついでに（別件の手直し）

#2743 で `th` に付けた6行の説明コメントを2行に削った。経緯や計測値をコードに書かない方針に合わせたもので、動作に関わる制約（面の段から選ぶ）だけ残している。この PR から外したい場合はこの hunk だけ戻せる。

## 検証

`make css` で出た `public/css/site.css` を機械で確認した。

- `.article-entry details > summary:hover { background-color: #eee }`
- `.toc-mobile > summary { transition: background-color 0.05s ease }` / `.toc-mobile > summary:hover { background-color: #eee }`
- **hover で `#f5f5f5` を使うルールは 0件**になった

Closes #2749
