### PR TITLE
ホームの Lighthouse 指摘に対応する (#2748)

### DIFF
--- a/css.mjs
+++ b/css.mjs
@@ -4,8 +4,8 @@
 // 処理が毎回走るため。書き出し0ファイルでも同じ）。CSS の見た目を確かめる
 // だけならページの再生成は要らないので、連結済みの CSS を直接置き換える。
 //
-// 連結の順序と内容は scripts/combine_css.js と同じにすること。
-// あちらが公開ビルドの正で、ここはその写し。順序を変えると表示が壊れる。
+// 連結そのものは公開ビルド（scripts/combine_css.js）と同じ
+// scripts/lib/site_css.js を呼ぶ。ここが持つのは Stylus の描画だけ。
 import { readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -13,6 +13,7 @@ import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 const stylus = require('stylus');
+const { combineCss } = require('./scripts/lib/site_css');
 
 const root = dirname(fileURLToPath(import.meta.url));
 const themeDir = join(root, 'themes/future');
@@ -23,14 +24,11 @@ stylus.render(readFileSync(stylPath, 'utf8'), { filename: stylPath }, (err, css)
     console.error(err.message);
     process.exit(1);
   }
-  const combined = [
-    '/* bootstrap-subset.css */',
-    readFileSync(join(themeDir, 'css-src/bootstrap-subset.css'), 'utf8'),
-    '/* metronic/assets/style.css */',
-    readFileSync(join(themeDir, 'metronic-src/assets/style.css'), 'utf8'),
-    '/* theme-styles.styl */',
-    css,
-  ].join('\n');
+  const combined = combineCss({
+    bootstrap: readFileSync(join(themeDir, 'css-src/bootstrap-subset.css'), 'utf8'),
+    metronic: readFileSync(join(themeDir, 'metronic-src/assets/style.css'), 'utf8'),
+    themeStyles: css,
+  });
 
   const out = join(root, 'public/css/site.css');
   writeFileSync(out, combined);

--- a/scripts/combine_css.js
+++ b/scripts/combine_css.js
@@ -4,6 +4,7 @@ const path = require('path');
 const fs = require('hexo-fs');
 const fsNode = require('fs');
 const crypto = require('crypto');
+const { combineCss } = require('./lib/site_css');
 
 // CSS の URL に付ける内容ハッシュ。URL が /css/site.css 固定だと、
 // スタイルを変えてもブラウザがキャッシュを返し続けて反映されない。
@@ -26,8 +27,7 @@ hexo.extend.helper.register('css_version', function () {
  * Lighthouse でも「レンダリングをブロックしているリクエスト」として
  * 約290msの削減余地が指摘されていた。
  *
- * 読み込み順は従来の head.ejs と同じ（Bootstrap → metronic → テーマ）。
- * CSS は後勝ちなので、この順序を変えると表示が壊れる。
+ * 連結そのものは scripts/lib/site_css.js が持つ（make css と共用）。
  *
  * 元ファイルは themes/future/source/ の外（css-src / metronic-src）に置いている。
  * source/ 配下だと Hexo が public/ にそのまま複製してしまい、
@@ -45,17 +45,8 @@ hexo.extend.generator.register('site_css', async function () {
     engine: 'styl',
   });
 
-  const combined = [
-    '/* bootstrap-subset.css */',
-    bootstrap,
-    '/* metronic/assets/style.css */',
-    metronic,
-    '/* theme-styles.styl */',
-    themeStyles,
-  ].join('\n');
-
   return {
     path: 'css/site.css',
-    data: combined,
+    data: combineCss({ bootstrap, metronic, themeStyles }),
   };
 });

--- a/scripts/lib/site_css.js
+++ b/scripts/lib/site_css.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/**
+ * 配信する /css/site.css の組み立て。
+ *
+ * 公開ビルド（scripts/combine_css.js）と開発用の make css（css.mjs）の
+ * 両方から呼ぶ。以前は同じ連結をそれぞれが持っていて、片方だけ直すと
+ * 手元と本番で違う CSS を見ることになっていた。
+ */
+
+/**
+ * コメントを落とす。設計判断を書いた日本語のコメントが連結後の半分を占めて
+ * おり、そのぶんレンダリングを待たせている。
+ *
+ * 文字列リテラルは読み飛ばす。content: "/*" のような値をコメントの開始と
+ * 見なすと、そこから次の閉じまでが丸ごと消える。
+ */
+function stripComments(css) {
+  return css
+    .replace(/"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\/\*[\s\S]*?\*\//g, (m) =>
+      m.startsWith('/*') ? '' : m,
+    )
+    .replace(/[ \t]+$/gm, '')
+    .replace(/\n{2,}/g, '\n');
+}
+
+/**
+ * 読み込み順は従来の head.ejs と同じ（Bootstrap → metronic → テーマ）。
+ * CSS は後勝ちなので、この順序を変えると表示が壊れる。
+ */
+function combineCss({ bootstrap, metronic, themeStyles }) {
+  return [
+    '/* bootstrap-subset.css */',
+    stripComments(bootstrap),
+    '/* metronic/assets/style.css */',
+    stripComments(metronic),
+    '/* theme-styles.styl */',
+    stripComments(themeStyles),
+  ].join('\n');
+}
+
+module.exports = { stripComments, combineCss };

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -72,7 +72,9 @@
   margin-left: 5px;
   border-radius: 999px !important;
   border: none;
-  color: #868c93;
+  /* metronic 由来の #868c93 は白地で 3.39 しかなく WCAG AA に届かない。
+     添えのリンクの段（白地で 6.19）に寄せる */
+  color: ink-mute;
   padding: 6px 12px;
   position: relative;
   float: left;

--- a/themes/future/layout/_partial/head.ejs
+++ b/themes/future/layout/_partial/head.ejs
@@ -175,7 +175,9 @@
   <link rel="canonical" href="<%= url.replace("index.html", "") %>">
   <meta content="<%= keywords %>" name="keywords">
   <meta content="<%= author %>" name="author">
-  <link rel="preload" as="image" href="/banner.jpg" />
+  <%# ヘッダの背景。モバイルの LCP 要素なので、preload だけだと Low 優先度で
+      取得され表示が遅れる %>
+  <link rel="preload" as="image" href="/banner.jpg" fetchpriority="high" />
   <link rel='manifest' href='/manifest.webmanifest'/>
   <%# bootstrap-subset / metronic / theme-styles を1本にまとめたもの。生成は scripts/combine_css.js %>
   <link rel="stylesheet" href="/css/site.css?v=<%= css_version() %>">


### PR DESCRIPTION
添付の Lighthouse レポート（モバイル / performance 0.89・accessibility 0.96）を読み、名指しされた2件と、その隣で一番効く1件に対処した。

## 1. LCP 画像のプリロードに `fetchpriority="high"`

LCP 要素はヘッダの背景（`/banner.jpg`）で、`head.ejs` で preload 済みだった。ただしレポートの network-requests を見ると **priority は Low のまま**で、`lcp-discovery-insight` の3つのチェックのうち `priorityHinted` だけが false だった。preload はリクエストを早く出すだけで優先度は上げないので、ヒントを足す。

記事本文の先頭画像に `fetchpriority="high"` を付ける `scripts/lcp_image_priority.js` と同じやり方に揃えた形。

## 2. ページャの文字色（accessibility 0.96 → コントラスト違反 0件）

`color-contrast` で落ちていた3件はすべて `#page-nav` の中のリンク（ページ番号と「次のページ」）だった。

| | 色 | 白地でのコントラスト比 |
| --- | --- | --- |
| before | `#868c93`（metronic 由来の直値） | **3.39** |
| after | `ink-mute` = `#616161` | **6.19** |

`#868c93` は色の役割（#2534）の外にある直値で、AA の 4.5 に届いていない。添えのリンクの段である `ink-mute` に寄せた。hover の `--brand-navy` ＋ `surface-mute` はそのまま（この組み合わせは 14.08）。

同じ `#868c93` は metronic 側の `.pagination > li > a` と `.items-info` にも残っているが、どちらも**このサイトのマークアップに一致しない**（ページャは `li` を挟まない・`items-info` は使っていない）ので触っていない。

## 3. 配信する CSS からコメントを落とす（本文の半分がコメントだった）

レポートは `unminified-css`（28 KiB）と `render-blocking-insight`（450ms）を挙げていた。中身を測ると、**連結後 206KB のうち 108KB（53%）がコメント**で、しかもその 87KB が日本語だった。設計判断を書いたコメントで、これは保守者のためのもので読者に配る必要が無い。

`scripts/lib/site_css.js` を作り、連結時にコメントを落とすようにした。

| | 生 | gzip 後（＝実際に転送される量） |
| --- | --- | --- |
| before | 206,629 bytes | 68,349 bytes |
| after | 97,634 bytes | **24,847 bytes** |

レンダリングをブロックする唯一のリクエストが **69.8KB → 24.8KB** になる。空白の圧縮まで足しても gzip 後はさらに 1.1KB しか減らないので、**コメント除去だけに留めた**。空白を潰す変換は `content` の値や `calc()` を壊しうるのに対し、コメント除去は文字列リテラルさえ読み飛ばせば安全という違いがある。

連結は `scripts/combine_css.js`（公開ビルド）と `css.mjs`（`make css`）が同じコードを2つ持っていて、「同じにすること」とコメントで縛っていた。片方だけ直すと手元と本番で違う CSS を見ることになるので、`scripts/lib/mermaid.js` と同じやり方で共通化した。

### 壊れていないことの確認

before / after の `public/css/site.css` を独立にパースして、**セレクタと宣言の並びが一致すること**を確認した。

- ルールブロック **802 個 → 802 個**、差分は**意図した1ブロック（`.pagination > a, .pagination > span` の `color`）だけ**
- 波括弧 851 / 851、`@media` 44、`@keyframes` 1、`@supports` 1 も一致
- 文字列リテラルの中に `/*` を含む箇所は **0件**（含んでいてもスキップする実装だが、現状も確認した）
- `hexo server` が配信する CSS と `make css` の出力が**バイト一致**

## 今回やらなかったもの

レポートの残りは、こちらで直せないか、別の判断が要る。

| 指摘 | 理由 |
| --- | --- |
| `unused-css-rules` 49 KiB（72%） | 全ページで1本の `site.css` を共用しているため。ページ別に割るのは構成の判断が要る |
| `cache-insight` 634 KiB | キャッシュ 10 分は GitHub Pages 固定でヘッダを設定できない |
| `unused-javascript` 52 KiB / `forced-reflow-insight` 262ms | どちらも `gtag.js`。第三者のコード |
| `unminified-javascript` 2 KiB | 計測環境の Chrome 拡張のスクリプト。サイトのものではない |
| `image-delivery-insight` 472 KiB | サムネイル15枚。月次の pngquant / jpegoptim の運用か WebP 化の話で、別建てにしたい |

Closes #2748
