### PR TITLE
折り返しトグルを横スクロールから外す (#2821)

### DIFF
--- a/scripts/code_wrap_toggle.js
+++ b/scripts/code_wrap_toggle.js
@@ -117,7 +117,14 @@ function addToggles(content, prefix) {
     const control =
       `<input type="checkbox" id="${id}" class="${cls}" aria-label="${LABEL}">` +
       `<label class="code-wrap-label" for="${id}" title="${LABEL}"></label>`;
-    return figure.replace(/^(<figure class="highlight\b[^>]*>)/, `$1${control}`);
+    // figure を1枚包む。ラベルは figure の中に置いたまま、位置だけこの箱を
+    // 基準にする（#2821）。figure は横スクロールを受ける箱なので、その中に
+    // 包含ブロックがあるとラベルが中身と一緒に流れる。外に基準を作れば
+    // スクロールからも overflow の切り取りからも外れる。
+    // ラベルを figure の外へ出さないのは、トグルの出し分けが
+    // `@container scroll-state` で figure の子孫にしか効かせられないため
+    const withControl = figure.replace(/^(<figure class="highlight\b[^>]*>)/, `$1${control}`);
+    return `<div class="code-block">${withControl}</div>`;
   });
 }
 

--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -85,6 +85,16 @@ $line-numbers
       background: none
       border-radius: 0
       padding: 0
+  // 折り返しトグルの付くブロックだけ、scripts/code_wrap_toggle.js が
+  // figure を1枚包む。役割はトグルの位置の基準を横スクロールの外に作ること
+  // だけで、この箱自体は背景も余白も持たない (#2821)
+  .code-block
+    position: relative
+  // 折り返しトグルはファイル名のタブと同じ帯に置く。タブが無いブロックは
+  // 帯そのものが無いので、ラベルのぶんだけ上を空けてコードを下げる。
+  // 28px（枠1＋padding5＋絵柄16＋padding5＋枠1）にタブとの間隔4pxを足した値
+  .highlight:has(> .code-wrap-input):not(:has(> figcaption))
+    padding-top: 32px
   // コードブロックの構造は figure.highlight > figcaption + table。
   // 背景を figure ではなく table に持たせる。figure が背景を持つと
   // ファイル名の行まで幅いっぱいに暗くなり、暗い面積がその分増える
@@ -160,13 +170,18 @@ $line-numbers
       width: 1px
       height: 1px
       opacity: 0
-    // ファイル名のタブ（figcaption）と同じ帯の右端に置く。float なのは、
-    // ブロックにすると帯が2段になってコードが下がるため。
-    // タブより低くしてあるので、両方あるときの帯の高さは今までと変わらない
+    // ファイル名のタブ（figcaption）と同じ帯の右端に置く。
+    // タブより低くしてあるので、両方あるときの帯の高さは今までと変わらない。
+    //
+    // **基準は figure の外の .code-block** (#2821)。figure は横スクロールを
+    // 受ける箱なので、その中を基準にすると（float でも sticky でも絶対配置でも）
+    // 中身と一緒に左へ流れて画面外へ出る。sticky が効かないのは、包含ブロックが
+    // figure の「見えている幅」しかなく右へ動く余地が無いため
     .code-wrap-label
-      float: right
+      position: absolute
+      top: 0
+      right: 0
       padding: 5px
-      margin-bottom: 4px
       // 小物の段（_variables.styl の3段のうち radius-small）
       border-radius: radius-small
       // 触っていないときは絵柄だけ。枠も面も出さない。
@@ -211,9 +226,6 @@ $line-numbers
     .code-wrap-input:focus-visible + .code-wrap-label
       outline: 2px solid var(--brand-navy)
       outline-offset: 2px
-    // float の下にコードを送る。トグルのあるブロックにだけ効かせる
-    .code-wrap-input ~ table
-      clear: both
     .code-wrap-input:checked ~ table
       // 折り返すので内容ぶんの幅は要らない
       width: auto
@@ -483,14 +495,21 @@ pre
     // 端まで伸ばすのは .article-entry の直下にあるコードだけ (#2568 と同じ形)。
     // calc(50% - 50vw) の 50% は包む箱の幅を指すので、折りたたみ（141件）や
     // 箇条書き（117件）の中では包む箱のぶんだけ余分に外へ出てしまう。
-    // details の中では overflow: hidden に切り落とされる
+    // details の中では overflow: hidden に切り落とされる。
+    //
+    // トグルの付くブロックは figure が .code-block に包まれている (#2821)。
+    // **伸ばすのは包む箱の側**で、figure ではない。ラベルの位置は
+    // .code-block を基準にするので、箱が画面端まで伸びていないと
+    // ラベルだけコードの内側に取り残される
     > figure.highlight,
+    > .code-block,
     > pre
       margin-inline: calc(50% - 50vw)
     // 画面端まで伸びた面に角丸は掛からない
     > pre
       border-radius: 0
-    > figure.highlight
+    > figure.highlight,
+    > .code-block > figure.highlight
       table
         border-radius: 0
       // タブは内容幅のまま。左は画面端に接するので落とし、右上だけ残す
@@ -498,7 +517,7 @@ pre
         border-radius: 0 card-radius 0 0
       // 画面端まで伸びたぶん、トグルもコードの1文字目と同じだけ内側へ入れる
       .code-wrap-label
-        margin-right: article-padding-narrow
+        right: article-padding-narrow
 
 // **実際に横スクロールできるブロックにだけトグルを出す** (#2752)。
 //

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -680,6 +680,12 @@ h4 {
 .article-entry details > .highlight:last-child {
   margin-bottom: 0;
 }
+/* 折り返しトグルの付くコードブロックは .code-block に包まれているので、
+   直接子のセレクタから外れる (#2821)。包む箱の margin を 0 にしても
+   中の figure の下マージンが相殺で抜けてくるため、figure 側に書く */
+.article-entry details > .code-block:last-child > .highlight {
+  margin-bottom: 0;
+}
 .article-entry details > summary {
   display: flex;
   align-items: center;


### PR DESCRIPTION
折り返しトグルが横スクロールで一緒に流れていたのを、スクロールの外に固定した。

## なぜ `position: sticky` では直らないか

トグルの `<label>` は `figure.highlight`（`overflow: auto` の横スクロール箱）の中にあり、`float: right` で置かれている。**float でも sticky でも絶対配置でも、包含ブロックが figure の中にある限り中身と一緒に流れる。**

`position: sticky` が効かないのは包含ブロックの幅のため。sticky は「包含ブロックの中で」動ける範囲しか動けない。ラベルの包含ブロックは figure の**見えている幅**（本文列の幅）で、スクロール幅ではない。`right: 0` を付けても、スクロール前の位置がすでに包含ブロックの右端なので、右へ動く余地がゼロになる。表の固定列で sticky が効くのは、包含ブロック（行）がスクロール幅いっぱいあるから。

## なぜラベルを figure の外へ出さないか

トグルの出し分けがコンテナクエリで組まれている（#2752）。

```css
@container not scroll-state(scrollable: inline) {
  .article-entry .highlight .code-wrap-label { display: none }
}
```

コンテナは `.highlight`（スクロールする箱）で、コンテナクエリは**コンテナの子孫しか指定できない**。ラベルを figure の外へ出すと、「実際に溢れているブロックにだけトグルを出す」が丸ごと効かなくなる。

## やったこと

**DOM 上は figure の中に残したまま、位置の基準だけ外に作る。** 絶対配置の要素は、包含ブロックがスクロール箱の外にあればスクロールからも `overflow` の切り取りからも外れる。

1. `scripts/code_wrap_toggle.js` … トグルを付ける figure を `<div class="code-block">` で1枚包む（トグルの付かないブロックは包まない）
2. `.code-block { position: relative }` … 位置の基準。背景も余白も持たない
3. `.code-wrap-label` … `float: right` → `position: absolute; top: 0; right: 0`

## 併せて直した3件（包む箱を足したことで直接子のセレクタから外れる）

| 場所 | 直したこと |
| --- | --- |
| **帯の高さ** | `float` を外したので `.code-wrap-input ~ table { clear: both }` が空振りになる。ファイル名タブの無いブロックはコードがラベルの下に潜るので、`.highlight:has(> .code-wrap-input):not(:has(> figcaption))` に `padding-top: 32px`（枠1＋padding5＋絵柄16＋padding5＋枠1＝28、＋タブとの間隔4） |
| **モバイルの全幅化（#2568）** | `.article-entry > figure.highlight` は直接子のセレクタで、包んだ figure は外れる。**伸ばすのは包む箱の側**に変えた（`> .code-block`）。ラベルは `.code-block` を基準にするので、箱が画面端まで伸びていないとラベルだけ内側に取り残される。角丸とラベルの内寄せは `> .code-block > figure.highlight` を足して両方の形に効かせる |
| **`<details>` の中の末尾** | `.article-entry details > .highlight:last-child { margin-bottom: 0 }` も直接子。包む箱に `margin-bottom: 0` を付けても中の figure の下マージンが相殺で抜けてくるので、`> .code-block:last-child > .highlight` を足した |

## 検証

`scripts/` のフィルタを触ったので `hexo clean` してからサーバを起動し、配信中の HTML を機械で確かめた。

| 記事 | figure | トグル付き | `.code-block` で包まれた数 | ファイル名タブ |
| --- | --- | --- | --- | --- |
| /articles/20260729a/ | 8 | 5 | 5 | あり |
| /articles/20260807a/ | 7 | 2 | 2 | あり |
| /articles/20260612a/ | 7 | 2 | 2 | **なし**（padding で空ける側） |

- トグルの付かない figure が包まれていないこと、ラベルが figure の**中**にあること（コンテナクエリの条件）も確認した
- CSS 側は `.article-entry .code-block` / `:has(> .code-wrap-input):not(:has(> figcaption))` / `> .code-block` / `> .code-block > figure.highlight` / `details > .code-block:last-child > .highlight` の5つが出力されている
- `npx prettier --check "scripts/**/*.js" "*.mjs"` は通る

**ブラウザが無い環境なので、見た目は目視での確認をお願いしたい。**特に (a) 横スクロールしてもトグルが右上に残るか、(b) ファイル名タブの無いブロックでトグルとコードが重なっていないか、(c) モバイル幅でコードが画面端まで伸び、トグルが1文字目と同じだけ内側に入るか、(d) `<details>` の中のコードブロックの下の余白。

Closes #2821

🤖 Generated with [Claude Code](https://claude.com/claude-code)
