### PR TITLE
著者紹介ブロックの内側の余白を上下で揃える (#2813)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2968,6 +2968,10 @@ ul.tag-list {
 .author-box .more-link {
   text-align: left;
   margin-top: 14px;
+  /* 枠の内側の空きは .author-box-body の padding だけで決める。bootstrap の
+     p の margin-bottom: 1rem が残ると、最後の行の下だけ 16px 足されて
+     上 10.4px 対 下 26.4px になる (#2813) */
+  margin-bottom: 0;
 }
 
 /* 連載の前 / 次。関連記事・参照記事と同じ card を使いつつ、


### PR DESCRIPTION
記事末の著者紹介ブロック（#2567）の枠の内側の余白が上下で揃っておらず、下が広く見えていた。

## 原因

`.author-box-body` は四辺に `padding: 0.8em` を置いている。`body` が 13px なので 10.4px で、四辺が揃う指定になっていた。

ところが中身の最後が `<p class="more-link">執筆記事の一覧を見る（N本）</p>` で、`.author-box .more-link` は `text-align` と `margin-top` しか持たない。bootstrap-subset の `p{margin-top:0;margin-bottom:1rem}` がそのまま生きるため（`html` に font-size 指定が無いので rem = 16px）、下だけ 16px 足されていた。

`.author-box-body` は `display: flex` で、その中の `.author-box-text` は flex アイテムなので独立したフォーマットコンテキストを作る。子の下マージンは外へ抜けず、そのままブロックの高さに乗る。

| | 内側の空き | |
| --- | --- | --- |
| | before | after |
| 上 | 10.4px | 10.4px |
| 下 | 10.4 + 16 = **26.4px** | **10.4px** |

## やったこと

`.author-box .more-link` に `margin-bottom: 0` を足した。枠の内側の空きは `.author-box-body` の `padding` 1箇所だけで決まる形に戻している。`padding` の値は動かしていない。

## 併せて確かめたこと

- **イニシャルの丸（48px）との高さ差**: 紹介文が1行の著者でも文章列は 73px あり、丸より高い。丸が上端に残る見え方は変わらない
- **関連記事・参照記事のカードとの揃い**: あちらは見出しが `padding: 0.8em 0.8em 0.4em`、行のリストが `padding: 0 0.8em 0.6em` で、左右は同じ 0.8em。3つが縦に並んだときの左端は揃っている

## 検証

`make css` で `public/css/site.css` を再生成し、出力を確認した。

```css
.author-box .more-link {
  text-align: left;
  margin-top: 14px;
  margin-bottom: 0;
}
```

bootstrap-subset の `p{margin-top:0;margin-bottom:1rem}` は連結後の 1036 バイト目、こちらは 67241 バイト目なので、詳細度（0,2,0 対 0,0,1）でも順序でも勝つ。

CSS だけの変更なので `hexo generate` は回していない。

Closes #2813

🤖 Generated with [Claude Code](https://claude.com/claude-code)
