### PR TITLE
「よく読まれている記事」のタイトルを太字にし、サムネを大きくする (#2777)

### DIFF
--- a/scripts/lib/post_list.js
+++ b/scripts/lib/post_list.js
@@ -57,7 +57,7 @@ const postListItem = (post, itemClass, titleAttr, withThumb = false, rankMark = 
   // タイトルと重複するリンクなので、タブ移動と読み上げからは外す。
   // サムネの無い記事は同じ大きさの空き枠を置いて行頭を揃える
   const thumb = post.thumbnail
-    ? `<a href="/${post.path}" class="post-list-icon" tabindex="-1" aria-hidden="true"><img src="${post.thumbnail}" alt="" width="48" height="32" loading="lazy"></a>`
+    ? `<a href="/${post.path}" class="post-list-icon" tabindex="-1" aria-hidden="true"><img src="${post.thumbnail}" alt="" width="72" height="48" loading="lazy"></a>`
     : `<span class="post-list-icon post-list-icon-empty"></span>`;
   return `<li class="${itemClass} post-list-item-thumb">${rankLabel}${thumb}<div class="post-list-body">${body}</div></li>`;
 };

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2587,10 +2587,13 @@ a.series-nav-item:hover .series-nav-item-title {
   color: ink-strong;
 }
 /* ランキングはホームの主役なので、本文と同じ 1.2em で読ませる。
-   関連記事・参照記事は記事に付随する自動生成の情報なので 1em に留める */
+   関連記事・参照記事は記事に付随する自動生成の情報なので 1em に留める。
+   太字にするのはランキングだけ (#2777)。1行の中でタイトルと日付・反響が
+   並ぶので、太さで主従を付ける。関連記事・参照記事は付随情報なので素のまま */
 .featured-posts-item > a,
 .featured-posts-item .post-list-body > a {
   font-size: 1.2em;
+  font-weight: bold;
   color: ink-strong;
 }
 /* ランキングのサムネ (#2230)。カードにはせず、リストの密度を保ったまま
@@ -2670,8 +2673,11 @@ a.series-nav-item:hover .series-nav-item-title {
 .post-list-icon::before,
 .post-list-icon-empty {
   display: block;
-  width: 48px;
-  height: 32px;
+  /* 48×32 では何の画像か読み取れなかった (#2777)。比は 3:2 のまま 1.5倍にする。
+     サムネの実寸は幅300px・高さがばらばら（比 1.0〜3.2）なので、
+     この箱に object-fit: cover で切り取って収める */
+  width: 72px;
+  height: 48px;
   /* metronic の img { margin-bottom: 10px } が全画像に効いていて、
      このマージンが枠の中で画像を押し下げる。inline 時のベースライン
      余白と合わせて、ここで両方とも打ち消す */


### PR DESCRIPTION
## 変えたところ

| | before | after |
| --- | --- | --- |
| タイトル | 1.2em（15.6px）・太さは既定 | 1.2em・**太字** |
| サムネ | 48×32px | **72×48px**（1.5倍・比 3:2 のまま） |
| `img` の width / height 属性 | `48` / `32` | `72` / `48` |

サムネの実寸は幅300px・高さがばらばら（比 1.0〜3.2）で、`object-fit: cover` で
この箱に切り取って収める作りなので、寸法だけ変えれば比は崩れない。
`img` の属性も合わせたので、読み込み前に確保される場所がずれない。

## 太字はランキングだけ

同じ部品（`scripts/lib/post_list.js` の `postListItem`）を、ランキング・関連記事・
参照記事の3つが使っている。太字にしたのは `.featured-posts-item`（ランキング）だけ。

- ランキングは1行の中でタイトルと日付・反響が並ぶので、太さで主従を付ける
- 関連記事（`.related-posts-item`）と参照記事（`.reference-posts-item`）は記事に
  付随する自動生成の情報で、大きさも 1em に留めてある。ここを太くすると記事本文と競合する

サムネの寸法は3つで共通の箱（`.post-list-icon img` / `::before` / `-empty`）なので、
関連記事・参照記事のサムネも同じく大きくなる。**同じ見た目の3つで寸法が割れないように
1箇所で持っている**ので、ここは分けていない。

## 想定される副作用

- **行が高くなる。** これまで行の高さはサムネの32pxが決めていた（タイトル1行 ≒ 24px より
  高い）。48px になるぶん、10件のランキングで最大160px ほど縦に伸びる
- **モバイルでタイトルの幅が24px狭くなる。** 幅375pxで、順位の丸26px＋間隔6px＋
  サムネ72px＋間隔10px = 114px が本文列351pxから引かれ、タイトルに237px（現状261px）。
  タイトルの中央値は29文字なのでどちらも2行に折り返す想定で、行数は変わらない見込み

## 検証

`hexo server` が配信したホームで確認した。

- サムネの属性は `width="72" height="48"` が73件、**`48x32` の残りは0件**
- 配信 CSS に `.post-list-icon img { width: 72px; height: 48px }` と
  `.featured-posts-item ... > a { font-weight: bold }` が出ている
- サムネの無い記事の空き枠（`.post-list-icon-empty`）も同じ箱を共有しているので行頭は揃う
- prettier「All matched files use Prettier code style!」

**実機・PC での見え方は確認できていません**（この環境にブラウザが無いため）。
72×48 で足りない場合は 96×64 まで上げられます。その場合は行の高さがさらに16px増えます。

Closes #2777
