### PR TITLE
記事一覧を「日付 / ♡ / タイトル」の3列グリッドにする (#2793)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2462,25 +2462,36 @@ ul.tag-list {
   }
 }
 
+/* 「日付 / ♡ / タイトル」の3列。列幅は ul 単位の auto なので、
+   ♡ の列はその年（月）の最大桁に合う (#2793)。
+   字下げを li ではなくここで持つのは、subgrid の item に padding を置くと
+   端の列がそのぶん削られ、日付の列が痩せるため */
 .article-list {
-  padding-inline-start: 0px;
+  padding-inline-start: 1.2em;
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  column-gap: 10px;
+  row-gap: 8px;
 }
+/* 2行目をタイトルの左端にぶら下げるため、行は親の列をそのまま使う。
+   直前の宣言は subgrid を解さないブラウザ向けで、行ごとの auto 3列に落ちる */
 .article-list li {
   list-style: none;
-  margin-bottom: 8px;
-  padding: 0 0 0 1.2em;
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+  align-items: baseline;
+  /* 折り返しが前提の行になるので、フォント依存の normal に任せない */
+  line-height: 1.5;
 }
 .article-list .date {
-  padding-right: 10px;
   color: ink-faint;
   font-weight: bold;
 }
 .article-list .count {
-  padding-right: 5px;
   color: ink-faint;
   font-weight: bold;
-  display: inline-block;
-  min-width: 40px;
 }
 .article-list .title {
   text-decoration: none;


### PR DESCRIPTION
Closes #2793

`/articles/` と `/articles/<年>/` の一覧（`_partial/archive-all.ejs`）で、
折り返した2行目が行頭（日付の下）に回っていたのと、♡の桁数でタイトルの
開始位置が動いていたのを、CSS だけで直しました。EJS は変えていません。

## やったこと

`ul.article-list` を grid（`auto auto 1fr`）、`li` を subgrid にして
「日付 / ♡ / タイトル」を3列に割りました。

- **2行目のぶら下げ** … タイトルが3列目のブロックになるので、折り返しは
  タイトルの左端から始まる
- **開始位置** … 列幅は ul 単位の auto なので、♡の列はその年（月）の
  最大桁ちょうどになり、行ごとには動かない
- **間隔** … `column-gap: 10px` の1行に寄せた。`min-width: 40px` と
  `padding-right: 5px/10px` の3つの値でずらしていたのをやめる

字下げ（1.2em）は `li` から `ul` へ移しました。subgrid の item に padding を
置くと端の列がそのぶん削られ、日付の列が痩せるためです。

## 実測（幅375px、ヘッドレス Chrome で全1,475行を計測）

| 年 | 行数 | タイトル開始X（before） | （after） | 折り返し行 | 2行目がタイトル左端に揃う（before → after） |
| --- | ---: | --- | --- | ---: | --- |
| 2026 | 101 | 119.6 / 121.6 | 120.6 | 83 | 0 → 83 |
| 2025 | 186 | 119.6 / 121.6 | 120.6 | 149 | 0 → 149 |
| 2024 | 180 | 119.6 / 121.6 / 129.6 | 128.6 | 153 | 0 → 153 |
| 2023 | 185 | 119.6 / 121.6 / 129.6 | 128.6 | 144 | 0 → 144 |
| 2022 | 207 | 27.6 / 119.6 / 121.6 / 129.6 | 128.6 | 163 | 0 → 163 |
| 2021 | 280 | 119.6 / 121.6 / 137.6 | 136.6 | 209 | 0 → 209 |
| 2020 | 198 | 119.6 / 121.6 | 120.6 | 131 | 0 → 131 |
| 2019 | 75 | 119.6 / 121.6 / 129.6 | 128.6 | 59 | 0 → 59 |
| 2018 | 14 | 119.6 / 121.6 | 120.6 | 10 | 0 → 10 |
| 2017 | 28 | 119.6 / 121.6 | 120.6 | 18 | 0 → 18 |
| 2016 | 21 | 119.6 / 121.6 / 129.6 | 128.6 | 16 | 0 → 16 |

after は各グループで開始Xが**1値**、折り返した行は**すべて**タイトルの
左端にぶら下がります。横スクロールは幅375 / 768 / 1280 のいずれでも出ません
（`scrollWidth == clientWidth`）。

## ♡列の幅をグループごとの auto にした理由

記事1,484件のSNS合計の桁数は 1桁718 / 2桁610 / 3桁148 / 4桁7 / 5桁1件
（5桁は `/articles/20210621a/` の16250のみ）。年ごとの最大桁は
2026:3 2025:3 2024:4 2023:4 2022:4 2021:5 2020:3 2019:4 2018:3 2017:3 2016:4 で、
♡列は 37px / 45px / 53px の3通りに落ち着きます。

固定幅にするとマジックナンバーが1つ増え、5桁の1件をどう扱うかを決める必要が
出ます。グループ内で揃っていれば読者の目には十分で、年見出し（直前の空き32px）が
区切りになるため、年をまたぐ8pxのずれは並べて比較されません。

## 範囲外

- 月ページ（`/articles/<年>/<月>/`）はカード一覧（`_partial/archive-post`）で
  この partial を通らないため、変更なし
- ♡が0の行に「♡0」と出ること自体は、この issue の範囲外

🤖 Generated with [Claude Code](https://claude.com/claude-code)