### PR TITLE
タグオントロジーに親子28件を追記し、タスクランナータグを削除する

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -160,6 +160,8 @@ alias:
   tags/Grafana-Alloy/: tags/Grafana/ # タグ名「Grafana Alloy」のスラッグ
   tags/TechBlog/: tags/運営/ # ブログ論一般と当ブログ運営の使い分けを説明できず統合 (#2292)
   tags/新人向け/: tags/初心者向け/ # 同義のため統合 (#2292)
+  # 2記事とも Makefile と併記されており、単独では絞り込みに機能しない
+  tags/タスクランナー/: tags/Makefile/
   # 参加レポート（聴講含む）と参戦記（プレイヤーとして参加）は役割で分ける。
   # 登壇レポート／参加レポートの対と同じ整理 (#2334)
   tags/コンテスト/: tags/参戦記/

--- a/source/_data/tag_ontology.yml
+++ b/source/_data/tag_ontology.yml
@@ -58,13 +58,33 @@ S3:
   broader: [AWS]
 DynamoDB:
   broader: [AWS, NoSQL]
+DynamoDBStreams:
+  broader: [DynamoDB]
 Glue:
   broader: [AWS]
 LocalStack:
   broader: [AWS]
+RDS:
+  broader: [AWS, DB]
+Athena:
+  broader: [AWS, SQL]
+CloudEndure:
+  broader: [AWS]
+Session-Manager:
+  broader: [AWS]
 GoogleCloud:
   broader: []
 BigQuery:
+  broader: [GoogleCloud]
+GKE:
+  broader: [GoogleCloud, Kubernetes]
+CloudRun:
+  broader: [GoogleCloud, サーバーレス]
+CloudFunctions:
+  broader: [GoogleCloud, サーバーレス]
+CloudSQL:
+  broader: [GoogleCloud, DB]
+GCS:
   broader: [GoogleCloud]
 Azure:
   broader: []
@@ -88,17 +108,24 @@ net/netip:
   broader: [Go]
 text/template:
   broader: [Go]
-# context / testing / slog / slices は一般名詞と同じ綴りだが、当ブログでは
-# 全記事が Go の標準ライブラリの話（Go タグの無い1本も Go1.24 連載）(#2611)
+# context / testing / slog / slices / sync / tar / map は一般名詞と同じ綴りだが、
+# 当ブログでは全記事が Go の話（Go タグの無い1本も Go1.24 連載）(#2611)。
+# tar は archive/tar、map は言語の組み込み型を指す
 context:
   broader: [Go]
 testing:
   broader: [Go, テスト]
 testing/synctest:
-  broader: [Go, テスト]
+  broader: [testing]
 slog:
   broader: [Go]
 slices:
+  broader: [Go]
+sync:
+  broader: [Go]
+tar:
+  broader: [Go]
+map:
   broader: [Go]
 "go:embed":
   broader: [Go]
@@ -128,9 +155,15 @@ Mypy:
   broader: [Python]
 Pyright:
   broader: [Python]
+pytest:
+  broader: [Python, テスト]
 Java:
   broader: []
 SpringBoot:
+  broader: [Java]
+Tomcat:
+  broader: [Java]
+GraalVM:
   broader: [Java]
 # Java Enhancement Proposal
 JEP:
@@ -189,9 +222,15 @@ OpenAPI:
   broader: [WebAPI]
 Swagger:
   broader: [OpenAPI]
+OpenAPIGenerator:
+  broader: [OpenAPI]
 # サーバーサイド Wasm（WASI 等）の記事もあり、Web の子にはしない
 WebAssembly:
   broader: []
+CMS:
+  broader: []
+HeadlessCMS:
+  broader: [CMS]
 ネットワーク:
   broader: []
 # ネットワーク（インフラ寄り）とは読者が別。プロトコルで束ねる案は
@@ -219,6 +258,8 @@ Minikube:
   broader: [Kubernetes]
 Istio:
   broader: [Kubernetes]
+k3s:
+  broader: [Kubernetes]
 CNCF:
   broader: []
 OS:
@@ -235,10 +276,16 @@ Terraform:
   broader: [IaC]
 tfstate:
   broader: [Terraform]
+TerraformCloud:
+  broader: [Terraform]
 CI/CD:
   broader: []
 GitHubActions:
   broader: [CI/CD]
+GitLab:
+  broader: []
+GitLab CI:
+  broader: [GitLab, CI/CD]
 保守運用:
   broader: []
 # 災害対策。クラウド固有でも保守運用の包含でもないので根に置く
@@ -321,6 +368,8 @@ MLOps:
   broader: []
 TDD:
   broader: [テスト]
+ファジング:
+  broader: [テスト]
 E2Eテスト:
   broader: [テスト]
 Playwright:
@@ -351,6 +400,8 @@ Cypress:
   broader: [ドキュメント]
 アジャイル:
   broader: []
+スクラム:
+  broader: [アジャイル]
 コミュニケーション:
   broader: []
 リーダーシップ:
@@ -379,10 +430,16 @@ UI/UX:
   broader: []
 暗号:
   broader: [セキュリティ]
