### PR TITLE
コードブロックの上の空きを、折り返しトグルが出ているときだけにする (#2844)

### DIFF
--- a/themes/future/css-src/highlight.styl
+++ b/themes/future/css-src/highlight.styl
@@ -91,11 +91,6 @@ $line-numbers
   // だけで、この箱自体は背景も余白も持たない (#2821)
   .code-block
     position: relative
-  // 折り返しトグルはファイル名のタブと同じ帯に置く。タブが無いブロックは
-  // 帯そのものが無いので、ラベルのぶんだけ上を空けてコードを下げる。
-  // 28px（枠1＋padding5＋絵柄16＋padding5＋枠1）にタブとの間隔4pxを足した値
-  .highlight:has(> .code-wrap-input):not(:has(> figcaption))
-    padding-top: 32px
   // コードブロックの構造は figure.highlight > figcaption + table。
   // 背景を figure ではなく table に持たせる。figure が背景を持つと
   // ファイル名の行まで幅いっぱいに暗くなり、暗い面積がその分増える
@@ -172,12 +167,28 @@ $line-numbers
     //
     // input は隠すが display: none にはしない。タブ（radio）はそうしているが、
     // あちらはラベルが常に見えていて選択状態も面で分かる。こちらは
-    // 単独の切り替えなので、キーボードで辿れないと押せなくなる
+    // 単独の切り替えなので、キーボードで辿れないと押せなくなる。
+    //
+    // **ラベルを置く帯の高さはこの input が流れの中で作る** (#2844)。
+    // ラベルは絶対配置なので場所を空けられず、figure に padding を持たせると
+    // figure 自身がコンテナ（container-type: scroll-state）なので
+    // 「トグルが今出ているか」で消せない。input なら下の出し分けが
+    // そのまま display: none になり、帯も一緒に畳まれる
     .code-wrap-input
-      position: absolute
+      display: block
+      appearance: none
       width: 1px
-      height: 1px
+      height: 0
+      margin: 0
       opacity: 0
+      // 幅1pxとはいえ帯の高さぶん伸びるので、押せる的にしない
+      pointer-events: none
+    // 帯はファイル名のタブと同じ役。タブがあるブロックはタブ自身が帯なので、
+    // 無いブロックだけこの高さを持つ。28px（枠1＋padding5＋絵柄16＋padding5＋枠1）に
+    // タブとの間隔4pxを足した値
+    &:not(:has(> figcaption)) > .code-wrap-input
+      height: wrap-toggle-size
+      margin-bottom: 4px
     // ファイル名のタブ（figcaption）と同じ帯の右端に置く。
     // タブより低くしてあるので、両方あるときの帯の高さは今までと変わらない。
     //
@@ -549,7 +560,7 @@ pre
     /* 折り返しを入にすると溢れが消えてこの条件に入るので、入のときは出したまま。
        でないと一度折り返したら戻せなくなる */
     .article-entry .highlight .code-wrap-input:checked {
-      display: inline-block;
+      display: block;
     }
     .article-entry .highlight .code-wrap-input:checked + .code-wrap-label {
       display: block;
@@ -565,6 +576,6 @@ pre
   .article-entry .highlight .code-wrap-narrow + .code-wrap-label
     display: none
   .article-entry .highlight .code-wrap-narrow:checked
-    display: inline-block
+    display: block
   .article-entry .highlight .code-wrap-narrow:checked + .code-wrap-label
     display: block


### PR DESCRIPTION
Closes #2844

## 何が起きていたか

折り返しトグル (#2752) の付くブロックのうち、**ファイル名のタブが無いもの**は
ラベルを置く帯として `padding-top: 32px` を figure に持たせていた。

```styl
.highlight:has(> .code-wrap-input):not(:has(> figcaption))
  padding-top: 32px
```

この padding は**「トグルが今出ているか」に関係なく常に効く**。段落の下マージン
16px と合わせて、本文とコードの間が 48px（トグルの無いブロックの3倍）空く。

トグルを実際に出すかどうかを決めているのは、

- `@container not scroll-state(scrollable: inline)`（実際に横スクロールできるか）
- `@media (min-width: 768px)` の `code-wrap-narrow`（PC では収まると見積もったブロック）

の2つで、どちらも `display: none` で消す。**帯だけが残る。**

## 実データ

`db.json` の描画済み本文 7,820 ブロックを数えた（本文列 656px＝サイドバーが出る
1025px 以上の実効幅で判定）。

| | ブロック数 |
| --- | --- |
| コードブロック全体 | 7,820 |
| ファイル名のタブあり | 2,225 |
| トグルが付く | 5,013 |
| うちタブ無し＝32px の帯を確保 | 3,466 |
| **うち 656px で溢れず、トグルが隠れて帯だけ残る** | **2,037** |

issue に挙がっている `/articles/20260804a/` は14ブロック中10個にトグルが付き、
**そのうち6個が「空の帯」**（ファイル名のタブは0個）。

## 直し方

帯の高さを figure の padding ではなく、**input が流れの中で作る**ようにした。

figure に padding を持たせられないのは、figure 自身が `container-type: scroll-state`
のコンテナで、コンテナクエリは子孫しか選べないため（自分自身の padding を
「トグルが隠れているとき」に消せない）。input はコンテナの子で、しかも
**既にある出し分けがそのまま `display: none` になる**ので、帯も一緒に畳まれる。
消す条件を2箇所に書き足す必要が無い。

- `.code-wrap-input` を `position: absolute` から `display: block` の 0 高さへ
- タブが無いブロックだけ `height: 28px` ＋ `margin-bottom: 4px`（従来の 32px と同値）
- 出し分けの `display: inline-block` を `block` に（流れの中に入ったため）

`pointer-events: none` を足したのは、幅1pxとはいえ高さが 1px → 28px になり、
不可視の当たり判定が28倍になるため。ラベルの `for` 経由の起動とキーボード
フォーカスはどちらも pointer-events を通らないので、押せなくはならない。

## 結果

| | before | after |
| --- | --- | --- |
| タブ無し・トグルが出る | 帯 32px | 帯 32px（変更なし。ファイル名のタブ 32.8px と同じ高さ） |
| **タブ無し・トグルが隠れる（2,037個）** | **帯 32px（空）** | **0px。トグルの無いブロックと同じ空き** |
| タブあり | 変更なし | 変更なし |
| 折り返しを入にしたとき | 帯 32px | 帯 32px（`:checked` はトグルを出したままにするので帯も残る） |

DOM は変えていないので `scripts/code_wrap_toggle.js` は無変更。CSS だけ。

## 範囲外

- トグルが**実際に出ている**ブロック（656px で 1,429 個）の 32px はそのまま。
  中に操作子がある帯で、高さもファイル名のタブ（6+13×1.6+6＝32.8px）と揃っている
- コードブロックの下の空き（`.article-entry .highlight` の `margin-bottom: 0.5rem`＝8px）は触っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
