### PR TITLE
行として並ぶ記事名は太らせず、記事一覧のメタから太字を外す (#2803)

### DIFF
--- a/themes/future/css-src/_variables.styl
+++ b/themes/future/css-src/_variables.styl
@@ -49,15 +49,12 @@ font-mono = ui-monospace, "SF Mono", "Cascadia Code", "Source Code Pro", Menlo, 
 font-size = 14px
 line-height = 1.6em
 line-height-title = 1.1em
-// 一覧・ナビに並ぶ記事名の太さ (#2803)。13〜14.3px の小さいタイトルでは
-// 太字（700）が行の中で強すぎた。600 は中間ウェイトを持つフォント
-// （Hiragino Sans / Yu Gothic UI Semibold / Noto Sans CJK SemiBold）で
-// 一段軽く出て、持たないフォント（Hiragino Kaku Gothic ProN の W3・W6、
-// Meiryo の Regular・Bold）では太字に丸まる。効かない側でも太字より重くは
-// ならないので、片方向の変化しか起きない。
-// 大きいタイトル（一覧カード 20px、ランキングと連載パネル 15.6px）は
-// 太字のまま。大きい字は太くても字面が潰れない
-weight-list-title = 600
+// 太さの段は 400 / 700 / 800 の3つだけ（#2803）。行として並ぶ記事名
+// （ランキング・関連記事・参照記事・連載ナビ・記事一覧）は 400、
+// カード・パネルの見出しと見出し全般が 700、ページの主題が 800。
+// 13〜14.3px の記事名を太らせると、隣のメタより先に帯全体が重くなるので、
+// 行の中の主従は「メタから太字を外す」側で作る。中間の段は置かない
+// （ink の3段・角丸の3段・画像幅の2段と同じ理屈 #2534）
 
 // Header
 logo-size = 40px

--- a/themes/future/css-src/_variables.styl
+++ b/themes/future/css-src/_variables.styl
@@ -49,6 +49,15 @@ font-mono = ui-monospace, "SF Mono", "Cascadia Code", "Source Code Pro", Menlo, 
 font-size = 14px
 line-height = 1.6em
 line-height-title = 1.1em
+// 一覧・ナビに並ぶ記事名の太さ (#2803)。13〜14.3px の小さいタイトルでは
+// 太字（700）が行の中で強すぎた。600 は中間ウェイトを持つフォント
+// （Hiragino Sans / Yu Gothic UI Semibold / Noto Sans CJK SemiBold）で
+// 一段軽く出て、持たないフォント（Hiragino Kaku Gothic ProN の W3・W6、
+// Meiryo の Regular・Bold）では太字に丸まる。効かない側でも太字より重くは
+// ならないので、片方向の変化しか起きない。
+// 大きいタイトル（一覧カード 20px、ランキングと連載パネル 15.6px）は
+// 太字のまま。大きい字は太くても字面が潰れない
+weight-list-title = 600
 
 // Header
 logo-size = 40px

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2486,17 +2486,20 @@ ul.tag-list {
   /* 折り返しが前提の行になるので、フォント依存の normal に任せない */
   line-height: 1.5;
 }
+/* 日付と♡は行に添える属性なので ink-mute（_variables.styl の区分）。
+   太字にしないのは、1,475行が並ぶ帯で太字が3つ並ぶと主役が消えるため。
+   日付が座標であることは、揃った列の位置が示す (#2803) */
 .article-list .date {
-  color: ink-faint;
-  font-weight: bold;
+  color: ink-mute;
 }
 .article-list .count {
-  color: ink-faint;
-  font-weight: bold;
+  color: ink-mute;
 }
+/* 記事名なので、サイトの他の記事タイトルと同じ太字にする (#2803) */
 .article-list .title {
   text-decoration: none;
   font-size: 1.1em;
+  font-weight: bold;
 }
 /* 記事へのリンクは本文ではないので、月ページのカード一覧
    （.archive-post-item a）と同じ ink-strong に揃える (#2754)。

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2495,11 +2495,11 @@ ul.tag-list {
 .article-list .count {
   color: ink-mute;
 }
-/* 記事名なので、サイトの他の記事タイトルと同じ太字にする (#2803) */
+/* 記事名なので添えのメタより太くする。太さは _variables.styl が1箇所で持つ */
 .article-list .title {
   text-decoration: none;
   font-size: 1.1em;
-  font-weight: bold;
+  font-weight: weight-list-title;
 }
 /* 記事へのリンクは本文ではないので、月ページのカード一覧
    （.archive-post-item a）と同じ ink-strong に揃える (#2754)。
@@ -3093,12 +3093,12 @@ a.series-nav-item:hover .series-nav-item-title {
   content: ' ›';
 }
 /* 前後の記事名。上に添える「前の記事」（.series-nav-dir）と同じ 400 では
-   どちらが記事名か読み取れないので、他の記事タイトルと同じ太字にする (#2789)。
-   連載名（.series-nav-title）との序列は大きさが持つ */
+   どちらが記事名か読み取れない。太さは _variables.styl が1箇所で持つ
+   (#2789 / #2803)。連載名（.series-nav-title）との序列は大きさが持つ */
 .series-nav-item-title {
   display: block;
   font-size: 1em;
-  font-weight: bold;
+  font-weight: weight-list-title;
   line-height: 1.5;
 }
 /* モバイルでも縦に積まず、前 | 次 の横並び構造を保つ (#2045)。
@@ -3187,15 +3187,15 @@ a.series-nav-item:hover .series-nav-item-title {
 /* 上の metronic 由来の節に `.related-post-link a { font-size: 1.2em }` があり、
    関連記事のタイトルだけ大きくなっていた。参照記事側には同じ指定が無い。
    両者を本文と同じ大きさに揃える。
-   太さはサイトの他の記事タイトルと同じ太字にする。1行の中でタイトルと
-   日付・反響（0.85em・ink-mute）が並ぶので、2px と色の差だけでは
-   どちらが記事名か読み取れない (#2789) */
+   1行の中でタイトルと日付・反響（0.85em・ink-mute）が並ぶので、2px と
+   色の差だけではどちらが記事名か読み取れない。太さは _variables.styl が
+   1箇所で持つ (#2789 / #2803) */
 .related-posts-item > a,
 .reference-posts-item > a,
 .related-posts-item .post-list-body > a,
 .reference-posts-item .post-list-body > a {
   font-size: 1em;
-  font-weight: bold;
+  font-weight: weight-list-title;
   color: ink-strong;
 }
 /* ランキングはホームの主役なので、本文と同じ 1.2em で読ませる。

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2495,11 +2495,11 @@ ul.tag-list {
 .article-list .count {
   color: ink-mute;
 }
-/* 記事名なので添えのメタより太くする。太さは _variables.styl が1箇所で持つ */
+/* 行として並ぶ記事名なので太らせない。主従は日付・♡から太字を外したこと
+   （上の2つ）と、サイズ 1.1em・色 ink-strong が持つ (#2803) */
 .article-list .title {
   text-decoration: none;
   font-size: 1.1em;
-  font-weight: weight-list-title;
 }
 /* 記事へのリンクは本文ではないので、月ページのカード一覧
    （.archive-post-item a）と同じ ink-strong に揃える (#2754)。
@@ -3092,13 +3092,11 @@ a.series-nav-item:hover .series-nav-item-title {
 .series-nav-next .series-nav-dir:after {
   content: ' ›';
 }
-/* 前後の記事名。上に添える「前の記事」（.series-nav-dir）と同じ 400 では
-   どちらが記事名か読み取れない。太さは _variables.styl が1箇所で持つ
-   (#2789 / #2803)。連載名（.series-nav-title）との序列は大きさが持つ */
+/* 前後の記事名。連載名（.series-nav-title = 1.2em の太字）との序列は
+   大きさが持つので、こちらは太らせない (#2803) */
 .series-nav-item-title {
   display: block;
   font-size: 1em;
-  font-weight: weight-list-title;
   line-height: 1.5;
 }
 /* モバイルでも縦に積まず、前 | 次 の横並び構造を保つ (#2045)。
@@ -3187,24 +3185,22 @@ a.series-nav-item:hover .series-nav-item-title {
 /* 上の metronic 由来の節に `.related-post-link a { font-size: 1.2em }` があり、
    関連記事のタイトルだけ大きくなっていた。参照記事側には同じ指定が無い。
    両者を本文と同じ大きさに揃える。
-   1行の中でタイトルと日付・反響（0.85em・ink-mute）が並ぶので、2px と
-   色の差だけではどちらが記事名か読み取れない。太さは _variables.styl が
-   1箇所で持つ (#2789 / #2803) */
+   行として並ぶ記事名は太らせない（#2803）。太さを上げると、同じ帯に並ぶ
+   日付・反響（0.85em・ink-mute）より先に帯全体が重くなる。
+   主従はサイズと色（ink-strong 対 ink-mute）が持つ */
 .related-posts-item > a,
 .reference-posts-item > a,
 .related-posts-item .post-list-body > a,
 .reference-posts-item .post-list-body > a {
   font-size: 1em;
-  font-weight: weight-list-title;
   color: ink-strong;
 }
 /* ランキングはホームの主役なので、本文と同じ 1.2em で読ませる。
    関連記事・参照記事は記事に付随する自動生成の情報なので 1em に留める。
-   太さは同じなので、3つの序列は大きさが持つ */
+   太さは3つとも素のまま。序列は大きさが持つ */
 .featured-posts-item > a,
 .featured-posts-item .post-list-body > a {
   font-size: 1.2em;
-  font-weight: bold;
   color: ink-strong;
 }
 /* ランキングのサムネ (#2230)。カードにはせず、リストの密度を保ったまま


### PR DESCRIPTION
「**行として並ぶ記事名は太らせない。カード・パネルの見出しは太字**」という線を引き、
行の中の主従は太さではなく「メタ側から太字を外す」ことで作る。

## 1. `/articles/` の一覧（#2803 の本題）

| 列 | before | after |
| --- | --- | --- |
| 日付（`.article-list .date`） | 13px・**700**・`ink-faint` #757575（4.61） | 13px・400・**`ink-mute`** #616161（6.19） |
| ♡（`.article-list .count`） | 13px・**700**・`ink-faint` | 13px・400・**`ink-mute`** |
| タイトル（`.article-list .title`） | 14.3px・400・`ink-strong`（10.05） | 14.3px・400（変えない） |

タイトルより添えの日付・♡が太い、という逆転を**メタ側だけを触って**解いた。

- 色は `_variables.styl` の区分（`ink-mute` =「本文に添える属性。日付・著者・タグ・件数」、
  `ink-faint` =「空表示・無効」）に戻す。薄い色を太字で補っていた状態を色の側で解く
- 1,475行が並ぶ帯で太字を並べない。パンくずで同じ判断をしている（#2705 / #2722）
- 日付が座標であることは #2798 で揃った列の位置が示す
- 日付の太字は 8px 使っていた（`2026.08.05` が 64px → 72px）。♡列と合わせて
  **9〜12px** がタイトル側に戻る

## 2. 行として並ぶ記事名は 400 に戻す

一覧・ナビの記事名を太字（#2782 / #2802 で入れたもの）から素の 400 に戻す。
13〜15.6px では、太くすると行の中の主従が付く前に**帯全体が重くなる**。

| 対象 | サイズ | before | after |
| --- | --- | --- | --- |
| ランキング（`.featured-posts-item`） | 15.6px | 太字（#2782） | **400** |
| 関連記事・参照記事 | 13px | 太字（#2802） | **400** |
| 連載ナビの前後の記事名 | 13px | 太字（#2802） | **400** |
| `/articles/` の一覧 | 14.3px | 400 | 400 |
| 一覧カード（`.archive-post-title`） | 20px | 太字 | 太字（変えない） |
| 連載パネル（`.panel-title`） | 15.6px | 太字 | 太字（変えない） |

**線引きは「行」か「カード・パネル」か。** 行は密度が主役で、1件ごとに主張させると
帯として読めなくなる。カード・パネルは1件に1つの見出しなので太字が効く。

### 太さの段は 3つに戻る

`theme-styles.styl` の太さは **400 / 700 / 800** の3段だけになる（`bold` は 700 と同値）。
中間の 600 は置かない。`_variables.styl` が ink の3段・角丸の3段・画像幅の2段で
掲げている「段を増やさない」（#2534）と同じ扱いで、その方針をこのファイルに書き足した。

700 が担っているのは45か所で、見出し（本文 h2〜h6・サイドバー・表のヘッダ・
一覧の年月）、カード・パネルの見出し、現在地（パンくず・選択中のタブ・年月カード）、
そして**単独で置くメタ**（著者名・公開日・タグチップ・統計の数値・順位の丸）。
13px の記事名に 700 を当てると、同じページに並ぶ著者名やタグチップと同じ重さになる。

（`site.css` には `h1〜h6 { font-weight: 500 }` と `b, strong { bolder }` も出るが、
これは bootstrap-subset のリセットで、テーマ側の語彙ではない）

## 確認したこと

- `make css` 後の `public/css/site.css` で、ランキング・関連記事・参照記事・連載ナビ・
  記事一覧の記事名がいずれも `font-weight` を持たない（`body` の 400 を継ぐ）。
  `600` の出現は 0件。一覧カードと連載パネルは `bold` のまま
- `/articles/` の日付・♡が `color: #616161` かつ `font-weight` を持たないこと。
  `.article-list` に触る他のルールで打ち消しが無いこと、`a` / `li` / `span` に
  太さを設定するルールも無いこと
- HTML は無変更（CSS だけの変更）

## ♡の輪郭について

`♡`（U+2661）は細い輪郭の記号なので、太字を外すと線が弱くなる。色を
`ink-faint`（4.61）から `ink-mute`（6.19）へ一段濃くしてコントラストは34%上がるが、
ここは実機で見て判断してほしい。沈むなら♡だけ太字に戻すか、記号を一段大きくする
（ランキング側は #2453 で `.snscount-icon` を大きくしている）。

## 範囲外

- 記事ページのメタ（著者名・公開日・カテゴリ・タグチップ）の太字は触っていない。
  #2681 / #2699 で意図的に入れたもので、全ページの見え方が変わるため別途判断する
- 列の幅・並び（#2798 で決めたグリッドのまま）
- 記号側の調整（♡の大きさ・アイコン化）

Closes #2803
