### PR TITLE
折れ線の太さを一律 4px にする (#2794)

### DIFF
--- a/scripts/chart_style.js
+++ b/scripts/chart_style.js
@@ -31,18 +31,13 @@ hexo.extend.helper.register('chart_series_colors', function (kind) {
   return JSON.stringify(PALETTES[kind] || NAVY_STEPS);
 });
 
-// 年別の折れ線（最新年から遡る5本）の太さ。先頭が最新年で、そこから1pxずつ落とす。
-// 重なりの前後と太さを同じ向きに揃えて、古い年が背景になるようにする
-const LINE_WIDTHS = [8, 7, 6, 5, 4];
+// 折れ線の太さ (#2794)。年別の重ね描きも、積み上げの上に重ねるアクセント線も
+// 同じ値にする。年の前後は色と描画順（z）が表すので、太さは順序を持たない。
+//
+// 投稿数の推移は軸の上限30件・プロット高141pxで 1件 = 4.7px。4px の線は
+// 値0.85件ぶんで、これより太いと隣の年の線と接する月が 2/12 から 6/12 に増える
+const LINE_WIDTH = 4;
 
-// 積み上げの上に重ねる1本の太さ（著者の推移の「常連」）。上の5本とは役割が
-// 違うので値を分ける。あちらは並んだ線の順序を太さで表すが、こちらは1本しかない
-const ACCENT_LINE_WIDTH = 6;
-
-hexo.extend.helper.register('chart_line_widths', function () {
-  return JSON.stringify(LINE_WIDTHS);
-});
-
-hexo.extend.helper.register('chart_accent_line_width', function () {
-  return ACCENT_LINE_WIDTH;
+hexo.extend.helper.register('chart_line_width', function () {
+  return LINE_WIDTH;
 });

--- a/themes/future/layout/_partial/posts-chart.ejs
+++ b/themes/future/layout/_partial/posts-chart.ejs
@@ -58,8 +58,6 @@
   });
 <% } else { %>
   const yearData = <%- posts_year_overlay_series() %>;
-  <%# 直近の年を強く出す。太さは scripts/chart_style.js が1箇所で持つ %>
-  const yearWidths = <%- chart_line_widths() %>;
   echarts.init(document.getElementById('chart-years')).setOption({
     <%# 同じ月の全年を1つの吹き出しに出す。年どうしの差を読むグラフなので、
         1本ずつ見るより並べた方が速い %>
@@ -85,9 +83,11 @@
       name: s.name,
       type: 'line',
       showSymbol: false,
-      lineStyle: { width: yearWidths[i] },
+      <%# 太さは scripts/chart_style.js が1箇所で持つ %>
+      lineStyle: { width: <%= chart_line_width() %> },
       <%# 系列は新しい年が先。echarts は後の系列を上に描くので、
           そのままだと古い年が前に出る。z を逆順に振って新しい年を上に置く。
+          太さが揃っているので、手前に来るのは新しい年だけが頼り。
           既定の 2 より下に落とすと軸の補助線に潜るので +2 する %>
       z: yearData.series.length - i + 2,
       data: s.data

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -92,7 +92,7 @@
                   name: '常連',
                   type: 'line',
                   showSymbol: false,
-                  lineStyle: { width: <%= chart_accent_line_width() %> },
+                  lineStyle: { width: <%= chart_line_width() %> },
                   data: chartData.regulars
               }
           ]


### PR DESCRIPTION
年別の折れ線を太さで区別するのをやめ、**一律 4px** にする。/authors/ の「常連」の線も同じ値に寄せた。

## 太さを揃えるだけでは詰まりが直らない

issue は「2024年の太さ（6px）で5年分同じに」だったが、測ってみると一律6pxでは重なりが1つも減らない。

投稿数の推移は軸の上限30件（月あたりの最大26件を刻み5で切り上げ）でプロット高141px、つまり **1件 = 4.70px**。

| 太さ | 値の何件ぶんか | 初期表示の3年で隣の年の線と接する月 |
| --- | --- | --- |
| 8/7/6px（変更前） | 1.70 / 1.49 / 1.28件 | **6/12**（1・2・6・7・8・12月） |
| 一律 6px | 1.28件 | **6/12**（同じ） |
| **一律 4px** | **0.85件** | **2/12**（6・12月） |
| 一律 3px | 0.64件 | 2/12（4pxと同じ） |

4px は現行の一番細い年（2022年）と同じ値なので、新しい太さを決め直していない。3px との差は重なりに出ず色の見え方だけなので、コントラストが 3.18〜3.25 の緑・グレー（#2767 で図形の基準 3:1 に合わせて選んだ色）が細くならない側を採った。

/authors/ の「常連」の線は軸の上限110人・プロット高241px（1人 = 2.19px）で、6px は 2.74人ぶん、4px は 1.83人ぶん。

## 変えたもの

- `scripts/chart_style.js`: `LINE_WIDTHS = [8,7,6,5,4]` と `ACCENT_LINE_WIDTH = 6` を
  `LINE_WIDTH = 4` の1つにまとめ、ヘルパーも `chart_line_width()` の1本にした
- `_partial/posts-chart.ejs`: 系列ごとに太さを引くのをやめた。
  年の前後は色と `z`（新しい年を上）が表す
- `authors.ejs`: 「常連」の線も同じヘルパーを使う

## 確認したこと

- 開発サーバが配信している HTML の `lineStyle` が、`/articles/` の年別タブと
  `/authors/` の常連の線でどちらも `width: 4`。旧ヘルパー（`yearWidths`）の痕跡なし
- 年別データを生成物から取り出し、記事のフロントマター直接集計と月ごとに突き合わせて
  **5年 × 12か月すべて一致**。系列は 2026〜2022年の5本で、初期表示は直近3年
  （`YEAR_OVERLAY_SHOWN`）＝ 8/7/6px が並んでいた組み合わせ
- `npx prettier --check "scripts/**/*.js" "*.mjs"` … 通過

## 範囲外

- `scripts/archive_post_chart.js` の年別タブの説明に「色は新しい年ほど濃い同系の濃淡で、
  凡例の並びと濃さが年代の順に対応する」という記述が残っているが、#2767 で色相を
  年ごとに変えたので現状と合っていない。コメントだけの話なのでこの PR では触っていない
- 24ヶ月の軸のX軸ラベル（#2795 で範囲外にしたもの）はそのまま

Closes #2794
