### PR TITLE
記事末の箱から枠を外す (#2820)

### DIFF
--- a/scripts/reference_posts.js
+++ b/scripts/reference_posts.js
@@ -43,9 +43,7 @@ hexo.extend.helper.register('list_reference_posts', function () {
       <ul class="reference-post-link">${items(hidden)}</ul>
     </details>`;
 
+  // 見出しは呼び出し側の EJS が section-heading で出す
   return `
-  <div class="card">
-    <div id="reference" class="reference-lede"><a href="#reference" class="headerlink" title="参照されている記事"></a>この記事を参照している記事</div>
-    <ul class="reference-post-link">${items(shown)}</ul>${more}
-  </div>`;
+  <ul class="reference-post-link">${items(shown)}</ul>${more}`;
 });

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -393,28 +393,10 @@ details {
   padding-bottom: 24px;
 }
 
-aside h2 {
-  font-size: 22px;
-  font-weight: 700;
-}
-
-.featured-post,
-.related-post {
-  padding: 20px 0px 0px 10px;
-  border-radius: 8px; /* theme の card-radius と同値。素の CSS なので直書き */
-}
-.featured-post h2,
-.related-post h2{
-  font-size: 18px;
-}
 .featured-post-link a,
 .related-post-link a {
   font-size: 1.2em;
   color: #424242;
-}
-.featured-post-link li,
-.related-post-link li {
-  padding: 8px 0px 6px 0px;
 }
 .snscount {
   padding: 0px 10px 0px 10px;
@@ -2878,17 +2860,9 @@ ul.tag-list {
 .tag-cloud a:focus {
   color: ink-strong;
 }
-/* metronic の `.featured-post, .related-post { padding: 20px 0 0 10px }` により
-   関連記事のカードだけ上と左に余白が付き、参照記事のカードとずれていた。
-   card 自体が枠を持つので、section 側の余白は不要 */
-.related-post {
-  padding: 0;
-}
-
-/* 記事末の著者紹介 (#2567)。関連記事・参照記事と同じ card に載せるので、
-   見出しは下方の `.related-post .card > h2` と同じ規則で作る。
-   metronic の `.related-post { padding: 20px 0 0 10px }` に相当する
-   ずれはこちらには無いが、並ぶ3つの card の左端を揃えるため 0 を明示する */
+/* 記事末の著者紹介 (#2567)。見出しを持たない1件の塊なので枠（card）に載せる。
+   関連記事・参照記事は枠を外して節見出し + 行にしたので、左端をそちらに
+   揃えるため padding は 0 を明示する */
 .author-box {
   padding: 0;
 }
@@ -2950,8 +2924,8 @@ ul.tag-list {
   margin-bottom: 0;
 }
 
-/* 連載の前 / 次。関連記事・参照記事と同じ card を使いつつ、
-   中身は記事ナビの形にする。前を左・次を右に置いて進行方向を示す */
+/* 連載の前 / 次。左右に並ぶ2つで1組の部品なので、囲み（card）を持たせて
+   どこまでが1組かを示す。前を左・次を右に置いて進行方向を示す */
 /* 本文のすぐ後ろに来るので、本文との間隔を空けて別のブロックだと分かるようにする */
 .series-nav {
   margin-top: 40px;
@@ -3091,22 +3065,21 @@ a.series-nav-item:hover .series-nav-item-title {
   }
 }
 
-/* 関連記事は著者が書いた本文ではなく自動生成のブロックなので、
-   「この記事を参照している記事」と同じ card で囲って区別する。
-   2つのブロックが並ぶため、見出し・余白・行の作りを完全に揃える */
-.related-post .card > h2,
-.reference-lede {
-  padding: 0.8em 0.8em 0.4em;
-  margin: 0;
-  font-size: 1.2em;
-  font-weight: bold;
-  border-bottom: none;
-}
+/* 行は本文列の左端に揃える。枠が無いので字下げする理由が無く、
+   下の空きは節の margin-bottom-40 が持つ */
 .related-post-link,
 .reference-post-link {
-  padding: 0 0.8em 0.6em;
+  padding: 0;
   margin: 0;
   list-style: none;
+}
+/* サムネ・タイトルの左端を節見出しに揃える。`.nav li a` の左右 4px は
+   サイドバーの「1リンク＝1行」向けで、こちらでは見出しと 4px ずれる。
+   上下の 6px は行の高さを決めているので残す */
+.related-post-link .related-posts-item a,
+.reference-post-link .reference-posts-item a {
+  padding-left: 0;
+  padding-right: 0;
 }
 .related-posts-item,
 .reference-posts-item,
@@ -3289,7 +3262,7 @@ a.series-nav-item:hover .series-nav-item-title {
    JS は使わない */
 .reference-post-more,
 .related-posts-more {
-  padding: 0 0.8em 0.6em;
+  padding: 0;
 }
 .reference-post-more > summary,
 .related-posts-more > summary,
@@ -3322,11 +3295,6 @@ a.series-nav-item:hover .series-nav-item-title {
 .related-post-link:has(+ .related-posts-more) .related-posts-item:last-child,
 .featured-post-link:has(+ .ranking-more) .featured-posts-item:last-child {
   border-bottom: none;
-}
-/* metronic の `.featured-post-link li { padding: 8px 0 6px }` は
-   .featured-posts-item の padding と競合するので、こちらに揃える */
-.featured-post-link .featured-posts-item {
-  padding: 0.5em 0;
 }
 /* タイトルの後ろに続くメタ情報。日付と反響の数は判断材料であって
    見出しではないので、小さめの文字で添える。

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1195,6 +1195,20 @@ body.page-header-fixed .header {
   align-items: center;
   margin: 0;
 }
+/* 2列の切れ目は間隔だけが作るので、gutter の 24px（.row > * の左右 12px）では
+   左のパネルの説明文が右のパネルのロゴに近すぎる。内側だけ 24px に広げて
+   列間を 48px にする。中の空き（ロゴと文章の 12px）の4倍で、外が内より
+   十分大きい状態を作る (#2747)。列の外側は 12px のままなので、
+   節見出し・関連記事の行との左右の揃いは動かない。
+   パネルは常に2枚（scripts/hiring_panels.js） */
+@media (min-width: 768px) {
+  .career-counseling .row > :first-child {
+    padding-right: 24px;
+  }
+  .career-counseling .row > :last-child {
+    padding-left: 24px;
+  }
+}
 .hiring-card-thumb {
   flex: 0 0 88px;
   line-height: 0;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1184,22 +1184,16 @@ body.page-header-fixed .header {
     height: 100%;
   }
 }
-/* We're hiring のカード。以前は画像がカード幅の半分を占め、さらに
-   .article-card の padding と Bootstrap の p-3 が二重にかかっていて、
-   場所を取る割に情報量が薄かった。
-   サムネイルを左に小さく固定し、見出しと説明を右に積む横並びにする */
+/* We're hiring のパネル。サムネイルを左に小さく固定し、見出しと説明を右に積む。
+   記事末の他の節と同じく囲みは持たず、2枚の区別は .row の gutter（24px）で作る。
+   左端を節見出し・関連記事の行にそろえるため、内側の余白も持たない (#2820) */
 .career-counseling .article-card {
   display: flex;
   gap: 12px;
   /* 画像の縦横比がまちまち（88px幅で高さ32〜46px）なので、上揃えだと
      本文より低い画像が浮いて見える。垂直中央で釣り合わせる (#2347) */
   align-items: center;
-  padding: 18px;
   margin: 0;
-  /* 囲みは .article-card ではなくここが持つ (#2747)。枠は「カード・箱を囲む線」
-     なので rule-weak（区切りの線）ではなく rule-base */
-  border: 1px solid rule-base;
-  border-radius: card-radius;
 }
 .hiring-card-thumb {
   flex: 0 0 88px;

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -182,7 +182,9 @@
                     以前は画像がカード幅の半分を占め、場所の割に情報量が薄かった %>
                 <% hiring_panels(post).forEach(function(panel){ %>
                 <div class="col-12 col-md-6">
-                  <div class="article-card h-100">
+                  <%# h-100 は付けない。囲みが無いので高さをそろえる相手が無く、
+                      align-items: center と組むと短い方の中身が縦に浮く %>
+                  <div class="article-card">
                     <a href="<%= panel.url %>" title="<%= panel.title %>" class="thumb-link hiring-card-thumb">
                       <img src="<%= panel.image %>" alt="<%= panel.title %>" width="200" height="135" loading="lazy">
                     </a>

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -157,16 +157,21 @@
           <%# 最後の section ではなく aside に付ける。中の margin-bottom-40 は
               相殺で吸収され、skip_career で最後の節が変わっても間隔が保たれる %>
           <aside class="footer-gap">
-            <%# 自動生成のブロックであることが分かるよう、「この記事を参照している記事」と同じ card で囲う %>
+            <%# 縦に積むリストなので囲みは持たず、節見出しと行の区切りで分ける (#2820)。
+                見出しは一覧ページの節と同じ section-heading %>
             <section class="related-post margin-bottom-40 nav" data-nosnippet>
-              <div class="card">
-                <h2 id="related"><a href="#related" class="headerlink" title="関連記事"></a>関連記事</h2>
-                <%- list_related_posts(post) %>
-              </div>
+              <%- partial('section-heading', {id: 'related', text: '関連記事'}) %>
+              <%- list_related_posts(post) %>
             </section>
+            <%# 被参照が無いと helper は空を返す。見出しを EJS 側へ出したので、
+                節ごと出さないと見出しだけが残る %>
+            <% const referenceHtml = list_reference_posts(post); %>
+            <% if (referenceHtml) { %>
             <section class="reference-post margin-bottom-40 nav" data-nosnippet>
-              <%- list_reference_posts(post) %>
+              <%- partial('section-heading', {id: 'reference', text: 'この記事を参照している記事'}) %>
+              <%- referenceHtml %>
             </section>
+            <% } %>
             <% if (!page.skip_career){ %>
             <section class="career-counseling article-entry margin-bottom-40 nav" data-nosnippet>
               <h2 id="career"><a href="#career" class="headerlink" title="キャリア相談"></a>We're hiring</h2>


### PR DESCRIPTION
#2820 のうち、**枠の解除だけ**を扱う。グレー背景（面に替える話）は依頼により範囲外。

## やったこと

記事末の自動生成ブロック（関連記事・参照記事・We're hiring）から囲みを外し、節見出しと間隔・区切り線でまとまりを示す形にした。

いずれも縦に積む／記事末の読み下しの中に置かれるもので、囲みが担っていた「ここは自動生成のブロック」は節見出しが引き継ぐ。

### 関連記事・参照記事

| | before | after |
| --- | --- | --- |
| 囲み | bootstrap `.card`（`1px solid rgba(0,0,0,.125)` / 角丸 4px） | 無し |
| 見出し | 1.2em = 15.6px のラベル（カードの中） | `section-heading`（`.bottom-content-header`）= 24.05px |
| 行の左端 | カード内側 0.8em ＋ `.nav li a` の 4px = 14.4px の字下げ | 本文列の左端（0） |
| 被参照が0件のとき | 空の `<section>` が出る | 節ごと出さない |

見出しを EJS 側（`_partial/section-heading`）に寄せたので、`scripts/reference_posts.js` は行だけを返す。ホーム・タグ・カテゴリの節見出しと同じ部品になり、記事末の「We're hiring」（24.05px）とも大きさがそろう。

### We're hiring

| | before | after |
| --- | --- | --- |
| パネルの囲み | `1px solid rule-base` / 角丸 8px | 無し（2枚の区別は `.row` の gutter 24px） |
| パネル内側の余白 | 18px | 0（左端が節見出し・関連記事の行とそろう） |
| `h-100` | あり | 無し |

`h-100` を外したのは、囲みが無いと高さをそろえる相手が無く、`align-items: center` と組むと短い方の中身が縦に浮くため。

**この結果、`.article-card` を使う部品のうち枠を持つのはホームの「連載から探す」・特設パネル（`.series-panels` / `.post-panel`）だけになる。** 記事末は読み下しの流れの中にあり、囲みを持つのがここだけだと目立ちすぎるという判断。一覧ページのパネルは横に並ぶ箱として枠を残している（#2747）。

## ついでに直した実効サイズの割れ

`aside h2 { font-size: 22px }` を削除した。`.bottom-content-header` は自分でサイズを持たず `h2 { font-size: 1.85em }`（24.05px）に頼っているが、`aside h2`（0,0,2）が勝つため、**同じ部品が aside の中では 22px、外では 24.05px** になっていた。該当は関連タグ（タグページ）・関連カテゴリ（カテゴリページ）の2箇所で、どちらも 24.05px に揃う。

CLAUDE.md の「1つの要素のサイズは1箇所でしか決めない」「ブラウザ既定のサイズに頼らない」（#2004）に当たる形だった。

## 併せて削除した死んだ規則

- `.featured-post`（コンテナのクラス）はテンプレートで未使用。`.featured-post-link` / `.featured-posts-item` は使われている
- `.related-post { padding: 20px 0 0 10px }` は下方の `.related-post { padding: 0 }` で打ち消していた
- metronic の `.featured-post-link li { padding: 8px 0 6px }`（0,1,1）が `.featured-posts-item`（0,1,0）に勝っていたため、ランキング側に打ち消しの規則（`.featured-post-link .featured-posts-item`）を1つ置いていた。元を消して両方落とした。**関連記事の行だけ 8px/6px、参照記事とランキングは 0.5em という割れも直る**

## 検証

- `make css` が通り、コンパイル後の `site.css` で `h2.bottom-content-header` に効く font-size が `h2 { 1.85em }` だけになることを確認（`aside h2` は消えている）
- 行のリンクの左右 padding は `.related-post-link .related-posts-item a`（0,2,1）が `.nav li a`（0,1,2）に勝つことを詳細度で確認
- `hexo s` で配信し、生成 HTML をパースして確認
  - 記事末の `class="card"` の数: 連載ナビと著者紹介がある記事で 2、どちらも無い記事で 0
  - 記事末の `h-100` は 0 件、`.career-counseling .article-card` に border / padding が無いこと
  - 被参照のある記事では `reference-post` の節と `bottom-content-header` の見出しが出る／無い記事では節ごと出ない
  - ホーム・タグ・カテゴリ・著者・連載一覧・/doctor/・年別一覧・特設ページ・記事ページが 200 で返る
- `npx prettier --check "scripts/**/*.js" "*.mjs"` … 通過
- `node_modules/.bin/textlint themes/future/layout/_partial/article.ejs` … 指摘0（ルールが実際に走ることを、外部リンクの検体を置いて `no-unmarked-external-link` が発火することで確認）

## この PR の範囲外（#2820 に残るもの）

- **グレー背景（面に替える話）**。依頼により今回は扱わない。実測だけ置いておくと、`surface-tint` #f5f5f5 を地にすると行の hover（`surface-mute` #eee）の差が 1.16 → 1.06 に落ちて実質見えなくなる。地を #eee にして hover を白へ抜くと 1.16 のまま保てる
- **連載ナビ・著者紹介に残る bootstrap の `.card`**（`rgba(0,0,0,.125)` / 4px）。issue が指摘する「角丸が3段の規約から外れている」はこの2つに残る。`rule-base` / `card-radius` へ寄せるのは別途

Refs #2820
