### PR TITLE
横スクロールのつまみに色を付ける (#2775)

### DIFF
--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -16,6 +16,10 @@ highlight-green = #84a86f          // 文字列
 highlight-blue = #6897bb           // 数値・リテラル・関数
 highlight-purple = #b18ac4
 highlight-caption-background = #3c3f41   // Darcula のエディタタブ相当
+// 横スクロールのつまみ (#2775)。OS 既定の半透明の黒はこの地の上で 1.9 しかなく、
+// 出ていても位置が読めない。地に対して 4.10、本文の #a9b7c6 に対しては 1.69 で、
+// 見えるが文字と競合しない明るさにする
+highlight-scrollbar = #7f8b9c
 highlight-caption-border = #4e5254
 // 差分専用。文字列の緑（#6a8759）だと削除側の赤に対して弱く見えるため、
 // 追加・削除を同じくらいの鮮やかさに揃える
@@ -43,6 +47,8 @@ $code-block
   // 横線が残って2つの部品に見える。ブロック自身の暗さを輪郭にする (#2456)
   border: none
   overflow: auto
+  // トラックは transparent。ブロック自身の地がそのまま見える
+  scrollbar-color: highlight-scrollbar transparent
   color: highlight-foreground
   // font-size を指定しないと body の 13px を継承してしまい、
   // 本文（.article-entry p の 1.2em = 15.6px）より小さくなって読みにくい。
@@ -85,6 +91,7 @@ $line-numbers
   .highlight
     margin: 0
     overflow: auto
+    scrollbar-color: highlight-scrollbar transparent
     pre
       border: none
       margin: 0

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1212,8 +1212,12 @@ button.share-btn {
 
 /* Custom Feedly Button */
 
+/* 横に溢れる表の受け皿（table_filter.js が包む）。OS 既定のつまみは白地で
+   1.8 しかなく位置が読めない (#2775)。白地では ink-faint が 4.61。
+   トラックは transparent で地をそのまま見せる */
 .scroll {
   overflow-x: auto;
+  scrollbar-color: ink-faint transparent;
 }
 /*
   テーブルはヘッダに地色を敷き、本文行は白で揃える（Zenn と同じ構成）。


### PR DESCRIPTION
`scrollbar-color` を3箇所に足しただけ。issue の「あるべき（たたき台）」のとおり、
つまみの色を**地ごとに**決めた。

## 変えたところ

| 生成後のセレクタ | 何の受け皿か | 地 | つまみ | 対 地 |
| --- | --- | --- | --- | --- |
| `.article-entry pre` | 言語指定の無いコードブロック | `#2b2b2b` | `#7f8b9c` | **4.10** |
| `.article-entry .highlight` | 言語指定のあるコードブロック（figure が受ける） | `#2b2b2b` | `#7f8b9c` | **4.10** |
| `.scroll` | 横に溢れる表（`table_filter.js` が包む） | 白 | `ink-faint #757575` | **4.61** |

トラックはどちらも `transparent`。ブロック自身の地がそのまま見える。

`#7f8b9c` は `highlight.styl` の配色に足した。この地の上で 4.10、**本文の
`#a9b7c6` に対しては 1.69** なので、見えるがコードの文字と競合しない明るさ。
`highlight-comment #9a9a9a`（5.03）を流用しなかったのは、コメント文字と
スクロールバーで役割が違う色を1つの値に相乗りさせないため。

note の中のコードブロックは `.article-entry .highlight` に含まれるので同じ扱いになる。

## ブランド色を使わなかった理由

issue の表を独立に計算して確認した。**ネイビーは暗いコードブロックの上で
既定より悪くなる。**

| つまみの色 | `#2b2b2b` の上 | 白の上 |
| --- | --- | --- |
| 既定に近い黒 `#555` | 1.90 | 7.46 |
| `--brand-navy` `#0A1461` | **1.15** | 16.34 |
| `--brand-crimson` `#D5004A` | 2.65 | 5.35 |
| `#7f8b9c`（採用・暗い地） | **4.10** | 2.66 |
| `ink-faint`（採用・白地） | 3.07 | **4.61** |

ブランド色は白地を前提に選んだ値なので、暗い地の部品には効かない。
クリムゾンも使っていない（塗り面とインタラクションはネイビー、クリムゾンは
フッターの波とランキング1位、という使い分けを崩さない）。

## `scrollbar-width` と `::-webkit-scrollbar` は入れていない

- `scrollbar-width: thin` は環境によって常時表示の帯になり、コードブロックの下に
  線が残る（issue の指摘どおり）。**幅は既定のまま**、色だけ変える
- `::-webkit-scrollbar` を1つでも書くと WebKit は overlay をやめて常時表示の
  カスタムスクロールバーに切り替わるため、同じ副作用が出る。まず標準の
  `scrollbar-color` だけで出し、iOS で効かないことが分かってから足すのが順序として安全

## 検証したこと / していないこと

**したこと**

- 生成された `public/css/site.css` に3つの宣言が出ている（`.article-entry pre`、
  `.article-entry .highlight`、`.scroll`）。`make css` のみで確認
- 対象記事（/articles/20260804a/）に `figure.highlight` 14件・`pre` 14件・
  `div.scroll` 2件があり、いずれも上のセレクタに掛かる
- コントラスト比は WCAG 2.1 の相対輝度から算出

**していないこと**

- **実機での見え方。** この環境にブラウザが無いため、iOS Safari / Android Chrome /
  PC での before / after は撮れていない。issue が挙げていた
  「iOS Safari の overlay スクロールバーに効くか」は**実機で確認してください**
- 効かない場合は `::-webkit-scrollbar` の併記を追加します（このPRに追いコミット）

Closes #2775
