### PR TITLE
検索ボックスのフォーカスの輪郭をネイビーにする (#2796)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -962,9 +962,10 @@ blockquote p {
    反応（hover）と所在（focus）は別の役目なので、輪郭をここで1箇所持つ。
    :focus ではなく :focus-visible なので、マウスで押したときには出ない。
    色は選択・タブと同じインタラクションのネイビー。
-   タブ（.tab_item）は帯の中なので内側にずらす例外を自分で持つ */
+   タブ（.tab_item）と検索の入力欄は、帯・写真の中なので内側にずらす例外を自分で持つ */
 a:focus-visible,
 button:focus-visible,
+input:focus-visible,
 summary:focus-visible,
 [tabindex]:focus-visible {
   outline: 2px solid var(--brand-navy);
@@ -3952,6 +3953,12 @@ input[name="tab_item"] {
   border: 0;
   border-radius: radius-small 0 0 radius-small;
   background: rgba(255,255,255,0.92);
+}
+/* 輪郭は入力欄の内側に出す。ヘッダーは暗くしたバナー写真で、外側に出すと
+   ネイビーのコントラストが 2.25〜3.92 しか取れない（内側の白地なら 14.5）。
+   隣接する送信ボタンにも被らない */
+.header-search input:focus-visible {
+  outline-offset: -2px;
 }
 .header-search button {
   display: flex;


### PR DESCRIPTION
検索ボックスにフォーカスすると出ていた黒い輪郭を、サイトのネイビーに揃える。

## 何が起きていたか

キーボードのフォーカスの輪郭は `a` / `button` / `summary` / `[tabindex]` の
`:focus-visible` にネイビーで1箇所持たせている（#2686）が、**`input` がこの列に
入っていなかった**。`.header-search input` は `border: 0` なので、枠に見えていたのは
ブラウザ既定の輪郭（Chrome は黒）。テキスト入力欄はマウスで押しても
`:focus-visible` が当たるため、クリックしただけで出る。

## 直し方

共通ルールに `input:focus-visible` を足し、色はこれまでどおり1箇所で持つ。
そのうえで**検索の入力欄だけ輪郭を内側に出す**（`outline-offset: -2px`）。

ヘッダーは `banner.jpg` を暗くした写真で、輪郭を外側に出すと写真の上に乗る。
検索ボックスの位置（右上）の下地を実測した結果:

| 輪郭の位置 | 下地 | ネイビー `#0a1461` とのコントラスト |
| --- | --- | --- |
| 外側（`.header .container` の黒20%まで） | `#767B96` | 3.92 |
| 外側（`.header-overlay` の30%も乗る場合） | `#525669` | 2.25 |
| **内側（入力欄の白92%）** | `#F1F1F3` | **14.5** |

外側は図形の基準（3:1）を割る場合があり、内側なら AA（4.5）も余裕で満たす。
帯の中にあるタブ（`.tab_item`）が同じ理由で内側にずらす例外を持っているので、
形も揃う。隣接する送信ボタンに輪郭が被らない利点もある。

## 確認したこと

- `make css` 後の `public/css/site.css` で、共通ルールに `input:focus-visible` が入り、
  `.header-search input:focus-visible { outline-offset: -2px }` が後ろにあること
  （詳細度でも順序でも勝ち、後続に `input` の `outline` を触る規則が無いこと）
- サイト上の他の `input` はすべてタブ切り替え用のラジオで、
  `.chart-tabs input` / `.year-tabs input` / `input[name="tab_item"]` の
  `display: none` で隠れている。共通ルールに `input` を足しても影響はここだけ
- `npx prettier --check "scripts/**/*.js" "*.mjs"` … 通過（このPRでは JS を触っていない）

## 範囲外

検索ボックスをクリックしたときにおすすめのカテゴリ・タグを出す案（#2791）は別 PR。
常時の枠を持たせるかどうかも触っていない（今回は輪郭の色だけ）。

Closes #2796
