### PR TITLE
年別タブの色の説明を消す (#2807)

### DIFF
--- a/scripts/archive_post_chart.js
+++ b/scripts/archive_post_chart.js
@@ -79,7 +79,6 @@ const generatePostsSeries = (posts, year) => {
 //
 // 出すのは直近5年で、初期表示は直近3年（残りは凡例で足す）。11年すべてを
 // 重ねると、月1〜2本だった2016〜2018年の平坦な線が読み取りの邪魔になる。
-// 色は新しい年ほど濃い同系の濃淡で、凡例の並びと濃さが年代の順に対応する
 const YEAR_OVERLAY_SPAN = 5;
 const YEAR_OVERLAY_SHOWN = 3;
 


### PR DESCRIPTION
`scripts/archive_post_chart.js` の「年別」タブの説明から、実装と食い違っていた1行を消す。

```diff
 // 出すのは直近5年で、初期表示は直近3年（残りは凡例で足す）。11年すべてを
 // 重ねると、月1〜2本だった2016〜2018年の平坦な線が読み取りの邪魔になる。
-// 色は新しい年ほど濃い同系の濃淡で、凡例の並びと濃さが年代の順に対応する
```

## 消す（書き直さない）理由

このヘルパー（`posts_year_overlay_series`）が返すのは系列名・データ・初期表示（`selected`）だけで、
**色は決めていない**。年別の色は option を書く `_partial/posts-chart.ejs` が持っていて、
そこに理由まで書かれている（「5本を濃淡だけで分けると、細い線では隣り合う段の区別が付かない。
年ごとに色相を変えて、古い年ほど彩度を落として引かせる」＋白地とのコントラスト 5.35 / 16.34 /
3.25 / 3.18 / 3.23）。

同じ理由を2箇所に置くと片方だけ古くなる。実際この行は #2767 で色相に変えたときに取り残され、
「濃い同系の濃淡」という今は存在しない色の説明が残っていた。#2768 で決めた
「一致に意味があるならコードで共有し、意味が無いなら書かない」に従って、書き直さず消す。

`濃淡` を名指ししている他の箇所（`scripts/chart_style.js` の `NAVY_STEPS` まわり）は
実際に濃淡なので触っていない。

## 確認したこと

コメント1行の削除なので、出力が1バイトも変わらないことを見た。

- `node --check scripts/archive_post_chart.js` … 構文OK
- 開発サーバを**変更前のプロセスで**配信した `/articles/` の `const yearData = …;` を保存し、
  サーバを落として（`scripts/` は起動時にしか読まれないため）変更後に再起動、同じ行を取り直して
  `diff` … **差分なし**
- `npx prettier --check "scripts/**/*.js" "*.mjs"` … 通過

Closes #2807
