### PR TITLE
関連記事・参照記事・連載ナビのタイトルを太字にする (#2789)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -3089,9 +3089,13 @@ a.series-nav-item:hover .series-nav-item-title {
 .series-nav-next .series-nav-dir:after {
   content: ' ›';
 }
+/* 前後の記事名。上に添える「前の記事」（.series-nav-dir）と同じ 400 では
+   どちらが記事名か読み取れないので、他の記事タイトルと同じ太字にする (#2789)。
+   連載名（.series-nav-title）との序列は大きさが持つ */
 .series-nav-item-title {
   display: block;
   font-size: 1em;
+  font-weight: bold;
   line-height: 1.5;
 }
 /* モバイルでも縦に積まず、前 | 次 の横並び構造を保つ (#2045)。
@@ -3177,20 +3181,23 @@ a.series-nav-item:hover .series-nav-item-title {
   color: ink-strong;
   text-decoration: none;
 }
-/* metronic に `.related-post-link a { font-size: 1.2em }` があり、関連記事の
-   タイトルだけ大きくなっていた。参照記事側には同じ指定が無い。
-   両者を本文と同じ大きさに揃える */
+/* 上の metronic 由来の節に `.related-post-link a { font-size: 1.2em }` があり、
+   関連記事のタイトルだけ大きくなっていた。参照記事側には同じ指定が無い。
+   両者を本文と同じ大きさに揃える。
+   太さはサイトの他の記事タイトルと同じ太字にする。1行の中でタイトルと
+   日付・反響（0.85em・ink-mute）が並ぶので、2px と色の差だけでは
+   どちらが記事名か読み取れない (#2789) */
 .related-posts-item > a,
 .reference-posts-item > a,
 .related-posts-item .post-list-body > a,
 .reference-posts-item .post-list-body > a {
   font-size: 1em;
+  font-weight: bold;
   color: ink-strong;
 }
 /* ランキングはホームの主役なので、本文と同じ 1.2em で読ませる。
    関連記事・参照記事は記事に付随する自動生成の情報なので 1em に留める。
-   太字にするのはランキングだけ (#2777)。1行の中でタイトルと日付・反響が
-   並ぶので、太さで主従を付ける。関連記事・参照記事は付随情報なので素のまま */
+   太さは同じなので、3つの序列は大きさが持つ */
 .featured-posts-item > a,
 .featured-posts-item .post-list-body > a {
   font-size: 1.2em;


### PR DESCRIPTION
関連記事・参照記事・連載ナビの記事タイトルを太字にする。

## サイトの中で太字でないのはこの3か所だけだった

`body` 13px を基準に、記事タイトルらしいものの実効サイズと太さを全部並べた。

| 対象 | サイズ | 太さ |
| --- | --- | --- |
| 一覧カードのタイトル（`.archive-post-title`） | 20px | 太字 |
| 連載パネル（`.panel-title`） | 15.6px | 太字 |
| ランキング（`.featured-posts-item`） | 15.6px | 太字 |
| 連載ナビの連載名（`.series-nav-title`） | 15.6px | 太字 |
| **関連記事・参照記事**（`.related-posts-item` / `.reference-posts-item`） | 13px | **400** |
| **連載ナビの前後の記事名**（`.series-nav-item-title`） | 13px | **400** |
| 添えのメタ（`.post-meta` の日付・♡） | 11.05px | 400 |
| 連載ナビの「前の記事」（`.series-nav-dir`） | 11.05px | 400 |

タイトルと添えのメタは同じ行に並ぶのに、差が **2px と色（`ink-strong` / `ink-mute`）だけ**。
これが「メタ情報と同じに見える」の実体。太字にすると、どちらが記事名かが太さで分かる。

## 太さは 700（`bold`）

`theme-styles.styl` の太さの語彙は `bold` 38件 / `700` 9件 / `normal` 5件 / `800` 2件 /
`400` 2件 / `300` 1件で、**600 は1件も無い**。Web フォントを持たないサイトなので、
600 は環境によって 700 に丸められたり合成されたりして実効値が読めない。既存の語彙に合わせた。

3つの序列は大きさが持つ（ランキング 15.6px ＞ 関連記事・参照記事 13px、
連載名 15.6px ＞ 前後の記事名 13px）。

## #2782 の判断を1つ戻している

#2777 の対応（PR #2782）で「太字にするのはランキングだけ。関連記事・参照記事は
付随情報なので素のまま。ここを太くすると記事本文と競合する」としていた。今回そこを変えた。

本文は 15.6px の 400 で、太字にしても関連記事のタイトルは 13px。**大きさの序列が
本文より下のままなので、太さだけでは本文と競合しない**と判断した。太さは本文との
競合ではなく、同じ行のメタとの主従に使う。

## 折り返しは動かない

和文は太字でも字幅が変わらないため、行あたりの文字数は同じ（Noto Sans CJK 13px で
全角1文字 13.00px、通常も太字も同じ）。連載ナビは幅375pxで1枠約170px、
1行13文字・2行で26文字までという上限（`-webkit-line-clamp: 2`）も変わらない。

欧文を含むタイトルだけ 2〜9px（2〜3%）伸びる。

| タイトルの例 | 通常 | 太字 |
| --- | --- | --- |
| `関連記事のタイトルはどこまで太くするか` | 247.0px | 247.0px（±0） |
| `AWS Lambda のコールドスタートを計測する` | 264.0px | 269.0px（+5） |
| `Go 1.27 リリース連載：goroutineleak プロファイル` | 305.0px | 314.0px（+9） |

## 確認したこと

- `make css` 後の `public/css/site.css` で、4つのタイトル（関連記事・参照記事・
  連載ナビ・ランキング）がすべて `font-weight: bold`。詳細度と順序を見て、
  後から打ち消す規則が無いことも確認（`.related-post-link a` は metronic 由来で
  `font-size` と `color` だけ、詳細度も 0,1,1 で負ける）
- 太さの語彙は `theme-styles.styl` から機械的に集計

## 範囲外

- **`/articles/` の一覧**（`.article-list`）は同じ逆転が残っている。タイトル 14.3px の 400 に対して
  日付が太字。ここは別 issue にしたい（この PR の3か所とは部品も文脈も別）
- `scripts/archive_post_chart.js` の古いコメント（#2794 の PR で挙げたもの）は今回も触っていない

Closes #2789
