### PR TITLE
コードブロックのタブの地を本体と同じ色にする (#2818)

### DIFF
--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -24,6 +24,9 @@ highlight-caption-border = #4e5254
 // タブの根本が外へ広がる量 (#2818)。角丸の「箱」の段と同じ 8px で、
 // 上の角の丸みと根本のふくらみが同じ半径で釣り合う
 tab-flare = 8px
+// 折り返しトグルの外形（絵柄16px＋padding 5px×2＋枠1px×2）。
+// トグルは絶対配置で行から外れているので、タブがこの幅を自分で避ける
+wrap-toggle-size = 28px
 // 差分専用。文字列の緑（#6a8759）だと削除側の赤に対して弱く見えるため、
 // 追加・削除を同じくらいの鮮やかさに揃える
 highlight-diff-added = #89d185
@@ -190,6 +193,13 @@ $line-numbers
     figcaption::after
       right: -(tab-flare)
       background: unquote("radial-gradient(circle at 100% 0, transparent " + tab-flare + ", " + highlight-caption-background + " " + (tab-flare + 0.5px) + ")")
+    // ファイル名が長いと、タブが右上のトグルの下に潜る (#2818)。トグルは
+    // 絶対配置なので行ボックスを縮めてくれない（float だった頃は避けていた）。
+    // タブ側で幅を空ける。トグルが今出ているかに関わらず引くのは、出す出さないを
+    // 決めているのがコンテナクエリで、未対応のブラウザでは出たままになるため。
+    // 8px はタブとトグルの間隔
+    &:has(> .code-wrap-input) figcaption
+      max-width: unquote("calc(100% - " + (tab-flare * 2 + wrap-toggle-size + 8px) + ")")
     // タブが乗る側だけ角を落として、タブと本体をつなげて見せる
     figcaption + table
       border-top-left-radius: 0

--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -133,13 +133,15 @@ $line-numbers
       // ブロックのまま内容幅に縮める
       display: block
       width: fit-content
-      // 根本のふくらみのぶんだけ狭める。100% のままだと長いファイル名で
+      // 左右のふくらみのぶんだけ狭める。100% のままだと長いファイル名で
       // タブが幅いっぱいになり、ふくらみが figure の外へ出て横スクロールが
       // 生まれる。溢れの有無は折り返しトグルの出し分けに使っているので、
       // 飾りでスクロールを作らない
-      max-width: unquote("calc(100% - " + tab-flare + ")")
-      margin: 0
-      padding: 6px article-padding
+      max-width: unquote("calc(100% - " + (tab-flare * 2) + ")")
+      // 左のふくらみが広がる隙間を空ける。離したぶんは padding から引いて、
+      // ファイル名の1文字目がコードの1文字目に揃う位置を保つ（8 + 12 = 20）
+      margin: 0 0 0 tab-flare
+      padding: 6px article-padding 6px (article-padding - tab-flare)
       background: highlight-caption-background
       border-radius: card-radius card-radius 0 0
       color: highlight-foreground
@@ -172,15 +174,21 @@ $line-numbers
     // 根本のふくらみ (#2818)。Chrome や Windows ターミナルのタブと同じで、
     // タブの側面から本体の上辺へ弧でつなぐ。タブ色の正方形から四分円を
     // 抜いて作る（弧の内側は背後の白地が見える）。
-    // 左側は付けない。タブは本体と左端が揃っていて、間に広げる隙間が無い
+    // 円の中心を外側の上隅に置くので、タブ側は全高が塗られ、外へ行くほど
+    // 高さが減って 8px 地点で 0 になる。0.5px ずらすのは、抜いた縁に
+    // 地の色が線で残るのを防ぐため
+    figcaption::before,
     figcaption::after
       content: ''
       position: absolute
-      right: -(tab-flare)
       bottom: 0
       width: tab-flare
       height: tab-flare
-      // 0.5px ずらすのは、抜いた四分円の縁に地の色が線で残るのを防ぐため
+    figcaption::before
+      left: -(tab-flare)
+      background: unquote("radial-gradient(circle at 0 0, transparent " + tab-flare + ", " + highlight-caption-background + " " + (tab-flare + 0.5px) + ")")
+    figcaption::after
+      right: -(tab-flare)
       background: unquote("radial-gradient(circle at 100% 0, transparent " + tab-flare + ", " + highlight-caption-background + " " + (tab-flare + 0.5px) + ")")
     // タブが乗る側だけ角を落として、タブと本体をつなげて見せる
     figcaption + table
@@ -518,8 +526,13 @@ pre
         padding-left: article-padding-narrow
         padding-right: article-padding-narrow
       figcaption
+        // 左端に接する作りなので左のふくらみは出さない (#2818)。
+        // 離す隙間が無く、離すとコードの1文字目との揃いも崩れる
+        margin-left: 0
         padding-left: article-padding-narrow
         padding-right: article-padding-narrow
+        &::before
+          display: none
     // 端まで伸ばすのは .article-entry の直下にあるコードだけ (#2568 と同じ形)。
     // calc(50% - 50vw) の 50% は包む箱の幅を指すので、折りたたみ（141件）や
     // 箇条書き（117件）の中では包む箱のぶんだけ余分に外へ出てしまう。

--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -15,12 +15,10 @@ highlight-yellow = #ffc66d         // 関数名・型名
 highlight-green = #84a86f          // 文字列
 highlight-blue = #6897bb           // 数値・リテラル・関数
 highlight-purple = #b18ac4
-highlight-caption-background = #3c3f41   // Darcula のエディタタブ相当
 // 横スクロールのつまみ (#2775)。OS 既定の半透明の黒はこの地の上で 1.9 しかなく、
 // 出ていても位置が読めない。地に対して 4.10、本文の #a9b7c6 に対しては 1.69 で、
 // 見えるが文字と競合しない明るさにする
 highlight-scrollbar = #7f8b9c
-highlight-caption-border = #4e5254
 // タブの根本が外へ広がる量 (#2818)。角丸の「箱」の段と同じ 8px で、
 // 上の角の丸みと根本のふくらみが同じ半径で釣り合う
 tab-flare = 8px
@@ -145,7 +143,7 @@ $line-numbers
       // ファイル名の1文字目がコードの1文字目に揃う位置を保つ（8 + 12 = 20）
       margin: 0 0 0 tab-flare
       padding: 6px article-padding 6px (article-padding - tab-flare)
-      background: highlight-caption-background
+      background: highlight-background
       border-radius: card-radius card-radius 0 0
       color: highlight-foreground
       // ふくらみを外へ出すための土台
@@ -189,10 +187,10 @@ $line-numbers
       height: tab-flare
     figcaption::before
       left: -(tab-flare)
-      background: unquote("radial-gradient(circle at 0 0, transparent " + tab-flare + ", " + highlight-caption-background + " " + (tab-flare + 0.5px) + ")")
+      background: unquote("radial-gradient(circle at 0 0, transparent " + tab-flare + ", " + highlight-background + " " + (tab-flare + 0.5px) + ")")
     figcaption::after
       right: -(tab-flare)
-      background: unquote("radial-gradient(circle at 100% 0, transparent " + tab-flare + ", " + highlight-caption-background + " " + (tab-flare + 0.5px) + ")")
+      background: unquote("radial-gradient(circle at 100% 0, transparent " + tab-flare + ", " + highlight-background + " " + (tab-flare + 0.5px) + ")")
     // ファイル名が長いと、タブが右上のトグルの下に潜る (#2818)。トグルは
     // 絶対配置なので行ボックスを縮めてくれない（float だった頃は避けていた）。
     // タブ側で幅を空ける。トグルが今出ているかに関わらず引くのは、出す出さないを

--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -19,16 +19,13 @@ highlight-purple = #b18ac4
 // 出ていても位置が読めない。地に対して 4.10、本文の #a9b7c6 に対しては 1.69 で、
 // 見えるが文字と競合しない明るさにする
 highlight-scrollbar = #7f8b9c
-// タブの根本が外へ広がる量 (#2818)。角丸の「箱」の段と同じ 8px で、
-// 上の角の丸みと根本のふくらみが同じ半径で釣り合う
-tab-flare = 8px
-// 折り返しトグルの外形（絵柄16px＋padding 5px×2＋枠1px×2）。
-// トグルは絶対配置で行から外れているので、タブがこの幅を自分で避ける
-wrap-toggle-size = 28px
 // 差分専用。文字列の緑（#6a8759）だと削除側の赤に対して弱く見えるため、
 // 追加・削除を同じくらいの鮮やかさに揃える
 highlight-diff-added = #89d185
 highlight-diff-removed = #ff6b68
+// 折り返しトグルの外形（絵柄16px＋padding 5px×2＋枠1px×2）。
+// トグルは絶対配置で行から外れているので、タブがこの幅を自分で避ける (#2818)
+wrap-toggle-size = 28px
 article-padding = 20px
 // 狭い画面での左右 (#2563)。.container と note（モバイル）と同じ値。
 // 箱を画面端まで引き出したぶんの打ち消しとして効き、コードの1文字目が
@@ -134,20 +131,12 @@ $line-numbers
       // ブロックのまま内容幅に縮める
       display: block
       width: fit-content
-      // 左右のふくらみのぶんだけ狭める。100% のままだと長いファイル名で
-      // タブが幅いっぱいになり、ふくらみが figure の外へ出て横スクロールが
-      // 生まれる。溢れの有無は折り返しトグルの出し分けに使っているので、
-      // 飾りでスクロールを作らない
-      max-width: unquote("calc(100% - " + (tab-flare * 2) + ")")
-      // 左のふくらみが広がる隙間を空ける。離したぶんは padding から引いて、
-      // ファイル名の1文字目がコードの1文字目に揃う位置を保つ（8 + 12 = 20）
-      margin: 0 0 0 tab-flare
-      padding: 6px article-padding 6px (article-padding - tab-flare)
+      max-width: 100%
+      margin: 0
+      padding: 6px article-padding
       background: highlight-background
       border-radius: card-radius card-radius 0 0
       color: highlight-foreground
-      // ふくらみを外へ出すための土台
-      position: relative
       // ファイル名はコードではなくブロックのラベルなので、本文と同じ書体にする。
       // Astro（Expressive Code）も UI と中身で書体を分けている
       // （--ec-uiFontFamily はサンセリフ、コードだけ等幅） (#2456)
@@ -162,42 +151,17 @@ $line-numbers
       // 両方に最適な1つの値は無い。中身と同じという説明できる値に置く (#2456)
       font-size: 1em
       line-height: 1.6
-      // 長いファイル名は省略記号で切る。ellipsis には overflow が要るが、
-      // hidden だと根本のふくらみ（::after）まで切られる。clip に替えて
-      // 切り取りの範囲を外へ 8px だけ広げる。overflow-clip-margin に
-      // 未対応なら border box で切られ、ふくらみが出ないだけで壊れない
       overflow: hidden
-      overflow: clip
-      overflow-clip-margin: tab-flare
       text-overflow: ellipsis
       white-space: nowrap
       vertical-align: bottom
-    // 根本のふくらみ (#2818)。Chrome や Windows ターミナルのタブと同じで、
-    // タブの側面から本体の上辺へ弧でつなぐ。タブ色の正方形から四分円を
-    // 抜いて作る（弧の内側は背後の白地が見える）。
-    // 円の中心を外側の上隅に置くので、タブ側は全高が塗られ、外へ行くほど
-    // 高さが減って 8px 地点で 0 になる。0.5px ずらすのは、抜いた縁に
-    // 地の色が線で残るのを防ぐため
-    figcaption::before,
-    figcaption::after
-      content: ''
-      position: absolute
-      bottom: 0
-      width: tab-flare
-      height: tab-flare
-    figcaption::before
-      left: -(tab-flare)
-      background: unquote("radial-gradient(circle at 0 0, transparent " + tab-flare + ", " + highlight-background + " " + (tab-flare + 0.5px) + ")")
-    figcaption::after
-      right: -(tab-flare)
-      background: unquote("radial-gradient(circle at 100% 0, transparent " + tab-flare + ", " + highlight-background + " " + (tab-flare + 0.5px) + ")")
-    // ファイル名が長いと、タブが右上のトグルの下に潜る (#2818)。トグルは
-    // 絶対配置なので行ボックスを縮めてくれない（float だった頃は避けていた）。
-    // タブ側で幅を空ける。トグルが今出ているかに関わらず引くのは、出す出さないを
-    // 決めているのがコンテナクエリで、未対応のブラウザでは出たままになるため。
-    // 8px はタブとトグルの間隔
+    // ファイル名が長いと、タブが右上の折り返しトグルの下に潜る (#2818)。
+    // トグルは絶対配置なので行ボックスを縮めてくれない（float だった頃は
+    // 避けていた）。タブ側で幅を空ける。トグルが今出ているかに関わらず引くのは、
+    // 出す出さないを決めているのがコンテナクエリで、未対応のブラウザでは
+    // 出たままになるため。8px はタブとトグルの間隔
     &:has(> .code-wrap-input) figcaption
-      max-width: unquote("calc(100% - " + (tab-flare * 2 + wrap-toggle-size + 8px) + ")")
+      max-width: unquote("calc(100% - " + (wrap-toggle-size + 8px) + ")")
     // タブが乗る側だけ角を落として、タブと本体をつなげて見せる
     figcaption + table
       border-top-left-radius: 0
@@ -534,13 +498,8 @@ pre
         padding-left: article-padding-narrow
         padding-right: article-padding-narrow
       figcaption
-        // 左端に接する作りなので左のふくらみは出さない (#2818)。
-        // 離す隙間が無く、離すとコードの1文字目との揃いも崩れる
-        margin-left: 0
         padding-left: article-padding-narrow
         padding-right: article-padding-narrow
-        &::before
-          display: none
     // 端まで伸ばすのは .article-entry の直下にあるコードだけ (#2568 と同じ形)。
     // calc(50% - 50vw) の 50% は包む箱の幅を指すので、折りたたみ（141件）や
     // 箇条書き（117件）の中では包む箱のぶんだけ余分に外へ出てしまう。

--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -21,6 +21,9 @@ highlight-caption-background = #3c3f41   // Darcula のエディタタブ相当
 // 見えるが文字と競合しない明るさにする
 highlight-scrollbar = #7f8b9c
 highlight-caption-border = #4e5254
+// タブの根本が外へ広がる量 (#2818)。角丸の「箱」の段と同じ 8px で、
+// 上の角の丸みと根本のふくらみが同じ半径で釣り合う
+tab-flare = 8px
 // 差分専用。文字列の緑（#6a8759）だと削除側の赤に対して弱く見えるため、
 // 追加・削除を同じくらいの鮮やかさに揃える
 highlight-diff-added = #89d185
@@ -130,12 +133,18 @@ $line-numbers
       // ブロックのまま内容幅に縮める
       display: block
       width: fit-content
-      max-width: 100%
+      // 根本のふくらみのぶんだけ狭める。100% のままだと長いファイル名で
+      // タブが幅いっぱいになり、ふくらみが figure の外へ出て横スクロールが
+      // 生まれる。溢れの有無は折り返しトグルの出し分けに使っているので、
+      // 飾りでスクロールを作らない
+      max-width: unquote("calc(100% - " + tab-flare + ")")
       margin: 0
       padding: 6px article-padding
       background: highlight-caption-background
       border-radius: card-radius card-radius 0 0
       color: highlight-foreground
+      // ふくらみを外へ出すための土台
+      position: relative
       // ファイル名はコードではなくブロックのラベルなので、本文と同じ書体にする。
       // Astro（Expressive Code）も UI と中身で書体を分けている
       // （--ec-uiFontFamily はサンセリフ、コードだけ等幅） (#2456)
@@ -150,10 +159,29 @@ $line-numbers
       // 両方に最適な1つの値は無い。中身と同じという説明できる値に置く (#2456)
       font-size: 1em
       line-height: 1.6
+      // 長いファイル名は省略記号で切る。ellipsis には overflow が要るが、
+      // hidden だと根本のふくらみ（::after）まで切られる。clip に替えて
+      // 切り取りの範囲を外へ 8px だけ広げる。overflow-clip-margin に
+      // 未対応なら border box で切られ、ふくらみが出ないだけで壊れない
       overflow: hidden
+      overflow: clip
+      overflow-clip-margin: tab-flare
       text-overflow: ellipsis
       white-space: nowrap
       vertical-align: bottom
+    // 根本のふくらみ (#2818)。Chrome や Windows ターミナルのタブと同じで、
+    // タブの側面から本体の上辺へ弧でつなぐ。タブ色の正方形から四分円を
+    // 抜いて作る（弧の内側は背後の白地が見える）。
+    // 左側は付けない。タブは本体と左端が揃っていて、間に広げる隙間が無い
+    figcaption::after
+      content: ''
+      position: absolute
+      right: -(tab-flare)
+      bottom: 0
+      width: tab-flare
+      height: tab-flare
+      // 0.5px ずらすのは、抜いた四分円の縁に地の色が線で残るのを防ぐため
+      background: unquote("radial-gradient(circle at 100% 0, transparent " + tab-flare + ", " + highlight-caption-background + " " + (tab-flare + 0.5px) + ")")
     // タブが乗る側だけ角を落として、タブと本体をつなげて見せる
     figcaption + table
       border-top-left-radius: 0


### PR DESCRIPTION
ファイル名のタブの地をコードブロック本体と同じ色にした。**根本のふくらみ（Chrome / Windows ターミナル風の弧）は取り下げた。**

## やったこと

### 1. タブの地を本体と同じ色にする

```diff
 figcaption
-  background: highlight-caption-background   // #3c3f41（Darcula のエディタタブ相当）
+  background: highlight-background           // #2b2b2b（コードブロック本体）
```

タブと本体がひと続きの面になる。専用色 `#3c3f41` はサイト全体から 0 件になった。

文字色 `highlight-foreground` #a9b7c6 は本体と同じ組み合わせになるだけなので、コントラストは本体のコードと同一。

### 2. 長いファイル名が折り返しトグルの下に潜るのを直す

`#2821` で折り返しトグルを絶対配置にしたため、行ボックスが縮まなくなっていた（`float` だった頃は避けていた）。タブ側で幅を空ける。

```css
.highlight:has(> .code-wrap-input) figcaption { max-width: calc(100% - 36px) }
```

36px = トグルの外形 28px（絵柄16 ＋ padding 5×2 ＋ 枠 1×2）＋ 間隔 8px。値は `wrap-toggle-size` として1箇所で持つ。

トグルが今出ているかに関わらず引くのは、出す出さないを決めているのがコンテナクエリで、**未対応のブラウザでは出たままになる**ため（安全側）。

### 3. 参照の無い変数を落とす

`highlight-caption-border`（#4e5254）は宣言だけで参照が0件だった。`highlight-caption-background` の削除と同じ塊にあるので併せて落とした。

## 取り下げたもの

タブの根本を左右に広げて本体の上辺へ弧でつなぐ案（Chrome / Windows ターミナルのタブの形）は、実装して見てもらった結果、取り下げになった。

途中で分かったことを記録しておく。**ふくらみは「平らな上辺」の上にしか着地できない。**丸めた角の上に置くと、ふくらみの下辺（直線）と角の弧の間に白い隙間が開く（左端で最大8px、x=4px でも約1px）。隙間を色で埋めるのは角の欠けを塗ることなので、丸みが消える。したがって本体の左上を丸めたままふくらみを付けるには、タブを「角の半径＋ふくらみ」ぶん右へ寄せる必要があり、その場合タブの左の余白かファイル名の位置のどちらかが動く。

## 影響（ファイル名2,218件を実測）

タブの幅の中央値は 120px、最大 647px。

| | タブに使える幅 | 省略記号で切られる |
| --- | --- | --- |
| PC 813px・トグル無し | 813px | 0 件 (0.0%) |
| PC 813px・トグル有り | 777px | 0 件 (0.0%) |
| モバイル 327px・トグル無し | 327px | 62 件 (2.8%) |
| モバイル 327px・トグル有り | 291px | 96 件 (4.3%) |

**PC は1件も影響を受けない。**モバイルでトグルのあるブロックだけ、34件（全体の1.5%）が新たに省略記号で切られる。トグルの下に潜って読めなくなるより省略記号の方が良いという判断。

## 検証

`make css` と配信中の CSS を確認した。

- `#3c3f41` / ふくらみの `radial-gradient` / `overflow-clip-margin` はいずれも 0 件
- `.article-entry .highlight figcaption` の `background` は `#2b2b2b`
- `.article-entry .highlight:has(> .code-wrap-input) figcaption` が `max-width: calc(100% - 36px)` として出力されている

Closes #2818

🤖 Generated with [Claude Code](https://claude.com/claude-code)
