### PR TITLE
1記事だけのタグのチップが記事メタ行を膨らませるのを直す (#2764)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1537,8 +1537,14 @@ code {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+  /* 既定の stretch だと、余白を持つチップが1つ混じるだけで行の全チップが
+     その高さまで伸びる。行の他の項目と同じ baseline に揃える (#2764) */
+  align-items: baseline;
 }
-.blog-info-tags .tag-list-link {
+/* 1記事だけのタグは非リンクの .tag-list-text で描かれる。
+   どちらも margin を落とさないと gap に上乗せされる (#2764) */
+.blog-info-tags .tag-list-link,
+.blog-info-tags .tag-list-text {
   margin: 0;
 }
 /* 狭い画面では記事のメタ行を3行に分ける (#2738)。1行目「いつ・誰が」、
@@ -1704,8 +1710,10 @@ ul.tag-list {
    慣習で、これが無いとツールチップの存在に気づけない。
    li ではなく span に掛けるのは、li だと padding-left の空白にまで
    点線が伸びてしまうため。
-   タグは a に title を持つので span[title] なら巻き込まない */
-.blog-info-item span[title] {
+   対象は文字数・PV に限る。`.blog-info-item span[title]` と広く取ると
+   1記事だけのタグ（非リンクの .tag-list-text）も巻き込み、
+   チップの中に点線が引かれる (#2764) */
+.blog-info-metric span[title] {
   cursor: help;
   text-decoration: underline dotted #bbb;
   text-underline-offset: 3px;


### PR DESCRIPTION
/articles/20191128/ でタグのチップが膨らんでいた原因は、**記事数が1件のタグ**（このページの `fluentd`）が非リンクの `.tag-list-text` で描かれるのに、CSS の手当てが `.tag-list-link` にしか入っていなかったこと。2箇所外れていた。

## 1. margin の打ち消し漏れ → 行の全チップが縦に伸びる

#2125 でチップの間隔を `margin` から親の `gap` に移したとき、`margin: 0` の打ち消しを `.tag-list-link` にしか書いていなかった。`.tag-list-text` は `margin: 4px 6px 7px 4px` を持ったままで、`.blog-info-tags` は `align-items` が既定の `stretch` なので、**余白を持つチップが1つ混じるだけで行の全チップがその高さまで伸びる**。

| | チップの高さ | 行の高さ |
| --- | --- | --- |
| before | リンク 21.8px / 非リンク 21.8px + margin 11px | 32.8px |
| after | 21.8px | 21.8px |

打ち消しを両方に効かせたうえで、`align-items: baseline`（行の他の項目と同じ）を明示した。余白の混入で伸びること自体を止めておく。

## 2. ツールチップの点線がチップの中に引かれる

`.blog-info-item span[title]` の点線（`underline dotted` ＋ `cursor: help`）は文字数・PV の目印だが、`.tag-list-text` も `title` を持つ `span` なので拾われ、**ピルの中に点線が引かれていた**。元のコメントは「タグは `a` に title を持つので巻き込まない」としていたが、1記事だけのタグは `span` なので当てはまらない。対象を `.blog-info-metric span[title]` に狭めた（この行で `span[title]` を持つのは文字数と PV だけ）。

## 残した差

太さの違い（リンクは bold、非リンクは通常）はそのまま。この行では日付・著者・カテゴリ・タグのリンクが `ink-mute` ＋ bold、文字数・PV の素のテキストが通常で、**太さが「押せるかどうか」を示している**。1記事だけのタグは押せないので通常のままが正しい。

## 範囲

- 1記事だけのタグは 43件、記事 1,475本のうち **43本（2.9%）** に出る。「特定の記事で」がこれ
- 記事ページと一覧ページの両方に出る。一覧は `.blog-info-tags` を使わないので 1 は起きず、2 だけが起きていた
- CSS 1ファイル。`_partial/post/tag.ejs` は変えていない（`tag.length > 1` で非リンクにするのは、記事1本しか無いタグページへ読者を送らないための意図的な分岐）

Closes #2764

🤖 Generated with [Claude Code](https://claude.com/claude-code)