+Vuls:
+  broader: []
+FutureVuls:
+  broader: [Vuls]
 認証認可:
   broader: []
 Auth0:
   broader: [認証認可]
+Auth0Rules:
+  broader: [Auth0]
 # AWS / GoogleCloud 双方の記事で使われているのでクラウドの下には置かない
 IAM:
   broader: [認証認可]
@@ -425,12 +482,24 @@ SoftwareDesign:
 # --- ツール・その他 ---
 VSCode:
   broader: []
+VSCode拡張:
+  broader: [VSCode]
+# IDE タグは GoLand 系の記事に付いている。エディタとしての記事が主の VSCode は含めない
+IDE:
+  broader: []
+PyCharm:
+  broader: [IDE]
 LSP:
   broader: []
 Redmine:
   broader: []
 Slack:
   broader: []
+# GoogleCloud とは別系統の SaaS 群
+GoogleWorkspace:
+  broader: []
+GoogleChat:
+  broader: [GoogleWorkspace]
 OSS:
   broader: []
 電子工作:

--- a/source/_posts/2023/20231012a_Makefile覚書：_Goアプリ開発に役立ちそうな基礎知識.md
+++ b/source/_posts/2023/20231012a_Makefile覚書：_Goアプリ開発に役立ちそうな基礎知識.md
@@ -4,7 +4,6 @@ date: 2023/10/12 00:00:00
 postid: a
 tags:
   - Makefile
-  - タスクランナー
   - Go
   - チーム開発
   - EditorConfig

--- a/source/_posts/2025/20250605a_nektos／act_はMakefileの代わりになるか？.md
+++ b/source/_posts/2025/20250605a_nektos／act_はMakefileの代わりになるか？.md
@@ -4,7 +4,6 @@ date: 2025/06/05 00:00:00
 postid: a
 tags:
   - Makefile
-  - タスクランナー
   - GitHubActions
 categories:
   - DevOps


### PR DESCRIPTION
`/doctor/` の「オントロジーへの追加提案」32件を、規則で振り分けて採用しました。

## 採用した規則

**辺を書くのは「子の名前が親の外で指示対象を持たない」場合だけ。** RDS は AWS の外に、
Auth0Rules は Auth0 の外に存在しません。一般名詞と同綴りのもの（`map` / `sync` / `tar`）は
「当ブログでは全記事が Go の話」という実測を根拠に、既存の #2611 のコメントを広げて例外扱いにしています。

**親は「提供元」と「種別」の2軸で見て、種別がノードとして既にあれば両方書く**
（既存の `Lambda: [AWS, サーバーレス]` / `DynamoDB: [AWS, NoSQL]` に合わせた）。
祖先で届くものは書きません。

| 子 | 親 |
| --- | --- |
| GKE | GoogleCloud, Kubernetes |
| CloudRun / CloudFunctions | GoogleCloud, サーバーレス |
| CloudSQL | GoogleCloud, DB |
| RDS | AWS, DB |
| Athena | AWS, SQL |
| pytest | Python, テスト |
| GitLab CI | GitLab, CI/CD |

これ以外（GCS / CloudEndure / Session-Manager / DynamoDBStreams / TerraformCloud /
Auth0Rules / OpenAPIGenerator / VSCode拡張 / FutureVuls / GoogleChat / HeadlessCMS /
k3s / GraalVM / Tomcat / スクラム / ファジング / map / sync / tar）は、
種別に当たるノードが無いか祖先で届くため単親です。

親として参照するため **CMS / GitLab / Vuls / GoogleWorkspace / IDE を根（`broader: []`）で追加**しました。
上位を決めきれないものは「迷ったら書かない」に従って根に置いています。

## 個別の判断

- **PyCharm は `IDE` の下**。言語の子にすると、同型の GoLand（4記事）が `JetBrains` / `IDE` タグで
  付いているのと非対称になります。VSCode はエディタとしての記事が主なので `IDE` には含めていません
- **testing/synctest は親を `testing` 単独に**変更。`testing: [Go, テスト]` なので祖先で同じ所に届き、
  既存の「冗長な祖先は書かない」流儀（`Next.js: [React]`）に揃えました
- **encoding/csv はすでに登録済み**だったので変更なし
- **タスクランナー（2記事）は削除**。2記事とも `Makefile` と併記されており、単独では絞り込みに
  機能しません。タグURLは `tags/Makefile/` へ転送します

## 今回は入れなかったもの

- **他言語からGoへ（3記事）**: 実体は連載名タグで、`series` に移して旧タグURLを先頭記事へ
  転送する案件（#2374 の規則）です。オントロジーとは別レーンなので分けました
- **LPガス業界**: 削除しない方針で確定
- **tar → archive/tar の改名**: 既存は非トップレベルをフルパス（`encoding/json` / `path/filepath`）、
  トップレベルを短縮（`context` / `sync`）で書き分けており、`tar` だけこの規則を破っています。
  今回は辺だけ入れ、改名は別途

## 確認

- `node .claude/skills/tag-maintenance/check.mjs` → **ERROR 0**（ノード 215 / タグ 695）
- 提案32件のうち31件が祖先で接続済みになったことを確認（残り1件は上記の「他言語からGoへ」）
- 変更した2記事は textlint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
