### PR TITLE
本文の見出しを text-wrap: balance で均等に折る (#2776)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,10 +396,10 @@ bootstrap-subset → metronic → theme-styles.styl の順で `/css/site.css` �
   | --- | --- | --- |
   | `body` | 13px | `theme-styles.styl` |
   | 本文（`p` / `li` / `summary`） | `1.2em` = 15.6px | 〃 |
-  | 記事タイトル | `clamp(26px, 1.325rem + 0.9vw, 32px)` ＋ `text-wrap: balance` | 〃（1箇所のみ） |
+  | 記事タイトル | `clamp(26px, 1.325rem + 0.9vw, 32px)` ＋ `text-wrap: pretty`（#2655。均等化すると「列幅の半分×2行」に縮む） | 〃（1箇所のみ） |
   | クラス無しの `h2`（関連記事・We're hiring 等） | `1.85em` = 24.05px | 〃 |
   | サイドバーの `h2` | `1.4em` = 18.2px | 〃 |
-  | 本文見出し h2〜h6 | `1.85 / 1.5 / 1.3 / 1.2 / 1.1em` = 24.05 / 19.5 / 16.9 / 15.6 / 14.3px（太さは全て700。直前の空きは h2 56px / h3 32px / h4 以下 24px） | 〃 |
+  | 本文見出し h2〜h6 | `1.85 / 1.5 / 1.3 / 1.2 / 1.1em` = 24.05 / 19.5 / 16.9 / 15.6 / 14.3px（太さは全て700。直前の空きは h2 56px / h3 32px / h4 以下 24px）＋ `text-wrap: balance`（#2776。タイトルと逆で、中央値7文字なので2行を均等に割る） | 〃 |
   | 本文見出し h1（`.article-entry h1`） | 記事タイトルと同じ（`.article-title` / `.list-page` と同一ルール。直前の空き 64px・罫線 2px はここで持つ） | 〃 |
   | 一覧ページの見出し `.list-page` | 記事タイトルと同じ（`.article-title` と同一ルール） | 〃 |
   | 一覧ページの統計（数値 / ラベル） | `clamp(17px, 1rem + 0.4vw, 20px)` / 12px | 〃 |

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -852,6 +852,23 @@ body.page-header-fixed .header {
 .article-entry h4 {
   font-feature-settings: "palt" 1;
 }
+/* 折り返した見出しの最終行が短いと、見出しと本文の隙間が3倍空いて見える (#2776)。
+   読者が見ているのは「見出しの下の10px」ではなく「ほぼ空の行23.4px ＋ 10px」。
+   幅375pxで2行になる見出しのうち、h2 は 1,245件中528件、h3 は 1,114件中504件が
+   最終行が列幅の25%未満で、均等に割ればどちらも0になる。
+   余白（h2 12px / h3 10px）は動かさない。原因は余白ではない。
+
+   記事タイトル（.article-title / .list-page / .article-entry h1）は pretty のまま。
+   あちらは中央値29文字で長く、均等化すると「列幅の半分×2行」に縮む (#2655)。
+   本文の h2 は中央値7文字で、1行をわずかに超えて2行止まりになるものが多いので
+   逆の結論になる。balance は6行までで、それより長い見出しは貪欲な折り返しに戻る */
+.article-entry h2,
+.article-entry h3,
+.article-entry h4,
+.article-entry h5,
+.article-entry h6 {
+  text-wrap: balance;
+}
 
 /* クラスでサイズを持たない h2（「関連記事」「We're hiring」「タグから記事を探す」
    サイドバーの見出しなど）。


### PR DESCRIPTION
CSS のルール1つと、`CLAUDE.md` の2行。**余白は動かしていない**（原因は余白ではない）。

```styl
.article-entry h2, h3, h4, h5, h6 {
  text-wrap: balance;
}
```

## issue の実測を独立に再現した

`source/_posts` の全記事から h2 / h3 を抜き、幅375pxの本文列（351px）に
貪欲な折り返しで当てた（全角1字を h2 22.06px / h3 18.68px、半角を半分として概算）。

| | 見出し数 | 2行以上 | 2行ちょうど | 最終行が列幅25%未満 | **balance 後** |
| --- | --- | --- | --- | --- | --- |
| h2 | 8,205 | 1,359 | 1,245 | 528 | **0** |
| h3 | 6,022 | 1,246 | 1,114 | 504 | **0** |

issue の数字（h2 8,197 / 1,366 / 1,227 / 639、h3 6,012 / 1,274 / 1,079 / 535）と
件数はほぼ一致。「最終行25%未満」だけ差が出るのは1字あたりの幅の取り方の違いで、
issue は実測値、こちらは概算。**現象と規模は同じ。**

balance 後が0になるのは定義から。2行を均等に割ると各行が全体の約半分になり、
「25%未満」になるのは見出し全体が列幅の50%未満のとき（＝そもそも折り返さない）だけ。

## 報告された記事で確かめた

`/articles/20260730a/` の見出しは12本。幅375pxで折り返すのは**この h3 だけ**だった。

| 見出し | 字数 | 幅375pxで |
| --- | --- | --- |
| `なぜジェネリクス導入時には見送られたのか` | **20字** | 2行（`…見送ら` / `れたのか`） |
| 他の11本 | 3〜13字 | すべて1行 |

「ここだけ空いて見える」のは、このページで折り返す見出しがここだけだから、という
issue の診断どおり。balance では 10字 / 10字（各行が列幅の約60%）に割れる。

## 広げなかったところ

| 部品 | 判断 |
| --- | --- |
| `.article-entry h1` / `.article-title` / `.list-page` | `pretty` のまま。中央値29文字で長く、均等化すると「列幅の半分×2行」に縮む (#2655) |
| 一覧の期間見出し `.article-list-period` | 対象外。`2026年8月` の形で**最長8文字**なので幅375pxでも折り返さない |
| クラス無しの `h2`（関連記事・We're hiring） | 対象外。`.article-entry` の外にあり、どちらも12文字以内 |

## CLAUDE.md の訂正

CSS の表に「記事タイトル … ＋ `text-wrap: balance`」と書かれていたが、**#2655 で
`pretty` に変わっている**。読んだ人が逆の前提を持つので、実装に合わせた。
本文見出しの行にも今回の `balance` を追記した。

## 検証

- 配信 CSS に `.article-entry h2〜h6 { text-wrap: balance }` が出ている。
  `text-wrap` の宣言はサイト全体で2つ（タイトルの `pretty` と今回の `balance`）
- `npx markdownlint-cli2 CLAUDE.md` … 0 error、`make fmt` で整形の副作用なし

**していないこと**: issue が求めていた 375 / 414 / 768px の before / after の
スクリーンショット。この環境にブラウザが無いため撮れていない。上の折り返しは
文字幅からの計算で、**実際の描画は確認してください**。`pretty` との比較も
同じ理由で撮れていないので、balance の見え方に納得がいかない場合は差し替えます。

Closes #2776
