### PR TITLE
一覧の日付を MM.DD にして、年ページの見出しに年を入れる (#2773)

### DIFF
--- a/themes/future/layout/_partial/archive-all.ejs
+++ b/themes/future/layout/_partial/archive-all.ejs
@@ -15,7 +15,9 @@
     <% groups.forEach(function(group, gi){ %>
     <%
       const id = is_year() ? 'posts-' + page.year + '-' + group.key : 'posts-' + group.key;
-      const label = is_year() ? Number(group.key) + '月' : group.key + '年';
+      // 行の日付から年を落とすぶん、束ねている見出しが年を名乗る (#2773)。
+      // h1 と重なるが、h3 はスクロール中とアンカー着地時に単独で読まれる
+      const label = is_year() ? page.year + '年' + Number(group.key) + '月' : group.key + '年';
     %>
     <%# アンカーの形は _partial/section-heading と同じ。アイコンと末尾への移動は headerlink.js が補う %>
     <h3 id="<%= id %>" class="article-list-period"><a href="#<%= id %>" class="headerlink" title="<%= label %>"></a><%= label %></h3>
@@ -23,7 +25,9 @@
     <ul class="article-list<%= gi === groups.length - 1 ? ' footer-gap' : '' %>">
       <% group.posts.forEach(function(post){ %>
       <li>
-        <span class="date"><%= date(post.date, 'YYYY.MM.DD') %></span>
+        <%# 年は見出しが持っているので行では繰り返さない。DD だけにはしない
+            （「21」の列は日付に見えない）%>
+        <span class="date"><%= date(post.date, 'MM.DD') %></span>
         <span class="count">&#9825;<%= totalSNSCnt(post.permalink) %></span>
         <span class="title"><a href="<%- url_for(post.path) %>" title="<%= post.lede %>"><%= post.title %></a></span>
       </li>


### PR DESCRIPTION
`_partial/archive-all.ejs` の2行だけ。issue の仕様どおり。

## 変えたところ

| ページ | 期間の見出し（h3） | 行の日付 |
| --- | --- | --- |
| `/articles/` | `2026年`（変更なし） | `2026.08.21` → **`08.21`** |
| `/articles/2026/` | `8月` → **`2026年8月`** | `2026.08.21` → **`08.21`** |

全期間ページは1,475行すべてが、見出しが名乗っているのと同じ年を持っていた。
年ページは逆に、行が年を持ち、束ねている見出しが年を持っていなかった。
どちらも「年は見出し、月日は行」に揃えた。

`DD` だけにはしていない（年ページは月で束ねているので理屈では落とせるが、
`21` だけの列は日付に見えない）。

## 検証

`hexo server` が配信した HTML で確認した。

| 見たもの | /articles/ | /articles/2026/ |
| --- | --- | --- |
| 日付の総数 | 1,475 | 101 |
| `YYYY.` 形式の残り | **0** | **0** |
| 日付の例 | `08.21` `08.20` `08.19` | `08.21` `08.20` `08.19` |
| 期間の見出し | `2026年` `2025年` …（11件） | `2026年8月` `2026年7月` …（8件） |
| 見出しのアンカー | あり（`#posts-2026`） | あり（`#posts-2026-08`） |

- CSS は触っていない（`.article-list .date` は幅を持たず `padding-right: 10px` だけ）
- 月ページ（`/articles/2026/08/`）はカード一覧なのでこのファイルを通らず、変化なし
- textlint（`archive-all.ejs`）exit 0

issue の実測（幅375pxで日付列 82px → 46px、2行以上の行 1,250 → 1,101）は
ブラウザが無いため再測していません。文字数は `2026.08.21`（10字）→ `08.21`（5字）です。

Closes #2773
