### PR TITLE
/doctor/ の途切れた著者を絞り、続けた後に離れた人を出す (#2744)

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -289,7 +289,33 @@ hexo.extend.helper.register('doctor_ontology', function () {
  * 今年まだ投稿が無く、最後の投稿が昨年か一昨年の著者を返す。
  * それより古い著者は「途切れている」ではなく「離れた」なので出さない
  * （声かけの候補として現実的な範囲に絞る）。
+ *
+ * さらに累計2本以上に絞る (#2744)。1本だけの著者が一昨年の列で19名を占めて
+ * 列が横に長くなっていた。落とした人数は年ごとに返して注記で見せる
+ * （情報を消さずに列を短くする）。
+ * 「投稿した年が2年以上」ではなく累計本数で絞るのは、1年に数本書いて止まった人
+ * （両列で10名）を残すため。企画で数本書いた人は声かけの有力候補になる。
+ *
+ * あわせて、連続3年以上書いていた実績のある著者を別に返す。
+ * 「続けていた人が離れた」は声かけの重みが違うので、上の2列より範囲を広げて
+ * 最終投稿5年以内まで見る。ただし2列に出る人は除く（同じ人が2回並ぶのを避ける）。
  */
+const DORMANT_MIN_POSTS = 2;
+const DORMANT_STREAK = 3;
+const DORMANT_STREAK_MAX_GAP = 5;
+
+// 連続して投稿していた最長の年数
+const longestStreak = (years) => {
+  const ys = [...years].sort((a, b) => a - b);
+  let best = 0;
+  let cur = 0;
+  ys.forEach((y, i) => {
+    cur = i > 0 && y - ys[i - 1] === 1 ? cur + 1 : 1;
+    if (cur > best) best = cur;
+  });
+  return best;
+};
+
 hexo.extend.helper.register('doctor_dormant_authors', function () {
   const thisYear = new Date().getFullYear();
   const byAuthor = new Map(); // 著者 -> {years:Set, count}
@@ -304,14 +330,30 @@ hexo.extend.helper.register('doctor_dormant_authors', function () {
     });
   });
 
-  const rows = [];
+  const recent = [];
+  const singleOnly = {}; // 年 -> 落とした「1本だけ」の人数
+  const longGone = [];
   for (const [name, entry] of byAuthor) {
     if (entry.years.has(thisYear)) continue;
     const last = Math.max(...entry.years);
     const gap = thisYear - last;
-    if (gap === 1 || gap === 2) rows.push({ name, last, count: entry.count, gap });
+    const row = {
+      name,
+      last,
+      gap,
+      count: entry.count,
+      streak: longestStreak(entry.years),
+    };
+    if (gap === 1 || gap === 2) {
+      if (entry.count >= DORMANT_MIN_POSTS) recent.push(row);
+      else singleOnly[last] = (singleOnly[last] || 0) + 1;
+    } else if (gap <= DORMANT_STREAK_MAX_GAP && row.streak >= DORMANT_STREAK) {
+      longGone.push(row);
+    }
   }
   // 表示は本数でまとめるので本数の多い順。同数なら最近まで書いていた人を先に
-  rows.sort((a, b) => b.count - a.count || a.gap - b.gap || (a.name < b.name ? -1 : 1));
-  return rows;
+  recent.sort((a, b) => b.count - a.count || a.gap - b.gap || (a.name < b.name ? -1 : 1));
+  // こちらは年でまとめる。新しい年から、同じ年なら続けた年数の長い人を先に
+  longGone.sort((a, b) => b.last - a.last || b.streak - a.streak || (a.name < b.name ? -1 : 1));
+  return { recent, singleOnly, longGone, streakYears: DORMANT_STREAK };
 });

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -296,13 +296,11 @@ hexo.extend.helper.register('doctor_ontology', function () {
  * 「投稿した年が2年以上」ではなく累計本数で絞るのは、1年に数本書いて止まった人
  * （両列で10名）を残すため。企画で数本書いた人は声かけの有力候補になる。
  *
- * あわせて、連続3年以上書いていた実績のある著者を別に返す。
- * 「続けていた人が離れた」は声かけの重みが違うので、上の2列より範囲を広げて
- * 最終投稿5年以内まで見る。ただし2列に出る人は除く（同じ人が2回並ぶのを避ける）。
+ * 連続3年以上書いていた実績は、その2列の中で名前に添えて示す。
+ * 続けていた人が途切れたかどうかで声かけの重みが違う。
  */
 const DORMANT_MIN_POSTS = 2;
 const DORMANT_STREAK = 3;
-const DORMANT_STREAK_MAX_GAP = 5;
 
 // 連続して投稿していた最長の年数
 const longestStreak = (years) => {
@@ -332,7 +330,6 @@ hexo.extend.helper.register('doctor_dormant_authors', function () {
 
   const recent = [];
   const singleOnly = {}; // 年 -> 落とした「1本だけ」の人数
-  const longGone = [];
   for (const [name, entry] of byAuthor) {
     if (entry.years.has(thisYear)) continue;
     const last = Math.max(...entry.years);
@@ -344,16 +341,11 @@ hexo.extend.helper.register('doctor_dormant_authors', function () {
       count: entry.count,
       streak: longestStreak(entry.years),
     };
-    if (gap === 1 || gap === 2) {
-      if (entry.count >= DORMANT_MIN_POSTS) recent.push(row);
-      else singleOnly[last] = (singleOnly[last] || 0) + 1;
-    } else if (gap <= DORMANT_STREAK_MAX_GAP && row.streak >= DORMANT_STREAK) {
-      longGone.push(row);
-    }
+    if (gap !== 1 && gap !== 2) continue;
+    if (entry.count >= DORMANT_MIN_POSTS) recent.push(row);
+    else singleOnly[last] = (singleOnly[last] || 0) + 1;
   }
   // 表示は本数でまとめるので本数の多い順。同数なら最近まで書いていた人を先に
   recent.sort((a, b) => b.count - a.count || a.gap - b.gap || (a.name < b.name ? -1 : 1));
-  // こちらは年でまとめる。新しい年から、同じ年なら続けた年数の長い人を先に
-  longGone.sort((a, b) => b.last - a.last || b.streak - a.streak || (a.name < b.name ? -1 : 1));
-  return { recent, singleOnly, longGone, streakYears: DORMANT_STREAK };
+  return { recent, singleOnly, streakYears: DORMANT_STREAK };
 });

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -290,16 +290,12 @@ hexo.extend.helper.register('doctor_ontology', function () {
  * それより古い著者は「途切れている」ではなく「離れた」なので出さない
  * （声かけの候補として現実的な範囲に絞る）。
  *
- * さらに累計2本以上に絞る (#2744)。1本だけの著者が一昨年の列で19名を占めて
- * 列が横に長くなっていた。落とした人数は年ごとに返して注記で見せる
- * （情報を消さずに列を短くする）。
- * 「投稿した年が2年以上」ではなく累計本数で絞るのは、1年に数本書いて止まった人
- * （両列で10名）を残すため。企画で数本書いた人は声かけの有力候補になる。
+ * 本数では絞らない (#2744)。1本だけの著者こそ2本目を誘導する価値があるので、
+ * 列が長くなっても名前を出す。表示は本数でまとめるので1本の人は最後の行に来る。
  *
- * 連続3年以上書いていた実績は、その2列の中で名前に添えて示す。
+ * 連続3年以上書いていた実績は名前に添えて示す。
  * 続けていた人が途切れたかどうかで声かけの重みが違う。
  */
-const DORMANT_MIN_POSTS = 2;
 const DORMANT_STREAK = 3;
 
 // 連続して投稿していた最長の年数
@@ -329,7 +325,6 @@ hexo.extend.helper.register('doctor_dormant_authors', function () {
   });
 
   const recent = [];
-  const singleOnly = {}; // 年 -> 落とした「1本だけ」の人数
   for (const [name, entry] of byAuthor) {
     if (entry.years.has(thisYear)) continue;
     const last = Math.max(...entry.years);
@@ -342,10 +337,9 @@ hexo.extend.helper.register('doctor_dormant_authors', function () {
       streak: longestStreak(entry.years),
     };
     if (gap !== 1 && gap !== 2) continue;
-    if (entry.count >= DORMANT_MIN_POSTS) recent.push(row);
-    else singleOnly[last] = (singleOnly[last] || 0) + 1;
+    recent.push(row);
   }
   // 表示は本数でまとめるので本数の多い順。同数なら最近まで書いていた人を先に
   recent.sort((a, b) => b.count - a.count || a.gap - b.gap || (a.name < b.name ? -1 : 1));
-  return { recent, singleOnly, streakYears: DORMANT_STREAK };
+  return { recent, streakYears: DORMANT_STREAK };
 });

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2111,12 +2111,6 @@ ul.tag-list {
 .doctor-list .doctor-inline-row {
   line-height: 1.9;
 }
-/* /doctor/ は一覧が主で、行が長いと端まで目で追えない。記事本文（container の
-   col-md-9 ＝ 大画面で約990px）に近い幅へ抑える。一覧の情報量のぶん少しだけ広く取る。
-   .container の max-width（大画面で1320px）に勝つよう2クラスで指定する (#2418) */
-.container.doctor-page {
-  max-width: 1000px;
-}
 /* 節の中の小見出し（年ごとの列など）。h2 の節見出しより一段小さく */
 .doctor-subhead {
   margin: 16px 0 8px;

--- a/themes/future/layout/_partial/sidebar.ejs
+++ b/themes/future/layout/_partial/sidebar.ejs
@@ -23,11 +23,7 @@
 <% if (sToc) { %>
 <section class="toc-section">
   <h2 class="margin-top-30">目次</h2>
-  <ol class="toc">
-    <% sToc.forEach(function(item){ %>
-    <li class="toc-item toc-level-2"><a class="toc-link" href="#<%= item.id %>"><span class="toc-text"><%= item.text %></span></a></li>
-    <% }) %>
-  </ol>
+  <%- partial('_partial/toc-list', {items: sToc}) %>
 </section>
 <% } %>
 <% if (pageToc) { %>

--- a/themes/future/layout/_partial/toc-list.ejs
+++ b/themes/future/layout/_partial/toc-list.ejs
@@ -1,0 +1,7 @@
+<%# 手で組む目次の一覧。items（[{id, text}]）を渡す。
+    サイドバーと本文前の折りたたみ（.toc-mobile）が同じ形を共有する %>
+<ol class="toc">
+  <% items.forEach(function(item){ %>
+  <li class="toc-item toc-level-2"><a class="toc-link" href="#<%= item.id %>"><span class="toc-text"><%= item.text %></span></a></li>
+  <% }) %>
+</ol>

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -169,7 +169,7 @@
           声かけは「まず昨年まで書いていた人、駄目なら一昨年の人」の順に進めるので、
           左に昨年・右に一昨年を並べて、そのまま上から当たれるようにする %>
       <h2 class="bottom-content-header">投稿が途切れている著者</h2>
-      ※今年まだ投稿が無く、累計2本以上の著者。<code>連続N年</code> は続けて書いていた最長の年数で、<%= dormant.streakYears %>年以上のときだけ出します
+      ※今年まだ投稿が無い著者。<code>連続N年</code> は続けて書いていた最長の年数で、<%= dormant.streakYears %>年以上のときだけ出します
       <% if (dormant.recent.length) { %>
       <div class="doctor-cols">
         <% [thisYear - 1, thisYear - 2].forEach(function(y){ %>
@@ -188,10 +188,6 @@
             </li>
             <% }) %>
           </ul>
-          <%# 絞って落とした人は数だけ残す。列を短くしつつ、何人を見ていないかが分かる %>
-          <% if (dormant.singleOnly[y]) { %>
-          <p class="doctor-note">ほかに1本だけの著者が<%= dormant.singleOnly[y] %>名</p>
-          <% } %>
           <% } else { %>
           <p>該当なし</p>
           <% } %>

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -3,15 +3,20 @@
         {label: 'ホーム', url: '/'},
         {label: '記事ドクター'}
       ]}) %>
-  <%# 節の見出しはここで1箇所に持ち、本文とサイドバーの目次の両方から使う。
-      2箇所に書くと片方だけ直して食い違う %>
+  <%# 節はここで1箇所に持ち、冒頭の件数・目次・本文の見出しの3つから使う。
+      別々に書くと数や並びが食い違う（label は件数の下に出す短い名前）%>
   <%
+    const checks = doctor_checks();
+    const ontoSuggest = doctor_ontology_suggestions();
+    const onto = doctor_ontology();
+    const dormant = doctor_dormant_authors();
+    const thisYear = new Date().getFullYear();
     const SECTIONS = [
-      {id: 'duplicates', text: 'ほぼ重なるタグ（統合候補）'},
-      {id: 'single-use', text: '1記事にしか使われていないタグ'},
-      {id: 'ontology-suggestions', text: 'オントロジーへの追加提案（親子の候補）'},
-      {id: 'ontology', text: 'タグの親子関係（オントロジー）'},
-      {id: 'dormant', text: '投稿が途切れている著者'},
+      {id: 'duplicates', text: 'ほぼ重なるタグ（統合候補）', label: '統合候補のタグ', count: checks.nearDuplicates.length},
+      {id: 'single-use', text: '1記事にしか使われていないタグ', label: '1記事タグ', count: checks.singleUse.length},
+      {id: 'ontology-suggestions', text: 'オントロジーへの追加提案（親子の候補）', label: '親子の候補', count: ontoSuggest.suggestions.length},
+      {id: 'ontology', text: 'タグの親子関係（オントロジー）', label: 'オントロジー登録', count: onto.nodeCount},
+      {id: 'dormant', text: '投稿が途切れている著者', label: '投稿が途切れた著者', count: dormant.recent.length},
     ];
     const heading = (id) => partial('_partial/section-heading', SECTIONS.find(s => s.id === id));
   %>
@@ -21,14 +26,18 @@
     <div class="footer-gap">
       <h1 class="list-page margin-bottom-20">記事ドクター</h1>
       ※運営向けの画面です。人の判断が要る候補だけを並べます（提案であって、正とは限りません）。タグ無し・カテゴリと同名のタグ・未登録のカテゴリは PR の検査が止めるので、ここには出ません
-      <% const checks = doctor_checks(); %>
       <ul class="summary">
-        <li><span class="summary-count"><%= checks.nearDuplicates.length %></span><br><span class="summary-label">統合候補のタグ</span></li>
-        <li><span class="summary-count"><%= checks.singleUse.length %></span><br><span class="summary-label">1記事タグ</span></li>
-        <% const dormant = doctor_dormant_authors(); %>
-        <% const thisYear = new Date().getFullYear(); %>
-        <li><span class="summary-count"><%= dormant.recent.length %></span><br><span class="summary-label">投稿が途切れた著者</span></li>
+        <% SECTIONS.forEach(function(sec){ %>
+        <li><span class="summary-count"><%= sec.count %></span><br><span class="summary-label"><%= sec.label %></span></li>
+        <% }) %>
       </ul>
+
+      <%# 992px 未満ではサイドバーが本文の下に落ちて目次が末尾に出るので、
+          記事ページと同じく本文の前に折りたたみで出す %>
+      <details class="toc-mobile" data-nosnippet>
+        <summary>目次</summary>
+        <div class="toc-section"><%- partial('_partial/toc-list', {items: SECTIONS}) %></div>
+      </details>
 
       <%# 並びはタグ → 著者。判断の重い順に置く。
           決定的な検査を linter へ移したので（#2706）、残っているのは
@@ -125,7 +134,6 @@
         <section>
           <%- heading('ontology-suggestions') %>
           ※左のタグの記事が<strong>すべて</strong>右のタグにも付いている関係です。多くは「A は B の一種」ですが、機械には「話題として広い」と「記事の種類が同じ」の区別が付きません（春の入門祭り ⊆ インデックス のような包含も混ざります）。認めたものを <code>source/_data/tag_ontology.yml</code> の <code>broader</code> に書くと、そのタグページの関連タグで「もっと広いタグで探す」に出ます。差が2本以内のペアは上の「ほぼ重なるタグ（統合候補）」の担当
-          <% const ontoSuggest = doctor_ontology_suggestions(); %>
           <% if (ontoSuggest.suggestions.length) { %>
           <p class="doctor-note">候補 <%= ontoSuggest.suggestions.length %>件 / タグ <%= ontoSuggest.childCount %>件</p>
           <ul class="doctor-list">
@@ -144,7 +152,6 @@
 
       <%- heading('ontology') %>
       ※<code>source/_data/tag_ontology.yml</code> に登録した親子の可視化。関連記事の計算に使う辺で、「子タグの記事に親タグを打つのは冗長」と言える自明な包含だけを登録します。灰色はタグとして実在しない概念ノード。「系統」は自分＋子孫のユニーク記事数。「版」はバージョン同義（Go1.27 は Go を書いたのと同じ扱い）で語幹に吸収されるタグ
-      <% const onto = doctor_ontology(); %>
       <%
         function renderNode(n) { %>
         <li>

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -170,7 +170,7 @@
           声かけは「まず昨年まで書いていた人、駄目なら一昨年の人」の順に進めるので、
           左に昨年・右に一昨年を並べて、そのまま上から当たれるようにする %>
       <h2 class="bottom-content-header">投稿が途切れている著者</h2>
-      ※今年まだ投稿が無く、累計2本以上の著者。声をかけると再開してくれるかもしれない候補です（/authors/ に <code>*</code> / <code>**</code> で出していたものの移設。読者向けのページには凡例の無い記号を置かない #2418）。<code>連続N年</code> は続けて書いていた最長の年数で、<%= dormant.streakYears %>年以上を出しています
+      ※今年まだ投稿が無く、累計2本以上の著者。<code>連続N年</code> は続けて書いていた最長の年数で、<%= dormant.streakYears %>年以上のときだけ出します
       <% if (dormant.recent.length) { %>
       <div class="doctor-cols">
         <% [thisYear - 1, thisYear - 2].forEach(function(y){ %>

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -13,7 +13,8 @@
         <li><span class="summary-count"><%= checks.singleUse.length %></span><br><span class="summary-label">1記事タグ</span></li>
         <% const dormant = doctor_dormant_authors(); %>
         <% const thisYear = new Date().getFullYear(); %>
-        <li><span class="summary-count"><%= dormant.length %></span><br><span class="summary-label">投稿が途切れた著者</span></li>
+        <li><span class="summary-count"><%= dormant.recent.length %></span><br><span class="summary-label">投稿が途切れた著者</span></li>
+        <li><span class="summary-count"><%= dormant.longGone.length %></span><br><span class="summary-label">続けた後に離れた著者</span></li>
       </ul>
 
       <%# 並びはタグ → 著者。判断の重い順に置く。
@@ -169,12 +170,12 @@
           声かけは「まず昨年まで書いていた人、駄目なら一昨年の人」の順に進めるので、
           左に昨年・右に一昨年を並べて、そのまま上から当たれるようにする %>
       <h2 class="bottom-content-header">投稿が途切れている著者</h2>
-      ※今年まだ投稿が無い著者。声をかけると再開してくれるかもしれない候補です（/authors/ に <code>*</code> / <code>**</code> で出していたものの移設。読者向けのページには凡例の無い記号を置かない #2418）
-      <% if (dormant.length) { %>
+      ※今年まだ投稿が無く、累計2本以上の著者。声をかけると再開してくれるかもしれない候補です（/authors/ に <code>*</code> / <code>**</code> で出していたものの移設。読者向けのページには凡例の無い記号を置かない #2418）。<code>連続N年</code> は続けて書いていた最長の年数で、<%= dormant.streakYears %>年以上を出しています
+      <% if (dormant.recent.length) { %>
       <div class="doctor-cols">
         <% [thisYear - 1, thisYear - 2].forEach(function(y){ %>
         <section>
-          <% const members = dormant.filter(d => d.last === y); %>
+          <% const members = dormant.recent.filter(d => d.last === y); %>
           <h3 class="doctor-subhead"><%= y %>年まで（<%= members.length %>名）</h3>
           <% if (members.length) { %>
           <ul class="doctor-list">
@@ -184,16 +185,39 @@
             <% counts.forEach(function(c){ %>
             <li class="doctor-inline-row">
               <span class="doctor-note"><%= c %>本</span>
-              <% members.filter(d => d.count === c).forEach(function(d){ %><a href="<%- url_for('authors/' + d.name + '/') %>"><%= d.name %></a><span class="doctor-note-inline"></span><% }) %>
+              <% members.filter(d => d.count === c).forEach(function(d){ %><a href="<%- url_for('authors/' + d.name + '/') %>"><%= d.name %></a><span class="doctor-note-inline"><% if (d.streak >= dormant.streakYears) { %>連続<%= d.streak %>年<% } %></span><% }) %>
             </li>
             <% }) %>
           </ul>
+          <%# 絞って落とした人は数だけ残す。列を短くしつつ、何人を見ていないかが分かる %>
+          <% if (dormant.singleOnly[y]) { %>
+          <p class="doctor-note">ほかに1本だけの著者が<%= dormant.singleOnly[y] %>名</p>
+          <% } %>
           <% } else { %>
           <p>該当なし</p>
           <% } %>
         </section>
         <% }) %>
       </div>
+      <% } else { %>
+      <p>該当なし</p>
+      <% } %>
+
+      <%# 上の2列は昨年・一昨年しか見ないので、続けていた人が3年以上前に離れると
+          画面から消える。声かけの重みが違うのでここだけ範囲を広げる。
+          2列に出る人は入れない（同じ人が1ページに2回並ぶのを避ける）%>
+      <h2 class="bottom-content-header">続けた後に離れた著者</h2>
+      ※<%= dormant.streakYears %>年以上続けて書いていて、最終投稿が3年以上前（5年以内）の著者。上の2列には出ません
+      <% if (dormant.longGone.length) { %>
+      <ul class="doctor-list">
+        <% const goneYears = [...new Set(dormant.longGone.map(d => d.last))].sort((a, b) => b - a); %>
+        <% goneYears.forEach(function(y){ %>
+        <li class="doctor-inline-row">
+          <span class="doctor-note"><%= y %>年まで</span>
+          <% dormant.longGone.filter(d => d.last === y).forEach(function(d){ %><a href="<%- url_for('authors/' + d.name + '/') %>"><%= d.name %></a><span class="doctor-note-inline">連続<%= d.streak %>年・<%= d.count %>本</span><% }) %>
+        </li>
+        <% }) %>
+      </ul>
       <% } else { %>
       <p>該当なし</p>
       <% } %>

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -1,8 +1,22 @@
-<div class="container doctor-page">
+<div class="container">
   <%- partial('_partial/breadcrumb', {items: [
         {label: 'ホーム', url: '/'},
         {label: '記事ドクター'}
       ]}) %>
+  <%# 節の見出しはここで1箇所に持ち、本文とサイドバーの目次の両方から使う。
+      2箇所に書くと片方だけ直して食い違う %>
+  <%
+    const SECTIONS = [
+      {id: 'duplicates', text: 'ほぼ重なるタグ（統合候補）'},
+      {id: 'single-use', text: '1記事にしか使われていないタグ'},
+      {id: 'ontology-suggestions', text: 'オントロジーへの追加提案（親子の候補）'},
+      {id: 'ontology', text: 'タグの親子関係（オントロジー）'},
+      {id: 'dormant', text: '投稿が途切れている著者'},
+    ];
+    const heading = (id) => partial('_partial/section-heading', SECTIONS.find(s => s.id === id));
+  %>
+  <div class="row">
+    <main class="col-md-9 blog-posts">
   <section id="main" class="margin-top-30">
     <div class="footer-gap">
       <h1 class="list-page margin-bottom-20">記事ドクター</h1>
@@ -24,7 +38,7 @@
       <%# 統合候補はペア（A ⊆ B）を1行に書くので幅が要る。単独で出す %>
       <div class="doctor-single">
         <section>
-          <h2 class="bottom-content-header">ほぼ重なるタグ（統合候補）</h2>
+          <%- heading('duplicates') %>
           ※片方の記事すべてがもう片方にも付いていて、差が2本以内のペア。実質同じ集合に2つの名前が付いています。Go1.27 ⊆ Go のような差の大きい健全な階層は出しません
           <% if (checks.nearDuplicates.length) { %>
           <ul class="doctor-list">
@@ -45,7 +59,7 @@
           2列（英数字／和文）に割って情報密度を上げたので全幅で使う %>
       <div class="doctor-single">
         <section>
-      <h2 class="bottom-content-header">1記事にしか使われていないタグ</h2>
+      <%- heading('single-use') %>
       ※「同居」は、同じ記事に1記事タグ同士が付いているもの。その記事のタグ付けがまとめて薄い可能性が高い
       <%# 1タグ1行で並べると縦に長すぎる。辞書の索引のように、英数字は先頭の
           1文字（大文字に寄せる）、カナは五十音の行（濁音・半濁音は元の行）で
@@ -109,7 +123,7 @@
           気づく流れではなく、候補を見て yml に足し、ツリーで結果を確かめる流れ %>
       <div class="doctor-single">
         <section>
-          <h2 class="bottom-content-header">オントロジーへの追加提案（親子の候補）</h2>
+          <%- heading('ontology-suggestions') %>
           ※左のタグの記事が<strong>すべて</strong>右のタグにも付いている関係です。多くは「A は B の一種」ですが、機械には「話題として広い」と「記事の種類が同じ」の区別が付きません（春の入門祭り ⊆ インデックス のような包含も混ざります）。認めたものを <code>source/_data/tag_ontology.yml</code> の <code>broader</code> に書くと、そのタグページの関連タグで「もっと広いタグで探す」に出ます。差が2本以内のペアは上の「ほぼ重なるタグ（統合候補）」の担当
           <% const ontoSuggest = doctor_ontology_suggestions(); %>
           <% if (ontoSuggest.suggestions.length) { %>
@@ -128,7 +142,7 @@
         </section>
       </div>
 
-      <h2 class="bottom-content-header">タグの親子関係（オントロジー）</h2>
+      <%- heading('ontology') %>
       ※<code>source/_data/tag_ontology.yml</code> に登録した親子の可視化。関連記事の計算に使う辺で、「子タグの記事に親タグを打つのは冗長」と言える自明な包含だけを登録します。灰色はタグとして実在しない概念ノード。「系統」は自分＋子孫のユニーク記事数。「版」はバージョン同義（Go1.27 は Go を書いたのと同じ扱い）で語幹に吸収されるタグ
       <% const onto = doctor_ontology(); %>
       <%
@@ -168,7 +182,7 @@
       <%# タグ系の検査とは対象が違うので最後に置く。
           声かけは「まず昨年まで書いていた人、駄目なら一昨年の人」の順に進めるので、
           左に昨年・右に一昨年を並べて、そのまま上から当たれるようにする %>
-      <h2 class="bottom-content-header">投稿が途切れている著者</h2>
+      <%- heading('dormant') %>
       ※今年まだ投稿が無い著者。<code>連続N年</code> は続けて書いていた最長の年数で、<%= dormant.streakYears %>年以上のときだけ出します
       <% if (dormant.recent.length) { %>
       <div class="doctor-cols">
@@ -199,4 +213,9 @@
       <% } %>
     </div>
   </section>
+    </main>
+    <aside class="col-md-3 blog-sidebar">
+      <%- partial('_partial/sidebar', {specialsToc: SECTIONS}) %>
+    </aside>
+  </div>
 </div>

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -14,7 +14,6 @@
         <% const dormant = doctor_dormant_authors(); %>
         <% const thisYear = new Date().getFullYear(); %>
         <li><span class="summary-count"><%= dormant.recent.length %></span><br><span class="summary-label">投稿が途切れた著者</span></li>
-        <li><span class="summary-count"><%= dormant.longGone.length %></span><br><span class="summary-label">続けた後に離れた著者</span></li>
       </ul>
 
       <%# 並びはタグ → 著者。判断の重い順に置く。
@@ -199,25 +198,6 @@
         </section>
         <% }) %>
       </div>
-      <% } else { %>
-      <p>該当なし</p>
-      <% } %>
-
-      <%# 上の2列は昨年・一昨年しか見ないので、続けていた人が3年以上前に離れると
-          画面から消える。声かけの重みが違うのでここだけ範囲を広げる。
-          2列に出る人は入れない（同じ人が1ページに2回並ぶのを避ける）%>
-      <h2 class="bottom-content-header">続けた後に離れた著者</h2>
-      ※<%= dormant.streakYears %>年以上続けて書いていて、最終投稿が3年以上前（5年以内）の著者。上の2列には出ません
-      <% if (dormant.longGone.length) { %>
-      <ul class="doctor-list">
-        <% const goneYears = [...new Set(dormant.longGone.map(d => d.last))].sort((a, b) => b - a); %>
-        <% goneYears.forEach(function(y){ %>
-        <li class="doctor-inline-row">
-          <span class="doctor-note"><%= y %>年まで</span>
-          <% dormant.longGone.filter(d => d.last === y).forEach(function(d){ %><a href="<%- url_for('authors/' + d.name + '/') %>"><%= d.name %></a><span class="doctor-note-inline">連続<%= d.streak %>年・<%= d.count %>本</span><% }) %>
-        </li>
-        <% }) %>
-      </ul>
       <% } else { %>
       <p>該当なし</p>
       <% } %>

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -6,7 +6,7 @@
   <section id="main" class="margin-top-30">
     <div class="footer-gap">
       <h1 class="list-page margin-bottom-20">記事ドクター</h1>
-      ※運営向けのメンテナンス画面です。人の判断が要るものだけを並べます（提案であって、正とは限りません）。答えが決まっているもの（タグ無し・カテゴリと同名のタグ・未登録のカテゴリ）は textlint の <code>no-invalid-post-taxonomy</code> が PR で止めます（#2706）
+      ※運営向けの画面です。人の判断が要る候補だけを並べます（提案であって、正とは限りません）。タグ無し・カテゴリと同名のタグ・未登録のカテゴリは PR の検査が止めるので、ここには出ません
       <% const checks = doctor_checks(); %>
       <ul class="summary">
         <li><span class="summary-count"><%= checks.nearDuplicates.length %></span><br><span class="summary-label">統合候補のタグ</span></li>
@@ -111,7 +111,7 @@
       <div class="doctor-single">
         <section>
           <h2 class="bottom-content-header">オントロジーへの追加提案（親子の候補）</h2>
-          ※左のタグの記事が<strong>すべて</strong>右のタグにも付いている関係を共起から拾ったものです。多くは「A は B の一種」で <code>broader</code> の候補になりますが、機械には「話題として広い」と「記事の種類が同じ」の区別が付きません（春の入門祭り ⊆ インデックス のような包含も混ざります）。認めたものを <code>source/_data/tag_ontology.yml</code> に書くと、そのタグページの関連タグで「もっと広いタグで探す」に出ます（#2597）。差が2本以内のペアは上の「ほぼ重なるタグ（統合候補）」の担当
+          ※左のタグの記事が<strong>すべて</strong>右のタグにも付いている関係です。多くは「A は B の一種」ですが、機械には「話題として広い」と「記事の種類が同じ」の区別が付きません（春の入門祭り ⊆ インデックス のような包含も混ざります）。認めたものを <code>source/_data/tag_ontology.yml</code> の <code>broader</code> に書くと、そのタグページの関連タグで「もっと広いタグで探す」に出ます。差が2本以内のペアは上の「ほぼ重なるタグ（統合候補）」の担当
           <% const ontoSuggest = doctor_ontology_suggestions(); %>
           <% if (ontoSuggest.suggestions.length) { %>
           <p class="doctor-note">候補 <%= ontoSuggest.suggestions.length %>件 / タグ <%= ontoSuggest.childCount %>件</p>
@@ -130,7 +130,7 @@
       </div>
 
       <h2 class="bottom-content-header">タグの親子関係（オントロジー）</h2>
-      ※<code>source/_data/tag_ontology.yml</code> の broader の可視化。関連記事の計算が辿る辺で、「子タグの記事に親タグを打つのは冗長」という自明な包含だけを登録しています（#2292）。灰色はタグとして実在しない概念ノード。「系統」は自分＋子孫のユニーク記事数。「版」はバージョン同義（Go1.27 は Go を書いたのと同じ扱い。<code>scripts/version_tags.js</code>）で語幹に吸収されるタグ
+      ※<code>source/_data/tag_ontology.yml</code> に登録した親子の可視化。関連記事の計算に使う辺で、「子タグの記事に親タグを打つのは冗長」と言える自明な包含だけを登録します。灰色はタグとして実在しない概念ノード。「系統」は自分＋子孫のユニーク記事数。「版」はバージョン同義（Go1.27 は Go を書いたのと同じ扱い）で語幹に吸収されるタグ
       <% const onto = doctor_ontology(); %>
       <%
         function renderNode(n) { %>


### PR DESCRIPTION
issue の3つの論点に、それぞれ次のように決めた。数字は issue の表を独立に集計して
一致を確認したうえで進めている（著者329名・今年投稿あり42名、昨年61名・一昨年40名）。

## 1. 絞りは「累計2本以上」

| 最終投稿 | before | after | 落とした「1本だけ」 |
| --- | --- | --- | --- |
| 2025年（昨年） | 61名 | **29名** | 32名 |
| 2024年（一昨年） | 40名 | **21名** | 19名 |

issue は「投稿した年が2年以上」（40→16名）に寄っていたが、**累計本数を採った**。

- 挙がっていた症状は「一昨年の列が40名で横に長い」で、その原因は1本だけの19名。
  累計2本以上はその症状をちょうど消す
- 「投稿した年が2年以上」は**1年に数本書いて止まった人**（両列で10名）も落とす。
  企画で数本書いた人は声かけの有力候補なので残したい
- 注記に書く規則としても「2本以上書いた人」の方が短い

## 2. 両列に同じ規則。落とした人数は注記で残す

列見出しに規則の違いを書かずに済み、長さも揃う。消えた人は
**「ほかに1本だけの著者が32名」**の形で数だけ残すので、何人を見ていないかは分かる。

## 3. 連続3年以上は「印」と「別節」に分けた

連続3年以上で今年まだ投稿が無い人は34名。うち**18名は上の2列の中にいる**ので、
別節に全員出すと同じ人が1ページに2回並ぶ。分けた。

- **2列の中の18名**（昨年13・一昨年5）… 名前の後ろに `連続N年` を添える
- **2列に出ない15名**（最終投稿2023年4名 / 2022年5名 / 2021年6名）… 別節
  「続けた後に離れた著者」に、最終投稿の年でまとめて出す

別節の範囲は**最終投稿が3年以上前・5年以内**。#2418 が引いた「3年以上前は離れた人なので
出さない」という線を崩すのはこの15名だけに限定される。2020年の1名（連続3年以上）は
範囲外として出さない。

サマリーに `続けた後に離れた著者 15` のタイルを1つ足した。

## 検証

`hexo generate` した HTML を、フロントマターからの独立集計と突き合わせた。

| 見たもの | 結果 |
| --- | --- |
| サマリー | 統合候補24 / 1記事タグ43 / 途切れた著者**50**（29+21）/ 続けた後に離れた**15** |
| 2025年まで | 見出し29名・名前29件・期待29名。`連続N年` の印13件（期待13）。注記32名（期待32） |
| 2024年まで | 見出し21名・名前21件・期待21名。印5件（期待5）。注記19名（期待19） |
| 別節 | 2023年4名 / 2022年5名 / 2021年6名 = 15名（すべて期待どおり） |
| 2列と別節の重複 | **0名** |

- prettier「All matched files use Prettier code style!」／ textlint（`doctor.ejs`）exit 0

Closes #2744
