### PR TITLE
1年に収まる軸のX軸ラベルを月にして幅で間引く (#2795)

### DIFF
--- a/themes/future/layout/_partial/chart-xaxis-year-labels.ejs
+++ b/themes/future/layout/_partial/chart-xaxis-year-labels.ejs
@@ -2,13 +2,15 @@
     axisLabel: <この部品>, として使い、月の配列の式とチャートの要素idを渡す
     （例: partial('_partial/chart-xaxis-year-labels', {months: 'chartData.months', el: 'chart'})）。
 
-    軸が12ヶ月以下（投稿の少ないタグ・年ページ）なら月ラベルが全部読めるので
-    そのまま出す。10年分の軸では年の変わり目だけにする（#2135）。
+    ラベルの単位は軸の長さで決める。1年に収まる軸（投稿が1年に収まる著者、
+    新しいタグ）は月まで読ませ、年の変わり目だけ年を出す。
+    10年分の軸では年の変わり目だけにする（#2135）。
 
-    ただし年の変わり目だけにしても足りない。2016〜2026年は11本あり、
-    「2016年」1本に読める間隔まで含めて約64px 要る。11本で704px なので、
-    本文カラム（約700px）でも既に重なり、狭い画面では倍以上あふれる（#2530）。
-    そこで幅に収まる本数まで年を間引く。700px なら2年ごと、375px なら3年ごと。
+    どちらも幅に収まる本数まで間引く。1本ぶんの場所は「2016年」で約64px、
+    「12月」で約34px（Noto Sans CJK 12px の実測に隣との空きを足した値）。
+    2016〜2026年の11本は間引かないと本文カラム（約700px）でも重なり、
+    狭い画面では倍以上あふれる（#2530）。月も、12本を「2025/01」の形で出すと
+    幅375pxでは5本ぶんしか場所が無い（#2795）。
 
     幅は描画時の1回だけ見る。このサイトのチャートはどれも resize を
     購読しておらず、ここだけ追従させても他の寸法が揃わない。
@@ -18,15 +20,28 @@
     軸の規則を1箇所でしか決めないための共有部品。タグ・カテゴリ・著者・
     全期間の5ページに同じ式が散ると、片方だけ直して基準がズレる %>
 (function (months, el) {
-  if (months.length <= 12) return { interval: 0 };
+  const width = (document.getElementById(el) || {}).clientWidth || 700;
+  const fit = (per) => Math.max(2, Math.floor(width / per));
+  const yearLabel = (value) => value.slice(0, 4) + '年';
+  // 年ページは月名（1月…12月）をそのまま渡してくる（get_monthly_category_data）。
+  // 言い換えるのは YYYY/MM の形のときだけ
+  const monthLabel = (value) =>
+    !/^\d{4}\/\d{2}$/.test(value) ? value
+      : value.endsWith('/01') ? yearLabel(value) : +value.slice(5) + '月';
+  if (months.length <= 12) {
+    const step = Math.max(1, Math.ceil(months.length / fit(34)));
+    return {
+      interval: 0,
+      formatter: (value, index) => index % step ? '' : monthLabel(value)
+    };
+  }
   const starts = months
     .map((v, i) => (i === 0 || v.endsWith('/01')) ? i : -1)
     .filter((i) => i >= 0);
-  const width = (document.getElementById(el) || {}).clientWidth || 700;
-  const step = Math.max(1, Math.ceil(starts.length / Math.max(2, Math.floor(width / 64))));
+  const step = Math.max(1, Math.ceil(starts.length / fit(64)));
   const shown = new Set(starts.filter((_, k) => k % step === 0));
   return {
     interval: 0,
-    formatter: (value, index) => shown.has(index) ? value.slice(0, 4) + '年' : ''
+    formatter: (value, index) => shown.has(index) ? yearLabel(value) : ''
   };
 })(<%- months %>, '<%= el %>')


### PR DESCRIPTION
1年に収まる軸のラベルの単位を月に落とし、幅に収まる本数まで間引く。

## 何が起きていたか

`_partial/chart-xaxis-year-labels` は軸が12ヶ月以下なら「全部読める」として
`{ interval: 0 }` を返し、`2025/01`〜`2025/12` を12本そのまま出していた。
`author_monthly_chart` は軸を暦年に揃える（初投稿年の1月〜最終投稿年の12月 #2140）ので、
投稿が1年に収まる著者はちょうど12ヶ月になる。

**例外的なケースではなく、著者ページの61%がこの形。**

| ページ | 軸が12ヶ月以下 | 内訳 |
| --- | --- | --- |
| 著者（329人） | **200人（61%）** | 24ヶ月43人 / 36ヶ月24人 / 48ヶ月20人 / 以降は1桁 |
| タグ（グラフを出す264件） | 2件 | `Go1.27` / `Go1.26`（軸8ヶ月） |
| カテゴリ（18件） | 0件 | 最短でも `AIDD` の44ヶ月 |

ラベル1本の幅（Noto Sans CJK 12px ＝ echarts の既定サイズ、隣との空き8px込み）と、
軸の幅（本文列700px・幅375pxで351px、`containLabel` のY軸ラベル22pxを引いた値）:

| 書式 | 1本 | PC（678px）に入る | 幅375px（329px）に入る |
| --- | --- | --- | --- |
| `2025/01`（変更前） | 55px | 12本 | **5本** |
| `2025年` | 48px | 14本 | 6本 |
| `12月` | 34px | 19本 | 9本 |

12本を出そうとして5本ぶんしか場所が無い、というのが詰まりの正体。

## 直し方

長い軸で既にやっている「年の変わり目にラベル、幅に収まる本数まで間引く」の
**単位を年から月に落とすだけ**にした。`/01` の目盛は `2025年`、それ以外は `3月`。
1本ぶんの場所を 34px（`12月`）として間引く。

年ページのチャートだけは月名（`1月`…`12月`）をそのまま渡してくる
（`get_monthly_category_data`）ので、言い換えるのは `YYYY/MM` の形のときだけにした。
ここを見落とすと年ページのラベルが全部 `0月` になる（実際に踏んだ）。

## 変更前後（生成HTMLから式を切り出して実行）

| 軸 | 幅 | 変更前 | 変更後 |
| --- | --- | --- | --- |
| 著者12ヶ月 | 700px | `2025/01` … `2025/12`（12本） | `2025年 2月 3月 … 12月`（12本） |
| 著者12ヶ月 | 351px | 同じ12本を強制（重なる） | `2025年 3月 5月 7月 9月 11月`（6本） |
| タグ8ヶ月 | 351px | `2026/01` … `2026/08`（8本） | `2026年 2月 … 8月`（8本） |
| 年ページ12ヶ月 | 351px | `1月` … `12月`（12本を強制） | `1月 3月 5月 7月 9月 11月`（6本） |
| 24 / 44 / 60 / 132ヶ月 | 700px / 351px | — | **変化なし**（年ラベルのまま） |

## 確認したこと

- 開発サーバが配信している5ページの HTML から `axisLabel` の式と `months` を切り出し、
  器の幅を 700 / 351 に変えて実行。上の表はその出力
  （`/authors/松本朝香/`・`/tags/Go1-27/`・`/categories/AIDD/`・`/categories/`・`/articles/`・`/articles/2025/`）
- 変更前（`origin/main`）の式と変更後の式を同じ入力で回して突き合わせ、
  24ヶ月以上の軸と年ページの8ヶ月（今年）は**出力が完全に一致**することを確認
- 軸の長さは記事のフロントマターから直接集計（著者329人・タグ696件・カテゴリ18件）。
  生成物とは独立の計算
- `npx prettier --check "scripts/**/*.js" "*.mjs"` … 通過（この PR は `.ejs` 1ファイルのみ）

## 範囲外

- 24ヶ月の軸（著者43人）は年ラベル2本のままにした。詰まってはいないので今回は触らない。
  月まで出すなら間引きの単位を「2〜3ヶ月ごと」に決める話になり、別途判断する
- 年別グラフの折れ線の太さ（#2794）は別 PR

Closes #2795
