### PR TITLE
反響の数で ♡ を塗り分ける (#2755)

### DIFF
--- a/scripts/lib/post_list.js
+++ b/scripts/lib/post_list.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { getSNSCnt } = require('./sns');
+const { getSNSCnt, snsHeart } = require('./sns');
 
 /**
  * 記事リストの li マークアップを組み立てる。
@@ -18,9 +18,10 @@ const { getSNSCnt } = require('./sns');
 // 数字は日付と同じ大きさに揃えたいため（#2453）
 const snsLabel = (permalink) => {
   const n = getSNSCnt(permalink);
-  return n > 0
-    ? `<span class="snscount"><span class="snscount-icon">&#9825;</span>${n}</span>`
-    : '';
+  if (n <= 0) return '';
+  const heart = snsHeart(n);
+  const cls = heart.className ? ` ${heart.className}` : '';
+  return `<span class="snscount"><span class="snscount-icon${cls}">${heart.glyph}</span>${n}</span>`;
 };
 
 // 公開から30日以内なら NEW を付ける

--- a/scripts/lib/sns.js
+++ b/scripts/lib/sns.js
@@ -23,8 +23,23 @@ const getSNSCnt = (url) => {
   );
 };
 
+// 反響の段 (#2755)。数字だけでは大小が掴めないので、白抜き → 塗り → 差し色と
+// 記号自体を変える。閾値は実データから決めた（全1,484記事）。
+//   100以上 = 148件、1000以上 = 9件
+// ホーム1ページには ♡ が72個出るが、その内訳は塗り24個・クリムゾン1個になる。
+// クリムゾンを1000以上に置いたのは「差し色は画面内で同時に1箇所」を守るため。
+// 色を持つのは記号だけで、数字は地の文の段に置く（数字まで赤いと警告に見える）
+const SNS_FILLED = 100;
+const SNS_HOT = 1000;
+
+const snsHeart = (n) => ({
+  glyph: n >= SNS_FILLED ? '&#9829;' : '&#9825;',
+  className: n >= SNS_HOT ? 'snscount-icon-hot' : '',
+});
+
 module.exports = {
   getSNSCnt: getSNSCnt,
+  snsHeart: snsHeart,
   getTwitterCnt: getTwitterCnt,
   getFacebookCnt: getFacebookCnt,
   getHatebuCnt: getHatebuCnt,

--- a/scripts/sns_count.js
+++ b/scripts/sns_count.js
@@ -7,6 +7,7 @@ const {
   getHatebuCnt,
   getPocketCnt,
   getFeedlyCnt,
+  snsHeart,
 } = require('./lib/sns');
 
 // シェア数はそのまま返す。0 のときはボタン側が数字を出さない (#2716)。
@@ -34,4 +35,11 @@ hexo.extend.helper.register('get_feedly_count', (url) => {
 
 hexo.extend.helper.register('totalSNSCnt', (url) => {
   return getSNSCnt(url);
+});
+
+// 反響の段は lib/sns.js が1箇所で持つ (#2755)。ここは記号とクラスを返すだけで、
+// 組み立ては EJS 側（_partial/archive-all.ejs）に置く
+hexo.extend.helper.register('sns_heart', (url) => {
+  const count = getSNSCnt(url);
+  return Object.assign({ count: count }, snsHeart(count));
 });

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2800,6 +2800,13 @@ a.series-nav-item:hover .series-nav-item-title {
 .snscount-icon {
   font-size: 1.15em;
 }
+/* 反響が飛び抜けている記事の記号だけ差し色にする (#2755)。全期間で9記事、
+   1画面に1個までなので「差し色は同時に1箇所」を守れる。
+   数字は地の文の段のまま（数字まで赤いと警告に見える）。
+   白地で 5.35 = AA */
+.snscount-icon-hot {
+  color: var(--brand-crimson);
+}
 /* 一覧ページ */
 .summary {
   font-weight: bold;

--- a/themes/future/layout/_partial/archive-all.ejs
+++ b/themes/future/layout/_partial/archive-all.ejs
@@ -28,7 +28,9 @@
         <%# 年は見出しが持っているので行では繰り返さない。DD だけにはしない
             （「21」の列は日付に見えない）%>
         <span class="date"><%= date(post.date, 'MM.DD') %></span>
-        <span class="count">&#9825;<%= totalSNSCnt(post.permalink) %></span>
+        <%# 反響が多い記事は記号が塗りになり、飛び抜けたものだけ差し色が付く (#2755) %>
+        <% const heart = sns_heart(post.permalink); %>
+        <span class="count"><span class="snscount-icon<%= heart.className ? ' ' + heart.className : '' %>"><%- heart.glyph %></span><%= heart.count %></span>
         <span class="title"><a href="<%- url_for(post.path) %>" title="<%= post.lede %>"><%= post.title %></a></span>
       </li>
       <% }) %>


