### PR TITLE
関連記事と参照している記事から NEW を外す (#2788)

### DIFF
--- a/scripts/lib/post_list.js
+++ b/scripts/lib/post_list.js
@@ -10,7 +10,7 @@ const { getSNSCnt } = require('./sns');
  *
  * 並びはタイトル -> NEW -> (日付 / 反響) の順。読み手は「何の記事か」を
  * 見てから「古くないか」「評判はどうか」を確認するため、
- * 判断の順序に合わせている。
+ * 判断の順序に合わせている。NEW を出すかは呼び出し側が決める（newLabel の注記）。
  */
 
 // 反響が0のときは何も出さない。0と表示されると寂しく見えるため。
@@ -23,7 +23,15 @@ const snsLabel = (permalink) => {
     : '';
 };
 
-// 公開から30日以内なら NEW を付ける
+// 公開から30日以内なら NEW を付ける。
+//
+// **出すのはランキングだけ**（呼び出し側が withNew で渡す、#2788）。
+// 関連記事は関連度順、参照している記事は張られたリンクの記録で、どちらも
+// 新しさが並びの理由ではない。実測では参照している記事の92%が NEW
+// （12ページ中10ページが全行 NEW）で、しかも並びが日付降順なので二重だった。
+// 関連記事は逆に全期間で0.5%しか出ず、出るのは同じ連載の同時期の記事。
+// ランキングは PV 順で新しさと無関係なので、「まだ読んでいないかもしれない
+// 新顔」の合図として働く（74行中14行）
 const newLabel = (date) => {
   const threshold = new Date();
   threshold.setDate(threshold.getDate() - 30);
@@ -33,21 +41,27 @@ const newLabel = (date) => {
 /**
  * @param {object} post          Hexo の post
  * @param {string} itemClass     li に付けるクラス
- * @param {string} [titleAttr]   a の title 属性。省略時は lede
- * @param {boolean} [withThumb]  タイトルの左に小さいサムネを添える (#2230)
- * @param {{html: string, className: string}} [rankMark]
+ * @param {object} [opts]
+ * @param {string} [opts.titleAttr]  a の title 属性。省略時は lede
+ * @param {boolean} [opts.withThumb] タイトルの左に小さいサムネを添える (#2230)
+ * @param {{html: string, className: string}} [opts.rankMark]
  *        行頭に出す順位の丸。ランキング用 (#2249)。中身も段のクラスも呼び出し側が決める。
  *        何位がどの段か・数字を出すか記号にするかはランキング側の都合なので、
  *        ここは受け取った通りに包むだけにしている (#2681)
+ * @param {boolean} [opts.withNew]   NEW を出す (#2788)
  */
-const postListItem = (post, itemClass, titleAttr, withThumb = false, rankMark = null) => {
+const postListItem = (
+  post,
+  itemClass,
+  { titleAttr, withThumb = false, rankMark = null, withNew = false } = {},
+) => {
   const attr = (titleAttr === undefined ? post.lede : titleAttr) || '';
   const rankLabel = rankMark
     ? `<span class="post-list-rank${rankMark.className ? ' ' + rankMark.className : ''}">${rankMark.html}</span>`
     : '';
   const body =
     `<a href="/${post.path}" title="${attr}">${post.title}</a>` +
-    `${newLabel(post.date)}` +
+    `${withNew ? newLabel(post.date) : ''}` +
     // 関連記事・ランキングの日付は鮮度の目安なので年月まで (#2404)。
     // 日まで出すのは、日付が並びの座標になる時系列リストと記事自身だけ
     `<span class="post-meta"><span class="post-meta-date">${post.date.format('YYYY.MM')}</span>${snsLabel(post.permalink)}</span>`;

--- a/scripts/popular_posts.js
+++ b/scripts/popular_posts.js
@@ -38,13 +38,13 @@ const rankingList = (posts, crownSvg, caps = [RANKING_DISPLAY_COUNT, RANKING_MAX
   const items = (list, offset) =>
     list
       .map((post, i) =>
-        postListItem(
-          post,
-          'featured-posts-item',
-          undefined,
-          true,
-          rankMark(offset + i + 1, crownSvg),
-        ),
+        // NEW を出すのはここだけ (#2788)。PV 順の並びは新しさと無関係なので、
+        // 「まだ読んでいないかもしれない新顔」の合図として働く
+        postListItem(post, 'featured-posts-item', {
+          withThumb: true,
+          rankMark: rankMark(offset + i + 1, crownSvg),
+          withNew: true,
+        }),
       )
       .join('\n');
   // 段の境界。残りが1件だけの段は畳む意味がないので前段に吸収する

--- a/scripts/reference_posts.js
+++ b/scripts/reference_posts.js
@@ -31,7 +31,7 @@ hexo.extend.helper.register('list_reference_posts', function () {
 
   // マークアップは lib/post_list.js に集約している
   const items = (posts) =>
-    posts.map((p) => postListItem(p, 'reference-posts-item', undefined, true)).join('');
+    posts.map((p) => postListItem(p, 'reference-posts-item', { withThumb: true })).join('');
 
   // ul の直下に details は置けないため、畳む分は別の ul にして details で包む
   const more =

--- a/scripts/related_posts.js
+++ b/scripts/related_posts.js
@@ -123,7 +123,7 @@ function generateRelatedPostsHtml(posts, series) {
   const item = (related) => {
     const scoreText = related.score ? `スコア: ${related.score.toFixed(4)}` : '';
     const titleAttr = `${related.lede} ${scoreText}`.trim();
-    return postListItem(related, 'related-posts-item', titleAttr, true);
+    return postListItem(related, 'related-posts-item', { titleAttr, withThumb: true });
   };
 
   // 語彙と作りはランキング・参照記事の畳みに揃える (#2249)


### PR DESCRIPTION
記事末の「関連記事」「この記事を参照している記事」から NEW を外し、**ホームのランキングだけ**に残す。

Closes #2788

## issue の前提を1つ訂正

`postListItem` を通るのは3か所だが、3つ目は「よく読まれている記事」**ではなくホームのランキング**だった。カテゴリ・タグ・著者・期間ページの「よく読まれている記事」は `scripts/ga4_pv.js` の `popular_posts_in` が組む別のカード実装で、**NEW は付いていない**。

| 場所 | 並びの理由 | 変更前 | 変更後 |
| --- | --- | --- | --- |
| 関連記事（記事末） | 関連度 → 同点なら公開日の近さ | NEW あり | **無し** |
| この記事を参照している記事（記事末） | **公開日の新しい順** | NEW あり | **無し** |
| ホームのランキング（トレンド / 年間人気） | PV | NEW あり | あり（変更なし） |
| ホームの新着一覧（カード） | **公開日の新しい順** | 無し | 無し |
| よく読まれている記事（カテゴリ等、カード） | PV | 無し | 無し |

変更前は **「新しさ」が並びの理由になっている場所には NEW が無く、なっていない場所にだけ付いている**という逆転が起きていた。

## 数えた結果

NEW が付く母数は全1,234本のうち17本（1.4%）。

| 場所 | 行 | うち NEW | |
| --- | --- | --- | --- |
| 参照している記事（直近20本） | 24 | **22（92%）** | 12ページ中**10ページが全行 NEW** |
| 関連記事（直近20本） | 160 | 17（11%） | 全行が NEW のページは0 |
| 関連記事（全期間サンプル23本） | 184 | **1（0.5%）** | |
| ホームのランキング | 74 | 14（19%） | |

- **参照している記事は構造的にほぼ全行が NEW になる。** 自分より後に書かれた記事しか並ばないので、新しい記事ほど参照元も新しい。しかも `reference_posts.js` が**日付降順に並べている**ので、NEW は並びの二重表示だった
- **関連記事はほとんど出ない。** 全期間では0.5%。出るのは連載中の同時期の記事で、「新しいから読む」ではなく「同じ連載だから並んでいる」だけ
- **ランキングは PV 順で新しさと無関係**なので、19%（74行中14）の NEW は「まだ読んでいないかもしれない新顔」の合図として働く

## やったこと

`postListItem` の任意引数をオプションにして、**NEW を出すかを呼び出し側で明示**する形にした。「NEW はランキングだけ」という規則がコードから読めるようにするため。

```js
// 変更前（第3・4・5引数が位置引数）
postListItem(p, 'reference-posts-item', undefined, true)
// 変更後
postListItem(p, 'reference-posts-item', { withThumb: true })
postListItem(post, 'featured-posts-item', { withThumb: true, rankMark: …, withNew: true })
```

呼び出しは3か所すべて（`related_posts.js` / `reference_posts.js` / `popular_posts.js`）。判断の理由は `lib/post_list.js` の `newLabel` の注記に置いた。

## 検証

`hexo clean` して `hexo server` を立て直し（`scripts/` を触ったので）、生成物を数えた。

| | 変更前 | 変更後 |
| --- | --- | --- |
| 関連記事（直近20本・160行） | NEW 17 | **0** |
| 参照している記事（直近20本・24行） | NEW 22 | **0** |
| ホームのランキング（74行） | NEW 14 | **14**（変わらず） |
| ホーム全体の `newitem` の数 | 14 | **14** |

`npx prettier --check "scripts/**/*.js" "*.mjs"` は通る。`.md` / `.ejs` を触っていないので reviewdog（textlint）はスキップされる。

## この PR の範囲外

- **`.newitem` の CSS は残す。** 別の意味の NEW が2つある（著者一覧で「その年が初投稿の著者」#2413 / Tech Cast ウィジェットの新着エピソード）。どちらも別実装なので影響しない
- **「新しく関連記事として現れた」を示す NEW は作らない**（issue の4点目）。前回ビルド時の関連記事集合を保存して差分を取る必要があり、今の「公開30日以内」とは仕組みから別物になる。必要なら別 issue で

🤖 Generated with [Claude Code](https://claude.com/claude-code)
