### PR TITLE
Best Blogger of the Year の導線を2つ足す (#2760)

### DIFF
--- a/scripts/awards.js
+++ b/scripts/awards.js
@@ -44,12 +44,30 @@ hexo.extend.helper.register('article_award', function (post) {
 
 hexo.extend.helper.register('author_awards', function (author) {
   const rows = (this.site.data && this.site.data.awards) || [];
-  const years = rows
-    .filter((r) => r.author === author)
-    .map((r) => r.year)
-    .sort((a, b) => b - a); // 新しい年を先に
-  if (years.length === 0) return null;
-  return { years, hallOfFame: years.length >= HALL_OF_FAME_WINS };
+  const mine = rows.filter((r) => r.author === author).sort((a, b) => b.year - a.year); // 新しい年を先に
+  if (mine.length === 0) return null;
+  // 受賞年のバッジは代表記事へのリンクにする (#2760)。article が無い年
+  // （2020年）と、書かれていても記事が見つからない場合は article を null で
+  // 返し、EJS 側はリンクにしない
+  const years = mine.map((r) => {
+    const post = r.article ? this.site.posts.findOne({ path: `articles/${r.article}/` }) : null;
+    return {
+      year: r.year,
+      article: post ? post.path : null,
+      title: post ? post.title : null,
+    };
+  });
+  return { years, hallOfFame: mine.length >= HALL_OF_FAME_WINS };
+});
+
+// 賞の名前から受賞発表・振り返りの記事一覧へ飛ばす (#2760)。URL は
+// _config.yml の tag_map で変わりうるので、名前からタグの path を引く。
+// タグが無ければ null を返し、EJS 側はリンクにしない
+const AWARD_TAG = 'ベスブロ';
+
+hexo.extend.helper.register('award_tag_path', function () {
+  const tag = this.site.tags && this.site.tags.findOne({ name: AWARD_TAG });
+  return tag ? tag.path : null;
 });
 
 // /authors/ の表彰一覧 (#2409)。受賞バッジは著者ページにしか出ないため、

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2817,6 +2817,17 @@ a.series-nav-item:hover .series-nav-item-title {
   margin: 10px 0 6px;
   font-weight: bold;
 }
+/* 賞の名前はタグの一覧へのリンク (#2760)。パネルの見出しの位置にあるので
+   青くせず、反応は下線で返す（.awards-hall-name / .author-list-link と同じ規則） */
+.summary-panel .award-name a {
+  color: ink-strong;
+  text-decoration: none;
+}
+.summary-panel .award-name a:hover,
+.summary-panel .award-name a:focus {
+  color: ink-strong;
+  text-decoration: underline;
+}
 .award-badges {
   display: flex;
   flex-wrap: wrap;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -3045,12 +3045,32 @@ a.article-award:focus {
 .award-badge svg {
   flex: none;
 }
+/* バッジは li の中に入っている（リンクになる年だけ <a>）。li は箱としてだけ
+   使うので、中のバッジが高さいっぱいに揃うよう flex にする */
+.award-badges li {
+  display: flex;
+}
 /* アイコンは共有部品（.svg-icon）。バッジは gap で間隔を取るので、
    部品側の右マージンは打ち消す */
 .award-badge .svg-icon {
   width: 1.15em;
   height: 1.15em;
   margin-right: 0;
+}
+/* 受賞年のバッジは代表記事へのリンクになる (#2760)。形は変えず、下線を外して
+   hover / focus では枠と地だけを一段強める。color を書かないと Bootstrap の
+   a / a:hover が勝って青くなる。色を動かさない理由は a.article-award と
+   同じで、メダルの色が受賞回数を表しているため */
+a.award-badge {
+  color: ink-strong;
+  text-decoration: none;
+  transition: background-color hover-speed ease, border-color hover-speed ease;
+}
+a.award-badge:hover,
+a.award-badge:focus {
+  border-color: rule-strong;
+  background: surface-mute;
+  color: ink-strong;
 }
 /* 殿堂入り（3回受賞）だけ金（#8a6d1a: 対 白文字 4.90。AA充足） */
 .award-badge-hall {

--- a/themes/future/layout/_partial/award-name.ejs
+++ b/themes/future/layout/_partial/award-name.ejs
@@ -1,0 +1,4 @@
+<%# 賞の名前。ベスブロタグの一覧があればリンクにする (#2760)。
+    前後に空白を出さないよう各行を閉じる（地の文の途中に差し込むため） -%>
+<% const awardTagPath = award_tag_path(); -%>
+<% if (awardTagPath) { %><a href="<%- url_for(awardTagPath) %>" title="Best Blogger of the Year の発表・振り返りの記事へ">Best Blogger of the Year</a><% } else { %>Best Blogger of the Year<% } -%>

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -44,16 +44,25 @@
       <% if (awards) { %>
       <section class="summary-panel">
         <span class="summary-panel-label">表彰</span>
-        <p class="award-name">Best Blogger of the Year</p>
+        <p class="award-name"><%- partial('_partial/award-name') %></p>
         <%# 殿堂入り（最上位の称号）を先頭に、受賞年は新しい順 %>
+        <%# バッジは li の中に入れる。リンクになる年とならない年があり、
+            li 自体を pill にすると <a> を入れられない %>
         <ul class="award-badges">
           <% if (awards.hallOfFame) { %>
-          <li class="award-badge award-badge-hall"><%- partial('_partial/svg-icon', {icon: 'crown'}) %>殿堂入り</li>
+          <li><span class="award-badge award-badge-hall"><%- partial('_partial/svg-icon', {icon: 'crown'}) %>殿堂入り</span></li>
           <% } %>
           <%# years は新しい順。メダルの色・数字は「何回目の受賞か」で決まるので、
-              古い方から数え直して渡す %>
+              古い方から数え直して渡す。代表記事が分かる年はそこへ飛ばす (#2760) %>
           <% awards.years.forEach(function(y, i){ %>
-          <li class="award-badge"><%- partial('_partial/award-medal', {nth: awards.years.length - i}) %><%= y %></li>
+          <% const medal = partial('_partial/award-medal', {nth: awards.years.length - i}); %>
+          <li>
+            <% if (y.article) { %>
+            <a class="award-badge" href="<%- url_for(y.article) %>" title="<%= y.year %>年の選出記事「<%= y.title %>」へ"><%- medal %><%= y.year %></a>
+            <% } else { %>
+            <span class="award-badge"><%- medal %><%= y.year %></span>
+            <% } %>
+          </li>
           <% }) %>
         </ul>
       </section>

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -98,7 +98,7 @@
           並びは確定構成の「定番」枠に相当する位置（グラフの後・一覧の前） %>
       <%- partial('_partial/section-heading', {id: 'awards', text: 'Best Blogger of the Year'}) %>
       <%# .specials-text は名前こそ特設ページ由来だが実体は「本文サイズの地の文」 %>
-      <p class="specials-text">Best Blogger of the Year は、社外に影響を与えた記事を執筆した著者を年1回表彰する取り組みです。累計3回の受賞で殿堂入りします。</p>
+      <p class="specials-text"><%- partial('_partial/award-name') %> は、社外に影響を与えた記事を執筆した著者を年1回表彰する取り組みです。累計3回の受賞で殿堂入りします。</p>
       <% const awards = awards_list(); %>
       <%# 殿堂入りは年1回の表彰の主役なので、金のカードで大きく称える。
           各年の受賞者は著者ページのバッジと同じチップで淡々と並べ、


### PR DESCRIPTION
Best Blogger of the Year の導線を2つ足した。

## 1. 賞の名前を `/tags/ベスブロ/` へのリンクにする

/authors/ の説明文の「Best Blogger of the Year」がリンクになる。賞の名前を出す場所は
著者ページの表彰パネルにもあり、同じ文字列が片方だけリンクだと不揃いなので、
`_partial/award-name.ejs` に切り出して両方から使う形にした（**issue の指定は /authors/ だけ。
著者ページ側は揃えるために足している**）。

URL を直書きせず、タグ名から `path` を引いている（`_config.yml` の `tag_map` で
URL のスラッグが変わりうる。`ネットワーク` → `Network` の前例がある）。
タグが無くなったら `null` を返し、リンクにせず素のテキストで出す。

## 2. 著者ページの受賞年バッジを選出記事へのリンクにする

`awards.yml` の `article`（代表記事のID）へ飛ばす。

- **リンクになるのは15件**（2021〜2025年）。**2020年の3件はリンクにならない**
  （記録に記事の指定が無い。`awards.yml` にそう書かれている）
- 記事IDが書かれていても記事が見つからなければリンクにしない。
  awards.yml の打ち間違いで404へ飛ばさないため
- 殿堂入りのバッジ（王冠）はリンクにしない。特定の記事に対応しないので行き先が無い
- `title` は「2022年の選出記事「〈記事タイトル〉」へ」。バッジには年しか出ないので、
  行き先を補う。「選出記事」は記事側のバッジ (#2422) と同じ言い方に揃えた

見た目は変えていない。`a.award-badge` は下線を外し、hover / focus で枠と地を一段強めるだけ
（`a.article-award` / `.award-chip` と同じ規則）。**色は動かさない** — メダルの色が
受賞回数（灰→銅→金）を表しているため。`color` を明示しているのは、書かないと
Bootstrap の `a` / `a:hover` が勝って青くなるから。

## 構造の変更

バッジは `<li class="award-badge">` から `<li>` の中の `<a>` / `<span>` に変えた。
リンクになる年とならない年があり、`li` 自体を pill にすると `<a>` を入れられない。
`li` は箱としてだけ使うので、中のバッジが高さいっぱいに揃うよう
`.award-badges li { display: flex }` を足した。

## 検証

`hexo generate` した HTML と、`hexo server` の配信で確認した。

- リンクになったバッジ **15件** ＝ `awards.yml` の `article` あり15件（年・著者・href が全件一致）
- リンクにならないバッジ **3件** ＝ 2020年の3件
- `href` は全件 `/articles/YYYYMMDD<postid>/` の形。`title` に空・`null` は無い
- /authors/ の説明文と著者ページの賞名が、どちらも `/tags/ベスブロ/` へのリンクになっている
- 殿堂入りバッジは `<span>`（非リンク）のまま
- prettier「All matched files use Prettier code style!」／ textlint（変更した `.ejs`）exit 0

Closes #2760