### PR DESCRIPTION
♡ を一律クリムゾンにするのではなく、**反響の数で記号を段にした**。
「グレーを色塗りする」を、白抜き → 塗り → 差し色の3段で作っている。

## 段と実データ

| 段 | 閾値 | 記号 | 色 | 全記事 | ホーム | /articles/ |
| --- | --- | --- | --- | --- | --- | --- |
| 素 | 1〜99 | ♡ 白抜き | 地の文の段（変更なし） | 1,191 | 47個 | 1,319個 |
| 塗り | 100〜999 | **♥ 塗り** | 同じ | 148 | 24個 | 148個 |
| 差し色 | 1000以上 | ♥ 塗り | **クリムゾン** | 9 | **1個** | 8個 |

反響数の分布（全1,484記事）は中央値10・平均78・最大28,454で、上位10%が107以上、
上位1%が667以上。**100 は「上位1割」、1000 は「全期間で9記事」**に当たる。

クリムゾンを1000以上に置いたのは、`--brand-crimson` の「画面内で同時に1箇所だけの
差し色」を守るため。ホームでは1個、1,475行の全期間一覧でも8個に収まる。

**色を持つのは記号だけで、数字は地の文の段のまま。** 数字まで赤いと警告に見える。

## 一律クリムゾンにしなかった理由

ホーム1ページに ♡ は**72個**ある（ランキング・新着一覧・サイドバー）。
一律にすると赤い記号が72個並び、差し色の原則が実質無くなる。
コントラストは白地で 5.35 なので、論点は色の意味の方だけ。

## 段の判定は1箇所

`scripts/lib/sns.js` の `snsHeart(n)` が記号とクラスを返す。使うのは2系統。

- `lib/post_list.js`（ランキング・関連記事・参照記事）… JS が markup を組む既存の形
- `_partial/archive-all.ejs`（全期間・年の一覧）… ヘルパー `sns_heart` が
  データだけ返し、組み立ては EJS 側

閾値を2箇所に書くとずれるので、判定はライブラリに寄せてある。

## 副作用

全期間・年の一覧の記号を `.snscount-icon`（`font-size: 1.15em`）で包んだ。
これまでこの一覧だけ記号を包んでおらず、ランキング側にある
「記号は少し大きくしないと線が潰れる」の手当てが効いていなかった。
**記号がわずかに大きくなる**（数字の大きさは変わらない）。

## 検証

`hexo server` が配信した HTML で、段の判定を全件突き合わせた。

| ページ | 白抜き | 塗り | クリムゾン | 判定ミス |
| --- | --- | --- | --- | --- |
| ホーム | 47 | 24 | 1 | **0** |
| /articles/ | 1,319 | 148 | 8 | **0** |

判定ミスは「100以上なのに白抜き」「1000未満なのにクリムゾン」等を全行で照合した結果。
記事ページの関連記事（9件）はすべて100未満で白抜きのまま。

- prettier「All matched files use Prettier code style!」／ textlint（`archive-all.ejs`）exit 0

**実機での見え方は未確認**（この環境にブラウザが無いため）。塗りの段が地味なら、
中段にも色を持たせる（例: くすんだ赤）余地があります。

Closes #2755
