### PR TITLE
ホームのコピーの「AI」をクリムゾンで差す (#2811)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1391,6 +1391,12 @@ body.page-header-fixed .header {
   margin: 0;
   font-size: 1.2em;
 }
+/* コピーの「AI」だけを差し色にする (#2811)。白地で 5.35（AA）。
+   同じ文面を共有するフッターの About Us はグレー地で 4.17 と AA を
+   満たさないため、span は index.ejs 側だけで付けている */
+.site-lede-accent {
+  color: var(--brand-crimson);
+}
 
 /* 記事の概要文。一覧（トップ・タグ・カテゴリ・著者）と We're hiring カードで共用。
    line-height は normal だとフォント依存で環境により 1.4〜1.7 程度に揺れるため明示する */

--- a/themes/future/layout/index.ejs
+++ b/themes/future/layout/index.ejs
@@ -10,9 +10,12 @@
       <main class="col-xs-12 col-sm-12 col-md-10 blog-posts">
     <%# ホームにブログの説明が無く、初めて来た読者に何のサイトか伝わらなかった。
         文面はフッターの About Us と同じ theme.about を使い、二重に持たない %>
+    <%# 「AI」の差し色はここだけで付ける。theme.about に span を入れると
+        フッターの About Us にも出るが、あちらはグレー地でクリムゾンが
+        4.17 と AA を満たさない (#2811) %>
     <% if (page.current === 1) { %>
     <section class="site-lede">
-      <p class="site-lede-text"><%- theme.about %></p>
+      <p class="site-lede-text"><%- theme.about.replace('AI', '<span class="site-lede-accent">AI</span>') %></p>
     </section>
     <% } %>
     <% if (page.current > 1) { %>


### PR DESCRIPTION
#2815（コピーの差し替え）に続けて、ホームのコピーの「AI」だけをブランドのクリムゾンで差した。

## やったこと

`theme.about` は素の文字列のまま残し、`index.ejs` で「AI」を `<span class="site-lede-accent">` で包む。CSS は `color: var(--brand-crimson)` の1宣言。

```ejs
<p class="site-lede-text"><%- theme.about.replace('AI', '<span class="site-lede-accent">AI</span>') %></p>
```

**フッターの About Us は素のままにした。** `theme.about` は文面を1箇所で持ってホームとフッターが共有する作りなので、config 側に span を入れると両方に出る。フッターは `--brand-gray` #E3E3E2 の地で、クリムゾン #D5004A のコントラスト比が **4.17** と AA（4.5）を満たさない（白地のホームは **5.35** で満たす）。色を付ける側を EJS に寄せて、文面の共有は保った。

## 要判断: 1位の丸と同じ視界に入る

`--brand-crimson` は「画面内で同時に1箇所だけの差し色」という制約で運用していて、現状の2箇所（フッターの波のリボン、ホームのランキング1位の丸 #2681）は「ページが縦に長く同じ視界に入らない」ことを根拠に許容している。

**ホームの site-lede は、その直後がランキングの節。**生成 HTML 上で `site-lede-text` と `popular-articles` の間は 167 文字しかなく、1位の `post-list-rank-first`（クリムゾンの丸）とコピーの「AI」はノートPCの画面で確実に同時に見える。既存の根拠が成り立たない唯一の組み合わせになる。

このまま入れる場合は「差し色は画面内1箇所」を2箇所に緩めたことになる。避けるなら次のどれか。

- 「AI」は色ではなく**太字**で示す（差し色を増やさない）
- 1位の丸のクリムゾンを外す（#2681 の判断を覆す）
- ホームの差し色をやめる

指示が「クリムゾンに色を変えて」だったのでクリムゾンで実装してある。判断をもらえれば追いコミットで直す。

## 検証

配信中の HTML と CSS を確認した。

- ホーム: `経営と<span class="site-lede-accent">AI</span>をデザインする、…`
- フッター: `経営とAIをデザインする、フューチャーの技術ブログです。`（span 無し）
- `.site-lede-accent { color: var(--brand-crimson); }`

`replace` は最初の1件だけを置き換える。この文面に「AI」は1回しか出ない。将来コピーから「AI」が消えても no-op で、壊れない。

Refs #2811

🤖 Generated with [Claude Code](https://claude.com/claude-code)
