### PR TITLE
選択中の本文リンクを白＋下線にする (#2819)

### DIFF
--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -304,8 +304,7 @@ $line-numbers
         margin-top: 1em
         margin-left: article-padding
         // 暗い地の上のリンク色。旧 color-link（#258fb8）は 3.84 で AA 未満
-        // だった。値は本文選択中のリンク（a::selection）と同じ「暗い地の
-        // リンクは水色」の語彙（この地では 7.33）
+        // だった（この地では 7.33）
         a
           color: #57c8eb
           font-weight: normal

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -110,17 +110,15 @@ Misc tools
   background: var(--brand-navy);
 }
 /* 本文のリンクは下線が hover 時にしか無く、選択の白文字では本文と
-   区別が付かなくなる。::selection に text-decoration は効かない
-   （Chromium 非対応）ため文字色で区別する。水色はネイビーの選択地で
-   読める明るさ（8.45）を持つリンク系の色。
+   区別が付かなくなる。文字色は既定（白）のまま、下線で区別する。
    対象は本文（.article-entry）だけに絞る。素の a まで広げると、
    青いリンクの見た目をしていないもの（タグチップ・著者名などの
-   グレーのメタリンク）まで選択で水色になってしまう */
+   グレーのメタリンク）まで選択で下線が付いてしまう */
 .article-entry a::-moz-selection {
-  color: #57c8eb;
+  text-decoration: underline;
 }
 .article-entry a::selection {
-  color: #57c8eb;
+  text-decoration: underline;
 }
 /* コピーライト帯はネイビー地なので、ネイビーの選択色では選択が見えない。
    塗りと文字を反転させる（ネイビー文字とグレー地で 12.72）。


### PR DESCRIPTION
記事本文を選択したとき、選択範囲の中のリンクだけ水色になっていたのを、**白（既定の選択色）＋下線**に変えた。

## 変更

```diff
 .article-entry a::selection {
-  color: #57c8eb;
+  text-decoration: underline;
 }
```

`::-moz-selection` も同じ。`color` を外したので、選択の既定（`::selection { color: #fff; background: var(--brand-navy) }`）がそのまま効く。

対象を `.article-entry` に絞る形は変えていない。素の `a` まで広げると、青いリンクの見た目をしていないもの（タグチップ・著者名などのグレーのメタリンク）まで選択で下線が付く。

## 経緯

水色にしていた理由はコメントに残っていた。

> 本文のリンクは下線が hover 時にしか無く、選択の白文字では本文と区別が付かなくなる。`::selection` に `text-decoration` は効かない（**Chromium 非対応**）ため文字色で区別する。

つまり**下線で区別するのが元の意図で、当時それが使えないと判断して色で代えていた**。この PR はその代替を外して元の意図に戻すもの。CSS Pseudo-Elements Level 4 は highlight 疑似要素に `text-decoration` を認めており、Chromium の highlight 描画もその後作り直されている。

## 要確認: 下線が実際に描かれるか

**この環境にブラウザが無いため、`::selection` の `text-decoration` が描かれることを実機で確かめられていない。**目視での確認をお願いしたい。描かれない場合、リンクは選択中に本文と同じ白になり、区別が付かなくなる（現状より悪くなる）。

描かれなかったときの選択肢は2つ。

- 水色に戻す（この PR を取り下げ）
- **本文リンクに常時下線を引く。** そうすれば選択中も下線が残り、`::selection` の対応に依存しなくなる。ただしリンクの普段の見た目が変わるので別の判断になる

## 併せて直したコメント

`highlight.styl` のコードブロックのキャプション内リンク（`#57c8eb`）に「値は本文選択中のリンク（`a::selection`）と同じ『暗い地のリンクは水色』の語彙」というコメントがあった。本文側から水色が消えて参照先が無くなるので、その一句を落とした。色自体は暗い地の上のリンク色として残る（この地で 7.33）。

## 検証

`make css` と配信中の CSS を確認した。`.article-entry a::selection` / `::-moz-selection` はどちらも `text-decoration: underline` の1宣言だけになり、`#57c8eb` の残りは `highlight.styl` の1件のみ。

Closes #2819

🤖 Generated with [Claude Code](https://claude.com/claude-code)
