### PR TITLE
/doctor/ のタグ3節を直近1年に記事があるタグだけにする

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -21,8 +21,32 @@ hexo.extend.generator.register('doctor', function (locals) {
 // しかも票の高さが正しさと逆相関で、しきい値では直せなかった。
 // 監査のネタ出しとしての役目は上記3回で回収済み
 
+/**
+ * 直近1年に記事の無いタグは候補から外す。見送りを決めたタグが毎回並ぶと、
+ * 新しく増えた分が埋もれる。
+ *
+ * 包含の候補（統合候補・親子の候補）は子の記事集合が親に含まれるので、
+ * 子が活きていれば親も必ず活きている。判定は子だけで足りる。
+ */
+const ACTIVE_DAYS = 365;
+
+const activeTagNames = (tags) => {
+  const limit = Date.now() - ACTIVE_DAYS * 24 * 60 * 60 * 1000;
+  const active = new Set();
+  tags.forEach((tag) => {
+    let newest = 0;
+    tag.posts.forEach((post) => {
+      const t = post.date ? post.date.valueOf() : 0;
+      if (t > newest) newest = t;
+    });
+    if (newest >= limit) active.add(tag.name);
+  });
+  return active;
+};
+
 hexo.extend.helper.register('doctor_checks', function () {
   const posts = this.site.posts.sort('-date');
+  const active = activeTagNames(this.site.tags);
 
   // タグ -> 記事IDの集合。ほぼ重なるタグ（統合候補）と1記事タグの検出に使う
   const tagPostSets = new Map();
@@ -42,6 +66,7 @@ hexo.extend.helper.register('doctor_checks', function () {
   const nearDuplicates = [];
   const tagEntries = [...tagPostSets.entries()].filter(([, set]) => set.size >= 2);
   for (const [a, A] of tagEntries) {
+    if (!active.has(a)) continue;
     for (const [b, B] of tagEntries) {
       if (a === b || B.size < A.size || B.size - A.size > 2) continue;
       if (A.size === B.size && a > b) continue; // 完全一致ペアの重複を防ぐ
@@ -72,7 +97,7 @@ hexo.extend.helper.register('doctor_checks', function () {
   //    （タグクラウドで * / ** として出していた仕様の移設）
   const singleUse = [];
   for (const [name, set] of tagPostSets) {
-    if (set.size !== 1) continue;
+    if (set.size !== 1 || !active.has(name)) continue;
     const postId = [...set][0];
     let lonelyPair = false;
     for (const [other, otherSet] of tagPostSets) {
@@ -152,8 +177,10 @@ hexo.extend.helper.register('doctor_ontology_suggestions', function () {
   };
 
   const entries = [...sets.entries()].filter(([, s]) => s.size >= ONTOLOGY_SUGGEST_MIN_POSTS);
+  const active = activeTagNames(this.site.tags);
   const suggestions = [];
   for (const [child, C] of entries) {
+    if (!active.has(child)) continue;
     const stem = stemOf(child);
     const known = ancestorsOf(child);
     for (const [parent, P] of entries) {

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -25,7 +25,7 @@
   <section id="main" class="margin-top-30">
     <div class="footer-gap">
       <h1 class="list-page margin-bottom-20">記事ドクター</h1>
-      ※運営向けの画面です。人の判断が要る候補だけを並べます（提案であって、正とは限りません）。タグ無し・カテゴリと同名のタグ・未登録のカテゴリは PR の検査が止めるので、ここには出ません
+      ※運営向けの画面です。人の判断が要る候補だけを並べます（提案であって、正とは限りません）。タグ無し・カテゴリと同名のタグ・未登録のカテゴリは PR の検査が止めるので、ここには出ません。タグの3節（統合候補・1記事タグ・親子の候補）は、直近1年間に記事のあるタグだけを対象にします
       <ul class="summary">
         <% SECTIONS.forEach(function(sec){ %>
         <li><span class="summary-count"><%= sec.count %></span><br><span class="summary-label"><%= sec.label %></span></li>


### PR DESCRIPTION
タグ系の3節は、見送りを決めたタグが毎回並び続けます。処理し終えた今の状態では、
残っているのがほぼ全部「判断済みで動かないもの」なので、**直近1年に記事の無いタグを
対象から外しました**。

## 件数

| 節 | 現状 | フィルタ後 |
| --- | --- | --- |
| ほぼ重なるタグ（統合候補） | 21 | **0** |
| 1記事にしか使われていないタグ | 31 | **6** |
| オントロジーへの追加提案（親子の候補） | 192 | **19**（対象タグ 144 → 15） |

生成した `/doctor/` で確認した実測値です。統合候補は当面「該当なし」の表示になります
（#2831 で処理した CSS / IDE / パッケージ管理 も、最新記事が1年より古いのでこの条件では出ません）。

残るものは、たとえば以下です。

- **1記事タグ**: IME、C言語、インターン2026、コンテキストエンジニアリング、Skills、ISMS
- **親子の候補**: `cursor ⊆ 生成AI`、`ADK ⊆ AIエージェント`、`DeepResearch ⊆ 生成AI`、
  `サーバーコンポーネント ⊆ Next.js`、`CVSS ⊆ 脆弱性`、`GoogleCloudNext2025 ⊆ GoogleCloud` など

## 実装

判定は `scripts/doctor.js` に1箇所（`activeTagNames`）だけ置き、3節で共有します。

**判定するのは子（小さい側）だけで足ります。** 統合候補も親子の候補も
「子の記事すべてが親にも付いている」包含なので、親の最新記事は必ず子の最新記事以降に
なります。子が活きていれば親も活きているので、両方見る必要がありません。

除外していることは `/doctor/` の冒頭に1行書きました（節ごとに繰り返すと注記が重くなるため、
「PR の検査が止めるのでここには出ません」と同じ場所にまとめています）。

## 確認

- `npx hexo generate` して `public/doctor/index.html` を確認。冒頭の件数カードが
  `0 / 6 / 19 / 221 / 101`、統合候補が「該当なし」、1記事タグが6件、親子の候補が「候補 19件 / タグ 15件」
- 同じ条件を単独スクリプトで再計算し、生成結果と一致することを確認（21→0 / 31→6 / 192→19）
- `npx prettier --check scripts/doctor.js` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
