### PR TITLE
検索窓のパネルに「人気の連載」を足す (#2855)

### DIFF
--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const { snsLabel } = require('./lib/post_list');
+const { allSeries } = require('./lib/series');
 
 const load = JSON.parse(fs.readFileSync('ga4_pv.json', 'utf-8'));
 const map = new Map();
@@ -52,6 +53,36 @@ hexo.extend.helper.register('recent_popular_tags', function (limit = 10, minRece
     .slice(0, limit);
   popularTagsCache.set(cacheKey, tags);
   return tags;
+});
+
+// 検索窓のパネルの「人気の連載」(#2855)。物差しは人気のタグと揃える。
+// 同じ面に並ぶ3つの入口が別々の基準で選ばれていると、どれが「いま」を
+// 指しているのか読者には区別できない。
+// 行き先は索引記事（無ければ1本目）で、/series/ の一覧と同じ規則
+const popularSeriesCache = new Map();
+
+hexo.extend.helper.register('recent_popular_series', function (limit = 6, minRecent = 3) {
+  const cacheKey = `${limit}:${minRecent}:${this.site.posts.length}`;
+  if (popularSeriesCache.has(cacheKey)) return popularSeriesCache.get(cacheKey);
+  const YEAR = 365 * 24 * 60 * 60 * 1000;
+  const now = Date.now();
+  const series = allSeries(this.site)
+    .map((s) => {
+      const recent = s.posts.filter((p) => now - p.date.valueOf() <= YEAR);
+      return {
+        name: s.name,
+        path: s.index.path,
+        total: s.total,
+        recent: recent.length,
+        pv: recent.reduce((sum, p) => sum + getGA4PV('/' + p.path), 0),
+      };
+    })
+    .filter((s) => s.recent >= minRecent && s.pv > 0)
+    // 同点は名前で決める（決着が無いとビルドごとに並びが変わる）
+    .sort((a, b) => b.pv - a.pv || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+    .slice(0, limit);
+  popularSeriesCache.set(cacheKey, series);
+  return series;
 });
 
 // 推薦の件数は記事数から決める。推薦が全記事の半分を超えると

--- a/scripts/lib/series.js
+++ b/scripts/lib/series.js
@@ -196,6 +196,8 @@ function build(site) {
       return {
         name,
         total: posts.length,
+        // 直近の投稿だけを見たい呼び出し側（人気の連載 #2855）のために本体を渡す
+        posts,
         // 年ごとの著者数は連載をまたいで重複するため、数ではなく名前で持つ
         authors: [...authorsOf(posts)],
         index: index || posts[0],

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -4206,6 +4206,11 @@ a.award-badge:focus {
 .header-search-hint-categories .article-category-link {
   font-weight: normal;
 }
+/* 連載のチップの塊 (#2855)。チップ自身が下に 12px 持つので、
+   カテゴリの塊と同じ 28px の空きになるよう差分だけ足す */
+.header-search-hint-series {
+  margin-bottom: 16px;
+}
 /* 右肩の件数はタグのチップと同じく「総数」の意味 (#2129) */
 .header-search-hint-count {
   margin-left: 4px;

--- a/themes/future/layout/_partial/search-hint.ejs
+++ b/themes/future/layout/_partial/search-hint.ejs
@@ -1,17 +1,29 @@
 <%# 検索窓を押したときに出す行き先の一覧 (#2791)。JS は足さず、フォームの
     :focus-within で開き、input:placeholder-shown で「打ち始めたら閉じる」を作る。
-    カテゴリは直近3ヶ月に投稿のあるものだけ（いま動いている入口）、タグは人気10件。
-    全件でないことはラベルの「活発な」が名乗り、条件そのものは title が持つ (#2670)。
+    カテゴリは直近3ヶ月に投稿のあるものだけ（いま動いている入口）、
+    連載とタグは直近1年の PV 順に6件 / 10件。
+    全件でないことはラベルの「活発な」「人気の」が名乗り、条件そのものは title が持つ (#2670)。
+    ラベルのアイコンは各一覧ページの h1 と同じ絵にする（category / run-baton / tags）。
     カテゴリ一覧はサイドバーが持つが、記事ページでは意図して伏せている。
     ここは読者が求めたときだけ開くので、その判断とは競合しない %>
 <div class="header-search-hint">
-	<p class="header-search-hint-label">活発なカテゴリから探す</p>
+	<p class="header-search-hint-label"><%- partial('svg-icon', {icon: 'category'}) %>活発なカテゴリから探す</p>
 	<ul class="header-search-hint-categories">
 		<% active_categories(3).forEach(function(c){ %>
 		<li><a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事 <%= c.count %>本（直近3ヶ月に投稿あり）"><%- partial('category-icon', {name: c.name}) %><%= c.name %><span class="header-search-hint-count"><%= c.count %></span></a></li>
 		<% }) %>
 	</ul>
-	<p class="header-search-hint-label">人気のタグから探す</p>
+	<%# 連載はカテゴリ・タグと違って一覧ページを持たないので、行き先は索引記事
+	    （/series/ の一覧と同じ規則）。物差しはタグと同じ「直近1年のPV」(#2855) %>
+	<p class="header-search-hint-label"><%- partial('svg-icon', {icon: 'run-baton'}) %>人気の連載から探す</p>
+	<div class="blog-tags header-search-hint-series">
+		<ul class="tag-list">
+			<% recent_popular_series(6).forEach(function(s){ %>
+			<li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(s.path) %>" title="<%= s.name %> 連載 全<%= s.total %>本（直近1年 <%= s.recent %>本・<%= s.pv.toLocaleString() %> View）"><%= s.name %><span class="tag-list-count"><%= s.total %></span></a></li>
+			<% }) %>
+		</ul>
+	</div>
+	<p class="header-search-hint-label"><%- partial('svg-icon', {icon: 'tags'}) %>人気のタグから探す</p>
 	<%# ホームの「人気のタグから記事を探す」と同じ部品。件数の右肩は .blog-tags が持つ %>
 	<div class="blog-tags">
 		<%- partial('../_widget/tag.ejs') %>


### PR DESCRIPTION
検索窓を押したときに出るパネル（#2791）に「人気の連載から探す」を足しました。あわせて3つのラベルにアイコンを付けています。

## 物差し

人気のタグ（`recent_popular_tags`）と同じ **直近1年に公開された記事の PV 合計**。同じ面に3つの入口が並ぶので、選び方が別々だと「どれがいまを指しているのか」を読者が区別できません。足切りも同じで、直近1年に3本未満の連載は出しません（単発のバズを弾く）。

条件を満たすのは78連載中11連載で、上位6件を出します。

| # | 連載 | 直近1年PV | 全本数 | 直近1年 |
| --- | --- | ---: | ---: | ---: |
| 1 | 秋のブログ週間2025 | 23,100 | 6 | 6 |
| 2 | Go1.26リリース | 16,900 | 7 | 7 |
| 3 | PostgreSQL18リリース | 12,600 | 6 | 6 |
| 4 | Go1.27リリース | 12,300 | 9 | 9 |
| 5 | 夏の自由研究2025 | 12,300 | 11 | 8 |
| 6 | Vue.js2025 | 6,000 | 8 | 8 |

圏外は 春の入門祭り2026 5,800 / Terraform2026 4,300 / テスト2026 2,300 / データエンジニアリング 1,800 / Java25リリース 1,700。

他の物差しも数えたうえで採りませんでした。

- **全期間PVを経過年で割る**（`popular_posts_in` の `decay=linear`）… 上位6件が 夏の自由研究2020 / 春の入門祭り2024 / 春の入門祭り2025 / 秋のブログ週間2023 / 春の入門祭り2023 / フロントエンド。半分が春の入門祭り系で、最新でも1年3ヶ月前の更新
- **更新の新しい順**（ホームの「連載から探す」= `recent_series`）… ホームと顔ぶれが重複し、見出しの「人気の」が名乗れない

## 見せ方と置き場所

- **タグと同じチップ**（`tag-list`）。連載名は「PostgreSQL18リリース」「データエンジニアリング」と長さがばらつくので、カテゴリと同じ145pxの grid だと3列に収まらない幅が出る。チップなら名前の長さに合わせて折り返す
- 右肩の数字は**全本数**（カテゴリ・タグのチップと同じ「総数」の意味 #2129）。直近1年の内訳とPVは `title` が名乗る
- 置き場所は**カテゴリとタグの間**。粗い→細かい（カテゴリ18語 → 連載 → タグ714語）の順で、チップの塊が2つ続かないぶんブロックの切れ目が見た目で分かる

## 行き先

連載はカテゴリ・タグと違って一覧ページを持たないので、索引記事（無ければ1本目）へ飛ばします。`/series/` の一覧と同じ規則です。

## ラベルのアイコン

3つのラベルに、それぞれの一覧ページの h1 と同じ絵を付けました。新しい絵柄は足していません。

| ラベル | アイコン | 同じ絵を使っている場所 |
| --- | --- | --- |
| 活発なカテゴリから探す | `category` | `/categories/` の h1 |
| 人気の連載から探す | `run-baton` | `/series/` の h1 |
| 人気のタグから探す | `tags` | `/tags/` の h1 |

## 変更点

- `scripts/ga4_pv.js` … `recent_popular_series` ヘルパーを追加。PV を持つファイルに置き、タグの隣に並べた。全ページのヘッダーから呼ぶので結果はキャッシュする（タグ側と同じ）
- `scripts/lib/series.js` … 一覧のエントリに `posts` を足した。直近の投稿だけを見たい呼び出し側のため
- `themes/future/layout/_partial/search-hint.ejs` … 連載ブロックとラベルのアイコン
- `themes/future/css-src/theme-styles.styl` … `.header-search-hint-series` の下の空き16px。チップ自身が12px持つので、カテゴリの塊と同じ28pxになる差分だけ

## 検証

- `hexo.theme.getView` でパネルを描き、6件・リンク先・`title` の中身を確認
- 数字はフロントマター直接集計と突き合わせ済み。差が出たのは 夏の自由研究2025 の1本（2025/08/27 公開・4,600 View）だけで、これは1年の境界が時刻まで見るため。今日を境に外れる位置にある
- チップの件数の span は `tag-list-count`。`header-search-hint-count` にすると hover でチップがネイビーに塗られたとき数字だけ薄いグレーで残る
- `node_modules/.bin/textlint themes/future/layout/_partial/search-hint.ejs` … 0件
- `npx prettier --check "scripts/**/*.js" "*.mjs"` … 通過

## 範囲外

- ホームの「連載から探す」（`recent_series`、更新の新しい順2件）はそのまま。パネルとは違う軸なので、両方あってよい

Closes #2855

🤖 Generated with [Claude Code](https://claude.com/claude-code)
