### PR TITLE
コーポレートのコピーを「経営とAIをデザインする」に変える (#2811)

### DIFF
--- a/scripts/weekly_digest_mail.js
+++ b/scripts/weekly_digest_mail.js
@@ -28,7 +28,7 @@ hexo.extend.helper.register('weekly_digest_mail_body', function () {
           <td style="padding:4%">
               <h1 style="text-align:center">Future Tech Blog Weekly Digest</h1>
               <p style="text-align:center"><a href="https://future-architect.github.io/">フューチャー技術ブログ</a>の${currentYear}年${currentMonth}月${weeknumber}週目の投稿サマリです🚀</p>
-              <p style="text-align:center"> 経営とITをデザインする、フューチャーが運営しており、業務で利用している幅広い技術について紹介しています。 </p>
+              <p style="text-align:center"> 経営とAIをデザインする、フューチャーが運営しており、業務で利用している幅広い技術について紹介しています。 </p>
 
               <h2 style="text-align:center"> 最近投稿された記事 <img goomoji="2764" data-goomoji="2764"
                   style="margin:0 0.2ex;vertical-align:middle;max-height:24px" alt="❤"

--- a/themes/future/_config.yml
+++ b/themes/future/_config.yml
@@ -29,6 +29,6 @@ favicon: /favicon.ico # path from root of hexo site
 twitter_widget_id: "twsrc%5Etfw" # as a string, from https://publish.twitter.com/?buttonType=MentionButton&dnt=1&lang=ja&query=https%3A%2F%2Ftwitter.com%2Ffuture_techblog&widget=Timeline
 twitter_username: future_techblog # twitter username without the @
 
-about: 経営とITをデザインする、フューチャーの技術ブログです。業務で利用している幅広い技術について紹介します。
+about: 経営とAIをデザインする、フューチャーの技術ブログです。業務で利用している幅広い技術について紹介します。
 corporate_url: http://www.future.co.jp/
 email: techblog@future.co.jp


### PR DESCRIPTION
コーポレートのコピーが「経営とITをデザインする」から「経営とAIをデザインする」に変わったので、サイト自身が名乗っている箇所を差し替えた。

## 変えたところ（2箇所）

| ファイル | 出る先 |
| --- | --- |
| `themes/future/_config.yml` の `about` | フッターの「About Us」（`theme.about.split('。')[0]` で1文目だけ）とホームの `site-lede`（全文） |
| `scripts/weekly_digest_mail.js` | 週次ダイジェストメールの本文 |

`about` は文面を1箇所で持ってフッターとホームが共有する作りなので、1行の変更で両方に出る。

`weekly_digest_mail.js` のヘルパー `weekly_digest_mail_body` は `// Work In Progress` のまま、どのレイアウトからも呼ばれていない（`grep` で参照0件）。公開ページには出ないが、リポジトリの中に古い方のコピーが残るのは避けたいので併せて直した。

サイト側に「経営とITをデザインする」はもう残っていない（`themes` / `scripts` / ルートの設定・`*.mjs` / README を走査して0件）。

## 変えていないところ（過去記事6箇所）

過去記事は当時の表記なので触っていない。中身の性質が3つに分かれ、いずれも書き換えると事実と違うものになる。

- **当時の固有名詞**: `20251031b`（Vue Fes Japan 2025 で実際にアナウンスされた「経営とITをデザインする フューチャーアーキテクトトラック」というルームネイミングライツの名前）
- **引用・サンプル入力**: `20200309`（`>` の引用ブロック内のプロフィール文）、`20210312`（Text-to-Speech に読ませた入力テキストの値）
- **地の文でスローガンを引いているもの**: `20210422a` / `20220916a` / `20230313a`

## 検証

`hexo server` を再起動（テーマ設定と `scripts/` は起動時にしか読まれない）して、配信中の HTML を確認した。

- ホーム `<p class="site-lede-text">`: `経営とAIをデザインする、フューチャーの技術ブログです。業務で利用している幅広い技術について紹介します。`
- フッター About Us: `経営とAIをデザインする、フューチャーの技術ブログです。`（1文目だけ）

`npx prettier --check "scripts/**/*.js" "*.mjs"` は通っている。記事は触っていないので textlint の対象は無い。

Closes #2811

🤖 Generated with [Claude Code](https://claude.com/claude-code)
