### PR TITLE
検索窓を押したら行き先の一覧を出す (#2791)

### DIFF
--- a/scripts/categories.js
+++ b/scripts/categories.js
@@ -15,3 +15,24 @@ hexo.extend.helper.register('count_categories', function () {
     .flat()
     .unique().length;
 });
+
+// 検索窓のパネル（#2791）用。全ページのヘッダーから呼ぶので結果を持ち回る。
+// 記事数が変わったら作り直すため、server での編集にも追随する
+const activeCategoriesCache = new Map();
+
+// 直近 months ヶ月に投稿のあるカテゴリだけを、累計本数の多い順に返す。
+// 全件だと数年止まっているカテゴリが入口として並ぶ。件数は累計のまま
+// （そのカテゴリの規模を示す数字で、サイドバー・/categories/ と揃える）
+hexo.extend.helper.register('active_categories', function (months = 6) {
+  const cacheKey = `${months}:${this.site.posts.length}`;
+  if (activeCategoriesCache.has(cacheKey)) return activeCategoriesCache.get(cacheKey);
+  const since = Date.now() - months * 30 * 24 * 60 * 60 * 1000;
+  const categories = this.site.categories
+    .toArray()
+    .filter((c) => c.posts.toArray().some((p) => p.date.valueOf() >= since))
+    .map((c) => ({ name: c.name, path: c.path, count: c.length }))
+    // 同点は名前で決める（決着が無いとビルドごとに並びが変わる）
+    .sort((a, b) => b.count - a.count || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  activeCategoriesCache.set(cacheKey, categories);
+  return categories;
+});

--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -19,6 +19,11 @@ hexo.extend.helper.register('get_ga4_pv', (url) => {
   return pv > 0 ? pv.toLocaleString() : '';
 });
 
+// 全ページのヘッダー（検索窓のパネル #2791）から呼ぶので結果を持ち回る。
+// 714タグ×所属記事を毎ページ舐めると、その分だけビルドが伸びる。
+// 記事数が変わったら作り直すため、server での編集にも追随する
+const popularTagsCache = new Map();
+
 // トップの「人気のタグ」(#2358)。以前は全期間のSNSシェア合計順で、
 // 古い大型タグが上位に固定されいまの人気を反映しなかった。
 // 公開が1年以内の記事の PV 合計で選ぶ（直近1年の記事はシェア数の
@@ -26,25 +31,27 @@ hexo.extend.helper.register('get_ga4_pv', (url) => {
 // 直近3本未満のタグは、話題の勢いではなく単発のバズなので出さない
 // （「3件あれば選択肢として成立する」の related_tags と同じ基準）
 hexo.extend.helper.register('recent_popular_tags', function (limit = 10, minRecent = 3) {
+  const cacheKey = `${limit}:${minRecent}:${this.site.posts.length}`;
+  if (popularTagsCache.has(cacheKey)) return popularTagsCache.get(cacheKey);
   const YEAR = 365 * 24 * 60 * 60 * 1000;
   const now = Date.now();
-  return (
-    this.site.tags
-      .map((tag) => {
-        const recent = tag.posts.toArray().filter((p) => now - p.date.valueOf() <= YEAR);
-        return {
-          name: tag.name,
-          path: tag.path,
-          count: tag.length,
-          recent: recent.length,
-          pv: recent.reduce((sum, p) => sum + getGA4PV('/' + p.path), 0),
-        };
-      })
-      .filter((t) => t.recent >= minRecent && t.pv > 0)
-      // 同点は名前で決める（決着が無いとビルドごとに並びが変わる）
-      .sort((a, b) => b.pv - a.pv || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
-      .slice(0, limit)
-  );
+  const tags = this.site.tags
+    .map((tag) => {
+      const recent = tag.posts.toArray().filter((p) => now - p.date.valueOf() <= YEAR);
+      return {
+        name: tag.name,
+        path: tag.path,
+        count: tag.length,
+        recent: recent.length,
+        pv: recent.reduce((sum, p) => sum + getGA4PV('/' + p.path), 0),
+      };
+    })
+    .filter((t) => t.recent >= minRecent && t.pv > 0)
+    // 同点は名前で決める（決着が無いとビルドごとに並びが変わる）
+    .sort((a, b) => b.pv - a.pv || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+    .slice(0, limit);
+  popularTagsCache.set(cacheKey, tags);
+  return tags;
 });
 
 // 推薦の件数は記事数から決める。推薦が全記事の半分を超えると

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -4042,6 +4042,66 @@ input[name="tab_item"] {
     right: 8px;
   }
 }
+/* 検索窓を押したときに出る行き先の一覧 (#2791)。フォームの :focus-within で開き、
+   input:placeholder-shown で「打ち始めたら閉じる」を作る。JS は使わない。
+   影は持たない (#2747)。白い面と枠で本文から浮かせる */
+.header-search-hint {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  /* カテゴリを3列に並べられる幅。最長の「DataEngineering 45」が実測139px */
+  width: unquote('min(490px, calc(100vw - 24px))');
+  padding: 12px 14px 4px;
+  background: #fff;
+  border: 1px solid rule-base;
+  border-radius: 4px;
+  /* ヘッダーは中央揃えなので、面の中だけ戻す */
+  text-align: left;
+  color: ink-strong;
+  visibility: hidden;
+  opacity: 0;
+  /* 閉じるときだけ visibility を遅らせる。Safari はクリックでリンクに
+     フォーカスを与えず、blur で先に閉じるとタップが着地しない（送信ボタンを
+     モバイルで出していないのと同じ理由）。消えるまでの間に click が届く */
+  transition: opacity 0.12s ease, visibility 0s 0.3s;
+}
+.header-search:focus-within input:placeholder-shown ~ .header-search-hint {
+  visibility: visible;
+  opacity: 1;
+  transition: opacity 0.12s ease;
+}
+/* 枠の中のラベル。見出しではなく面の中の仕切りなので h2 は使わない */
+.header-search-hint-label {
+  margin: 0 0 4px;
+  font-size: 12px;
+  font-weight: bold;
+  color: ink-mute;
+}
+.header-search-hint-categories {
+  margin: 0 0 12px;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  /* 18件が幅490pxの面で3列6行、幅375pxの端末で2列9行になる */
+  grid-template-columns: repeat(auto-fill, minmax(145px, 1fr));
+  gap: 2px 10px;
+  font-size: 13px;
+}
+.header-search-hint-categories li {
+  list-style: none;
+}
+/* 右肩の件数はタグのチップと同じく「総数」の意味 (#2129) */
+.header-search-hint-count {
+  margin-left: 4px;
+  font-size: 0.75em;
+  font-weight: normal;
+  color: ink-faint;
+}
+/* 幅の狭い面なので、行末に置く「すべて見る」はサイドバーと同じく左へ寄せる (#2718) */
+.header-search-hint .more-link {
+  margin: 0 0 8px;
+  text-align: left;
+}
 .blog-news {
   padding-top: 20px;
 }

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -3952,7 +3952,10 @@ input[name="tab_item"] {
 .header-search {
   position: absolute;
   top: 10px;
-  right: 12px;
+  /* 端からの距離は変数で1箇所に持つ。下に開くパネルは右端をここに合わせ、
+     幅をこの2倍だけ縮めることで左右の隙間が揃う */
+  --header-search-inset: 12px;
+  right: var(--header-search-inset);
   display: flex;
   align-items: center;
 }
@@ -4039,7 +4042,7 @@ input[name="tab_item"] {
 @media (max-width: 558px) {
   .header-search {
     top: 6px;
-    right: 8px;
+    --header-search-inset: 8px;
   }
 }
 /* 検索窓を押したときに出る行き先の一覧 (#2791)。フォームの :focus-within で開き、
@@ -4050,7 +4053,7 @@ input[name="tab_item"] {
   top: calc(100% + 6px);
   right: 0;
   /* カテゴリを3列に並べられる幅。最長の「DataEngineering 45」が実測150px */
-  width: unquote('min(530px, calc(100vw - 24px))');
+  width: unquote('min(530px, calc(100vw - var(--header-search-inset) * 2))');
   padding: 16px 14px 4px;
   /* 320px 幅では1列に落ちて縦に伸びるので、面の中で送れるようにする */
   max-height: unquote('calc(100vh - 60px)');

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -4078,14 +4078,19 @@ input[name="tab_item"] {
   color: ink-mute;
 }
 /* チップはホームでは 12px。あちらは本文と並ぶ添えの情報だが、こちらは
-   面の中の行き先そのものなので、カテゴリの行と同じ大きさまで上げる。
-   左のマージンも外して、上のカテゴリの列と頭を揃える */
+   面の中の行き先そのものなので、カテゴリの行と同じ大きさまで上げる */
 .header-search-hint .tag-list-link {
   font-size: 13px;
-  margin: 5px 12px 12px 0;
+  margin: 5px 12px 12px 4px;
+}
+/* 揃えるのは枠の位置ではなく文字の位置 (#2429 / #2453)。ul.tag-list の
+   -13px が既にチップの文字を帯の左端へ合わせているので、そこから
+   カテゴリ名の頭（アイコンの 1em ＋ 0.3em）まで帯ごと送る */
+.header-search-hint .blog-tags {
+  margin-left: 18px;
 }
 .header-search-hint-categories {
-  margin: 0 0 20px;
+  margin: 0 0 28px;
   padding: 0;
   list-style: none;
   display: grid;
@@ -4096,6 +4101,10 @@ input[name="tab_item"] {
 }
 .header-search-hint-categories li {
   list-style: none;
+}
+/* 太字はラベルとチップが担う。ここは13行あるので、素の太さで面を静める */
+.header-search-hint-categories .article-category-link {
+  font-weight: normal;
 }
 /* 右肩の件数はタグのチップと同じく「総数」の意味 (#2129) */
 .header-search-hint-count {

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -4052,6 +4052,9 @@ input[name="tab_item"] {
   /* カテゴリを3列に並べられる幅。最長の「DataEngineering 45」が実測150px */
   width: unquote('min(530px, calc(100vw - 24px))');
   padding: 16px 14px 4px;
+  /* 320px 幅では1列に落ちて縦に伸びるので、面の中で送れるようにする */
+  max-height: unquote('calc(100vh - 60px)');
+  overflow-y: auto;
   background: #fff;
   border: 1px solid rule-base;
   border-radius: 4px;
@@ -4083,14 +4086,14 @@ input[name="tab_item"] {
   font-size: 13px;
   margin: 5px 12px 12px 4px;
 }
-/* 揃えるのは枠の位置ではなく文字の位置 (#2429 / #2453)。ul.tag-list の
-   -13px が既にチップの文字を帯の左端へ合わせているので、そこから
-   カテゴリ名の頭（アイコンの 1em ＋ 0.3em）まで帯ごと送る */
+/* ラベルは面の端、項目は一段下げて、カテゴリのアイコンとチップの枠を
+   同じ位置から始める。チップ側は ul.tag-list の -13px と自身の左マージン
+   4px を織り込んだ差 */
 .header-search-hint .blog-tags {
   margin-left: 18px;
 }
 .header-search-hint-categories {
-  margin: 0 0 28px;
+  margin: 0 0 28px 9px;
   padding: 0;
   list-style: none;
   display: grid;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -4049,8 +4049,8 @@ input[name="tab_item"] {
   position: absolute;
   top: calc(100% + 6px);
   right: 0;
-  /* カテゴリを3列に並べられる幅。最長の「DataEngineering 45」が実測139px */
-  width: unquote('min(490px, calc(100vw - 24px))');
+  /* カテゴリを3列に並べられる幅。最長の「DataEngineering 45」が実測150px */
+  width: unquote('min(520px, calc(100vw - 24px))');
   padding: 12px 14px 4px;
   background: #fff;
   border: 1px solid rule-base;
@@ -4072,20 +4072,25 @@ input[name="tab_item"] {
 }
 /* 枠の中のラベル。見出しではなく面の中の仕切りなので h2 は使わない */
 .header-search-hint-label {
-  margin: 0 0 4px;
-  font-size: 12px;
+  margin: 0 0 6px;
+  font-size: 13px;
   font-weight: bold;
   color: ink-mute;
+}
+/* チップはホームでは 12px。あちらは本文と並ぶ添えの情報だが、こちらは
+   面の中の行き先そのものなので、カテゴリの行と同じ大きさまで上げる */
+.header-search-hint .tag-list-link {
+  font-size: 13px;
 }
 .header-search-hint-categories {
   margin: 0 0 12px;
   padding: 0;
   list-style: none;
   display: grid;
-  /* 18件が幅490pxの面で3列6行、幅375pxの端末で2列9行になる */
-  grid-template-columns: repeat(auto-fill, minmax(145px, 1fr));
-  gap: 2px 10px;
-  font-size: 13px;
+  /* 14件が幅520pxの面で3列5行、幅375pxの端末で2列7行になる */
+  grid-template-columns: repeat(auto-fill, minmax(155px, 1fr));
+  gap: 4px 10px;
+  font-size: 14px;
 }
 .header-search-hint-categories li {
   list-style: none;
@@ -4096,11 +4101,6 @@ input[name="tab_item"] {
   font-size: 0.75em;
   font-weight: normal;
   color: ink-faint;
-}
-/* 幅の狭い面なので、行末に置く「すべて見る」はサイドバーと同じく左へ寄せる (#2718) */
-.header-search-hint .more-link {
-  margin: 0 0 8px;
-  text-align: left;
 }
 .blog-news {
   padding-top: 20px;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -4050,8 +4050,8 @@ input[name="tab_item"] {
   top: calc(100% + 6px);
   right: 0;
   /* カテゴリを3列に並べられる幅。最長の「DataEngineering 45」が実測150px */
-  width: unquote('min(520px, calc(100vw - 24px))');
-  padding: 12px 14px 4px;
+  width: unquote('min(530px, calc(100vw - 24px))');
+  padding: 16px 14px 4px;
   background: #fff;
   border: 1px solid rule-base;
   border-radius: 4px;
@@ -4072,24 +4072,26 @@ input[name="tab_item"] {
 }
 /* 枠の中のラベル。見出しではなく面の中の仕切りなので h2 は使わない */
 .header-search-hint-label {
-  margin: 0 0 6px;
+  margin: 0 0 10px;
   font-size: 13px;
   font-weight: bold;
   color: ink-mute;
 }
 /* チップはホームでは 12px。あちらは本文と並ぶ添えの情報だが、こちらは
-   面の中の行き先そのものなので、カテゴリの行と同じ大きさまで上げる */
+   面の中の行き先そのものなので、カテゴリの行と同じ大きさまで上げる。
+   左のマージンも外して、上のカテゴリの列と頭を揃える */
 .header-search-hint .tag-list-link {
   font-size: 13px;
+  margin: 5px 12px 12px 0;
 }
 .header-search-hint-categories {
-  margin: 0 0 12px;
+  margin: 0 0 20px;
   padding: 0;
   list-style: none;
   display: grid;
-  /* 14件が幅520pxの面で3列5行、幅375pxの端末で2列7行になる */
-  grid-template-columns: repeat(auto-fill, minmax(155px, 1fr));
-  gap: 4px 10px;
+  /* 13件が幅530pxの面で3列5行、幅375pxの端末で2列7行になる */
+  grid-template-columns: repeat(auto-fill, minmax(145px, 1fr));
+  gap: 10px 14px;
   font-size: 14px;
 }
 .header-search-hint-categories li {

--- a/themes/future/layout/_partial/header.ejs
+++ b/themes/future/layout/_partial/header.ejs
@@ -9,7 +9,9 @@
 		    :focus-within で展開する（CSSのみ）。送信はキーボードの検索キーが担う %>
 		<form action="https://google.com/cse" target="_blank" class="header-search">
 			<label for="header-search-q" class="header-search-open" aria-label="検索を開く"><%- partial('svg-icon', {icon: 'search'}) %></label>
-			<input type="text" id="header-search-q" name="q" placeholder="検索" aria-label="サイト内検索キーワード" />
+			<%# autocomplete: ブラウザが出す入力履歴のポップアップが、下に開く
+			    パネルと同じ場所に重なる (#2791) %>
+			<input type="text" id="header-search-q" name="q" placeholder="検索" aria-label="サイト内検索キーワード" autocomplete="off" />
 			<button type="submit" aria-label="サイト内検索"><%- partial('svg-icon', {icon: 'search'}) %></button>
 			<input type="hidden" name="cx" value="7f77887fafdb7bb62" />
 			<input type="hidden" name="ie" value="UTF-8" />

--- a/themes/future/layout/_partial/header.ejs
+++ b/themes/future/layout/_partial/header.ejs
@@ -13,6 +13,8 @@
 			<button type="submit" aria-label="サイト内検索"><%- partial('svg-icon', {icon: 'search'}) %></button>
 			<input type="hidden" name="cx" value="7f77887fafdb7bb62" />
 			<input type="hidden" name="ie" value="UTF-8" />
+			<%# input より後ろに置く。開閉は input の兄弟結合子で決める (#2791) %>
+			<%- partial('search-hint') %>
 		</form>
 		<%# ホームではここがページの見出しそのものなので h1 にする。記事ページは
 		    記事タイトルが h1 なので div のまま。見た目は同じ %>

--- a/themes/future/layout/_partial/search-hint.ejs
+++ b/themes/future/layout/_partial/search-hint.ejs
@@ -1,0 +1,23 @@
+<%# 検索窓を押したときに出す行き先の一覧 (#2791)。JS は足さず、フォームの
+    :focus-within で開き、input:placeholder-shown で「打ち始めたら閉じる」を作る。
+    カテゴリは全18件（変わらない地図）、タグは人気10件（いまの話題）。
+    カテゴリ一覧はサイドバーが持つが、記事ページでは意図して伏せている。
+    ここは読者が求めたときだけ開くので、その判断とは競合しない %>
+<div class="header-search-hint">
+	<p class="header-search-hint-label">カテゴリから探す</p>
+	<%# 並びはサイドバーのカテゴリ一覧と同じ本数順。同点は名前で決める %>
+	<% const cats = site.categories.data
+		.slice()
+		.sort((a, b) => b.length - a.length || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0)); %>
+	<ul class="header-search-hint-categories">
+		<% cats.forEach(function(c){ %>
+		<li><a class="article-category-link" href="<%- url_for(c.path) %>"><%- partial('category-icon', {name: c.name}) %><%= c.name %><span class="header-search-hint-count"><%= c.length %></span></a></li>
+		<% }) %>
+	</ul>
+	<p class="header-search-hint-label">人気のタグから探す</p>
+	<%# ホームの「人気のタグから記事を探す」と同じ部品。件数の右肩は .blog-tags が持つ %>
+	<div class="blog-tags">
+		<%- partial('../_widget/tag.ejs') %>
+	</div>
+	<p class="more-link"><a href="<%- url_for('/tags/') %>">すべてのタグを見る</a></p>
+</div>

--- a/themes/future/layout/_partial/search-hint.ejs
+++ b/themes/future/layout/_partial/search-hint.ejs
@@ -1,12 +1,12 @@
 <%# 検索窓を押したときに出す行き先の一覧 (#2791)。JS は足さず、フォームの
     :focus-within で開き、input:placeholder-shown で「打ち始めたら閉じる」を作る。
-    カテゴリは直近半年に投稿のあるものだけ（いま動いている入口）、タグは人気10件。
+    カテゴリは直近3ヶ月に投稿のあるものだけ（いま動いている入口）、タグは人気10件。
     カテゴリ一覧はサイドバーが持つが、記事ページでは意図して伏せている。
     ここは読者が求めたときだけ開くので、その判断とは競合しない %>
 <div class="header-search-hint">
 	<p class="header-search-hint-label">カテゴリから探す</p>
 	<ul class="header-search-hint-categories">
-		<% active_categories(6).forEach(function(c){ %>
+		<% active_categories(3).forEach(function(c){ %>
 		<li><a class="article-category-link" href="<%- url_for(c.path) %>"><%- partial('category-icon', {name: c.name}) %><%= c.name %><span class="header-search-hint-count"><%= c.count %></span></a></li>
 		<% }) %>
 	</ul>

--- a/themes/future/layout/_partial/search-hint.ejs
+++ b/themes/future/layout/_partial/search-hint.ejs
@@ -1,13 +1,14 @@
 <%# 検索窓を押したときに出す行き先の一覧 (#2791)。JS は足さず、フォームの
     :focus-within で開き、input:placeholder-shown で「打ち始めたら閉じる」を作る。
     カテゴリは直近3ヶ月に投稿のあるものだけ（いま動いている入口）、タグは人気10件。
+    全件でないことはラベルの「活発な」が名乗り、条件そのものは title が持つ (#2670)。
     カテゴリ一覧はサイドバーが持つが、記事ページでは意図して伏せている。
     ここは読者が求めたときだけ開くので、その判断とは競合しない %>
 <div class="header-search-hint">
-	<p class="header-search-hint-label">カテゴリから探す</p>
+	<p class="header-search-hint-label">活発なカテゴリから探す</p>
 	<ul class="header-search-hint-categories">
 		<% active_categories(3).forEach(function(c){ %>
-		<li><a class="article-category-link" href="<%- url_for(c.path) %>"><%- partial('category-icon', {name: c.name}) %><%= c.name %><span class="header-search-hint-count"><%= c.count %></span></a></li>
+		<li><a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事 <%= c.count %>本（直近3ヶ月に投稿あり）"><%- partial('category-icon', {name: c.name}) %><%= c.name %><span class="header-search-hint-count"><%= c.count %></span></a></li>
 		<% }) %>
 	</ul>
 	<p class="header-search-hint-label">人気のタグから探す</p>

--- a/themes/future/layout/_partial/search-hint.ejs
+++ b/themes/future/layout/_partial/search-hint.ejs
@@ -1,17 +1,13 @@
 <%# 検索窓を押したときに出す行き先の一覧 (#2791)。JS は足さず、フォームの
     :focus-within で開き、input:placeholder-shown で「打ち始めたら閉じる」を作る。
-    カテゴリは全18件（変わらない地図）、タグは人気10件（いまの話題）。
+    カテゴリは直近半年に投稿のあるものだけ（いま動いている入口）、タグは人気10件。
     カテゴリ一覧はサイドバーが持つが、記事ページでは意図して伏せている。
     ここは読者が求めたときだけ開くので、その判断とは競合しない %>
 <div class="header-search-hint">
 	<p class="header-search-hint-label">カテゴリから探す</p>
-	<%# 並びはサイドバーのカテゴリ一覧と同じ本数順。同点は名前で決める %>
-	<% const cats = site.categories.data
-		.slice()
-		.sort((a, b) => b.length - a.length || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0)); %>
 	<ul class="header-search-hint-categories">
-		<% cats.forEach(function(c){ %>
-		<li><a class="article-category-link" href="<%- url_for(c.path) %>"><%- partial('category-icon', {name: c.name}) %><%= c.name %><span class="header-search-hint-count"><%= c.length %></span></a></li>
+		<% active_categories(6).forEach(function(c){ %>
+		<li><a class="article-category-link" href="<%- url_for(c.path) %>"><%- partial('category-icon', {name: c.name}) %><%= c.name %><span class="header-search-hint-count"><%= c.count %></span></a></li>
 		<% }) %>
 	</ul>
 	<p class="header-search-hint-label">人気のタグから探す</p>
@@ -19,5 +15,4 @@
 	<div class="blog-tags">
 		<%- partial('../_widget/tag.ejs') %>
 	</div>
-	<p class="more-link"><a href="<%- url_for('/tags/') %>">すべてのタグを見る</a></p>
 </div>


### PR DESCRIPTION
ヘッダーの検索窓にフォーカスすると、カテゴリ全18件と人気タグ10件を並べたパネルを下に開く。`Closes #2791`

## やったこと

- `_partial/search-hint.ejs` を新設し、ヘッダーの `<form>` の中（`input` より後ろ）に置いた
- CSS だけで開閉する。**JS は1行も足していない**
  - 開く: `.header-search:focus-within input:placeholder-shown ~ .header-search-hint`
  - 閉じる: フォーカスが外れる、または**1文字でも打った瞬間**（`:placeholder-shown` が外れる）
- カテゴリは `article-category-link`（アイコン＋名前）、タグはホームと同じ `_widget/tag.ejs` をそのまま呼ぶ

## モーダルにしなかった理由

JS 無しでは Esc も閉じるボタンもスクロールロックも作れず、閉じる手段が blur だけになる。入力欄の下に開くパネルなら、開く条件と閉じる条件が両方 CSS で書ける。

## Safari のタップ問題

`:focus-within` の中にリンクを置くと、**Safari はクリックでリンクにフォーカスを与えない**ので、blur で先に閉じるとタップが着地しない。このリポジトリは同じ理由でモバイルの送信ボタンを出していない（`theme-styles.styl` の既存コメント）。

閉じる側の `visibility` だけ 0.3 秒遅らせて、消えるまでの間に click を通した。ヘッドレス Chrome で **blur → click の順序を再現**して確かめている。

| | 遷移先 |
| --- | --- |
| 遅延あり（この実装） | `/categories/Programming/` ✅ |
| 遅延なし（対照） | `/` ❌ パネルが消えて**下のサイトタイトルを押していた** |

0.6 秒後には `visibility: hidden` に戻り、同じ座標の `elementFromPoint` は本文側（`toc-link`）を返す。閉じた後に見えないクリック避けは残らない。

**実機の Safari では未確認**（この環境に無い）。イベント順序の再現までしかできていない。

## 実測

ヘッドレス Chrome（Noto Sans CJK なので折り返しは概算）:

| 幅 | パネル | 列×行 | 本文を覆う量 |
| --- | --- | --- | --- |
| 1440px | 490×306 | 3列6行 | 212px |
| 1024px | 490×306 | 3列6行 | 212px |
| 375px | 351×434 | 2列9行 | 371px |

どの幅でも画面内に収まる（`belowFold=0`）。幅は最長の「DataEngineering 45」の実測139pxから決めた。

閉じている / 開く / 打ち始める の3状態は 1440・1024・375 の全てで `hidden → visible → hidden` を確認した。

## 件数

パネルの数字はフロントマターの直接集計と一致する。同点はカテゴリ名で決めている（DB→Infrastructure、IaC→Mobile）。

Programming 327 / DevOps 134 / Frontend 134 / Culture 130 / DataScience 100 / Cloud 75 / DB 70 / Infrastructure 70 / IaC 57 / Mobile 57 / IoT 52 / Business 50 / Management 48 / AIDD 46 / DataEngineering 45 / Security 36 / 認証認可 24 / VR 20

## ビルドへの影響

`recent_popular_tags` は714タグ×所属記事を舐めるので、全ページから呼ぶと効く。結果を持ち回るようにした（記事数が変わったら作り直すので `hexo server` でも古くならない）。

フルビルドは **85秒 / 2849ファイル / エラー0**。従来の記録（約90秒）と変わらない。

HTML は1ページあたり **+12.4KB（gzip +2.3KB）**。134KB の記事ページに対して +9%。半分はカテゴリアイコンの SVG で、サイドバーが同じものを既に持っている。

## 残した判断

- **キーボードのタブ順が29個増える。** 検索窓はページ最初のフォーカス対象なので、タブで本文へ向かう読者はパネルの中を通ることになる。開いた状態は目に見えているので順序としては破綻していないが、多い。`tabindex="-1"` で外す手はあるが、記事ページではキーボードからカテゴリへ行く道が無くなるので取らなかった
- **枠の色（#2796）は範囲外。** 別PRでマージ済み

## 確認したこと

- textlint（`.ejs` 込み）: 指摘なし
- prettier（`scripts/**/*.js` と `*.mjs`）: All matched files use Prettier code style
- 生成物: ホーム / 記事 / タグ / カテゴリ / 著者 / 特設 / doctor の7種で18件＋10件を確認。サンプル80ページで、パネルが無いのは alias のリダイレクトHTML 1件のみ（ヘッダーを持たないページ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)