### PR TITLE
期間ページの一覧を年・月で束ね、記事リンクの色を揃える (#2754)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1883,8 +1883,23 @@ ul.tag-list {
 }
 .article-list .title {
   text-decoration: none;
-  color: #1a75ff;
   font-size: 1.1em;
+}
+/* 記事へのリンクは本文ではないので、月ページのカード一覧
+   （.archive-post-item a）と同じ ink-strong に揃える (#2754)。
+   hover の下線は metronic の a:hover が持つ */
+.article-list .title a {
+  color: ink-strong;
+}
+/* 年・月の区切り。罫線を持たず直前の空きで階層を作るのは
+   .article-entry h3 と同じ。サイズだけは一覧の行に合わせて本文と同じ 1.2em */
+.article-list-period {
+  margin: 32px 0 10px;
+  font-size: 1.2em;
+  font-weight: 700;
+}
+.article-list-period:first-child {
+  margin-top: 0;
 }
 
 /*Archive*/

--- a/themes/future/layout/_partial/archive-all.ejs
+++ b/themes/future/layout/_partial/archive-all.ejs
@@ -1,14 +1,34 @@
+<%# 期間の一覧を時系列で並べる。全期間は年ごと、年ページは月ごとに束ねる (#2754)。
+    月ページはカード一覧（_partial/archive-post）なのでここを通らない %>
 <div class="row">
   <main class="blog-posts">
-      <%# アーカイブページの最後の要素なので footer-gap でフッター前の間隔を持つ %>
-      <ul class="article-list footer-gap">
-        <% page.posts.each(function(post, i){ %>
-        <li>
-          <span class="date"><%= date(post.date, 'YYYY.MM.DD') %></span>
-          <span class="count">&#9825;<%= totalSNSCnt(post.permalink) %></span>
-          <span class="title"><a href="<%- url_for(post.path) %>" title="<%= post.lede %>"><%= post.title %></a></span>
-        </li>
+    <%
+      const groups = [];
+      page.posts.each(function(post){
+        const key = is_year() ? post.date.format('MM') : post.date.format('YYYY');
+        if (!groups.length || groups[groups.length - 1].key !== key) {
+          groups.push({key: key, posts: []});
+        }
+        groups[groups.length - 1].posts.push(post);
+      });
+    %>
+    <% groups.forEach(function(group, gi){ %>
+    <%
+      const id = is_year() ? 'posts-' + page.year + '-' + group.key : 'posts-' + group.key;
+      const label = is_year() ? Number(group.key) + '月' : group.key + '年';
+    %>
+    <%# アンカーの形は _partial/section-heading と同じ。アイコンと末尾への移動は headerlink.js が補う %>
+    <h3 id="<%= id %>" class="article-list-period"><a href="#<%= id %>" class="headerlink" title="<%= label %>"></a><%= label %></h3>
+    <%# アーカイブページの最後の要素なので footer-gap でフッター前の間隔を持つ %>
+    <ul class="article-list<%= gi === groups.length - 1 ? ' footer-gap' : '' %>">
+      <% group.posts.forEach(function(post){ %>
+      <li>
+        <span class="date"><%= date(post.date, 'YYYY.MM.DD') %></span>
+        <span class="count">&#9825;<%= totalSNSCnt(post.permalink) %></span>
+        <span class="title"><a href="<%- url_for(post.path) %>" title="<%= post.lede %>"><%= post.title %></a></span>
+      </li>
       <% }) %>
     </ul>
+    <% }) %>
   </main>
 </div>


### PR DESCRIPTION
期間ページ（`/articles/` と `/articles/年/`）の記事一覧に年・月の区切りを入れ、記事へのリンクの色を揃える。

## 1. 記事へのリンクを ink-strong に揃える

同じ「記事へのリンク」が2色に割れていた。

| ページ | 一覧の形 | タイトルの色 |
| --- | --- | --- |
| 月ページ `/articles/2026/08/` | カード（`_partial/archive-post`） | `ink-strong` `#424242` |
| 年・全期間 | テキストの年表（`_partial/archive-all`） | **リンクの青 `#0072E5`** |

本文ではないので、月ページのカード一覧に合わせて `ink-strong` にした。hover の下線は metronic の `a:hover` が持つのでそのまま出る。日付・シェア数（`ink-faint` `#757575`）との差も保てる。

`.article-list .title` に書いてあった `color: #1a75ff` は削除した。**この値は元から表示に出ていない**（色が付いているのは `span.title` で、中の `<a>` は `a { color: var(--a-color) }` を持つため）。ついでに、白地で 4.17 と WCAG AA を下回る値でもあった。

## 2. 年・月の区切りを入れる

| ページ | 区切り | 本数 |
| --- | --- | --- |
| `/articles/` | 年ごと（`2026年`） | **11本** / 1,475件 |
| `/articles/年/` | 月ごと（`12月`） | 稼働月ぶん（8〜12本） |
| `/articles/年/月/` | **入れない** | — |

投稿の無い月は見出しを出さない（束ねる元が記事なので自動的に外れる）。

### 見出しは h3

issue には「h2」とあったが **h3 にした**。このページの構成は 統計 → グラフ → 定番 → 探索 → **記事一覧（h2）** で、年・月の区切りはその h2 の中に入る。h2 にすると「記事一覧」と同列になり、見出しの階層が崩れる。

### 見た目は太字だけ

```styl
.article-list-period {
  margin: 32px 0 10px;
  font-size: 1.2em;
  font-weight: 700;
}
.article-list-period:first-child {
  margin-top: 0;
}
```

**罫線は引かない。** `.article-entry h3` が罫線を持たず、直前の空き（32px）と太さ（700）だけで階層を作っているので、それに合わせた。マージンも `.article-entry h3`（`32px` / `10px`）と同じ値にしている。サイズだけは一覧の行に合わせて 1.2em（15.6px）で、本文の h3（1.5em）より小さい。

`id` と `headerlink` は `_partial/section-heading` と同じ形で付けた（`#posts-2020`、`#posts-2025-12`）。アイコンと見出し末尾への移動は `scripts/headerlink.js` が全ページの HTML に対して行うので、テンプレート側は空のアンカーを置くだけでよい。1,475件の中の特定の年に直接飛べるようになる。

マークアップは「h3 ＋ その年の `<ul>`」の繰り返しにした。`<ul>` の直下に置けるのは `<li>` だけなので、見出しをリストの中に入れる形は取らない。

## 検証

配信中の HTML をパースして、見出しごとの件数を**フロントマターの直接集計と突き合わせた**。

```
=== /articles/ ===
見出し 11 本 / 行 1475 件 / 見出し内合計 1475 件
  2026年  101 本   2026.08.21 〜 2026.01.14
  2025年  186 本   2025.12.29 〜 2025.01.09
  2024年  180 本   2024.12.27 〜 2024.01.09
  2023年  185 本   2023.12.27 〜 2023.01.05
  2022年  207 本   2022.12.28 〜 2022.01.06
  2021年  280 本   2021.12.28 〜 2021.01.07
  2020年  198 本   2020.12.28 〜 2020.01.15
  2019年   75 本   2019.12.27 〜 2019.01.02
  2018年   14 本   2018.12.05 〜 2018.02.09
  2017年   28 本   2017.12.17 〜 2017.01.09
  2016年   21 本   2016.12.09 〜 2016.02.16
```

- **11年ぶんの件数がすべて一致**（`source/_posts/**/*.md` の `date` を数えた値と同じ）。合計 1,475 = 行数
- `/articles/2025/` も12ヶ月ぶん一致（4 / 7 / 11 / 21 / 25 / 17 / 17 / 18 / 22 / 26 / 10 / 8）
- 各グループの先頭と末尾の日付が年・月の境界に収まっている（並びは新しい順のまま）
- `/articles/2026/08/` は `article-list-period` が **0個**、カードが12個で従来どおり
- 生成 CSS に `#1a75ff` は **0件**
- h3 の前にあるのは空白のテキストノードだけなので `:first-child` が当たり、最初の見出しの上の空きは 0 になる

`textlint` は変更した `.ejs` で 0件。`scripts/` と記事は触っていないので prettier / 記事の textlint は対象外。

Closes #2754
