### PR TITLE
検索窓のパネルのタグが枠に貼り付いていたのを直し、「すべてのタグを見る」を足す (#2887)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -4416,7 +4416,10 @@ a.award-badge:focus {
      カテゴリと連載をヘッダーのナビへ移して要らなくなった (#2877)。
      引く 24px は .container の左右の余白 12px × 2 */
   width: unquote('min(420px, calc(100vw - 24px))');
-  padding: 16px 14px 4px;
+  /* 面の中の余白は四辺で1つの値にする。中のチップは負のマージンを持つので
+     （ul.tag-list の -13px）、辺ごとに値が違うと打ち消しが噛み合わず、
+     左端が枠に貼り付く (#2887) */
+  padding: (space-step * 4);
   /* 320px 幅では1列に落ちて縦に伸びるので、面の中で送れるようにする */
   max-height: unquote('calc(100vh - ' + header-height + ')');
   overflow-y: auto;
@@ -4443,12 +4446,21 @@ a.award-badge:focus {
   font-weight: bold;
   color: ink-mute;
 }
+/* 地の文の中では ul.tag-list が -13px でチップの「文字」を段落の左端へ
+   そろえる (#2429 / #2453)。囲みの中では枠の左端をそろえる方が正しいので
+   打ち消す。間隔は gap が持つ (#2864)。チップのマージンで作ると、
+   行末と最終行のぶんだけ右と下に余分な空きが出て四辺が揃わない (#2887) */
+.header-search-hint ul.tag-list {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: (space-step * 3);
+}
 /* チップはホームでは 12px。あちらは本文と並ぶ添えの情報だが、こちらは
-   面の中の行き先そのものなので一段上げる。左マージンを落として、
-   チップの枠の左端をラベルの文字の左端に揃える */
+   面の中の行き先そのものなので一段上げる */
 .header-search-hint .tag-list-link {
   font-size: 13px;
-  margin: 5px 12px 12px 0;
+  margin: 0;
 }
 .reference-posts-item a {
   color: ink-strong;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -180,6 +180,13 @@ Header and header elements
 .header-dropdown-more:focus {
   text-decoration: none;
 }
+/* 全件への導線は面を一段変えて反応するので、文字色は動かさない (#2859)。
+   土台の青は下線と同じく当たる箇所で外す。中に span を持つ他の行は
+   span 側が色を決めているため、青が見えるのはここだけ (#2887) */
+.header-dropdown-more:hover,
+.header-dropdown-more:focus {
+  color: ink-mute;
+}
 /* サイト名。ホームでは h1、それ以外のページでは div で出している。見た目は同じ */
 /* 帯が詰まったときに縮むのは検索欄だけ。サイト名とナビは縮めない
    （サイト名が折り返すと帯の高さが動き、ナビは white-space: nowrap で縮めない）。
@@ -4462,10 +4469,14 @@ a.award-badge:focus {
   font-size: 13px;
   margin: 0;
 }
-/* 全件への行き先。.more-link は margin-top だけを持つので、UA 既定の
-   下マージンが面の余白に足し算されないよう落とす */
-.header-search-hint .more-link {
-  margin-bottom: 0;
+/* 全件への行き先。ヘッダーのナビの「連載の一覧を見る」と同じ部品
+   （.header-dropdown-more）で、色・線・hover の面はそちらが持つ。
+   行の左右の padding だけ落とすのは、この面ではラベルとチップが
+   padding の端から始まるため（あちらは行そのものが左右に 12px 持つ並び）*/
+.header-search-hint-more {
+  margin-top: (space-step * 3);
+  padding-left: 0;
+  padding-right: 0;
 }
 .reference-posts-item a {
   color: ink-strong;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -4462,6 +4462,11 @@ a.award-badge:focus {
   font-size: 13px;
   margin: 0;
 }
+/* 全件への行き先。.more-link は margin-top だけを持つので、UA 既定の
+   下マージンが面の余白に足し算されないよう落とす */
+.header-search-hint .more-link {
+  margin-bottom: 0;
+}
 .reference-posts-item a {
   color: ink-strong;
 }

--- a/themes/future/layout/_partial/search-hint.ejs
+++ b/themes/future/layout/_partial/search-hint.ejs
@@ -11,7 +11,7 @@
 	<div class="blog-tags">
 		<%- partial('../_widget/tag.ejs') %>
 	</div>
-	<%# 10件は人気順の抜粋なので、全件への行き先を添える。ホームの
-	    「人気のタグから記事を探す」と同じ .more-link %>
-	<p class="more-link"><a href="/tags/">すべてのタグを見る</a></p>
+	<%# 10件は人気順の抜粋なので、全件への行き先を添える。形はヘッダーのナビの
+	    「連載の一覧を見る」と同じ部品（.header-dropdown-more）%>
+	<a class="header-dropdown-more header-search-hint-more" href="/tags/">すべてのタグを見る</a>
 </div>

--- a/themes/future/layout/_partial/search-hint.ejs
+++ b/themes/future/layout/_partial/search-hint.ejs
@@ -11,4 +11,7 @@
 	<div class="blog-tags">
 		<%- partial('../_widget/tag.ejs') %>
 	</div>
+	<%# 10件は人気順の抜粋なので、全件への行き先を添える。ホームの
+	    「人気のタグから記事を探す」と同じ .more-link %>
+	<p class="more-link"><a href="/tags/">すべてのタグを見る</a></p>
 </div>


### PR DESCRIPTION
## 1. タグが枠に貼り付いていた（本題）

`ul.tag-list` は**地の文の中で**チップの「文字」を段落の左端へそろえるために `margin-left: -13px` を持っている（チップの左マージン4px ＋ 枠1px ＋ 左padding 8px の打ち消し。#2429 / #2453）。

#2877 でパネルのチップを `margin: 5px 12px 12px 0` にしたとき、**この `-13px` が打ち消す相手（チップの左マージン4px）が無くなった**ため、チップが13px ぶん左へ飛び出し、パネルの枠の内側 **1px** の位置に来ていた。

下側の空きが広すぎたのも同じ構図で、`ul` の UA 既定 `margin-bottom: 16px` ＋ チップの `margin-bottom: 12px` ＋ パネルの `padding-bottom: 4px` が積み上がって **33px** になっていた。

やったこと:

- **パネルの中では `ul.tag-list` の負のマージンを打ち消す。** 囲みの中はチップの**枠**の左端をラベルと揃える方が正しい（地の文では文字の位置を揃えるのが正しく、そちらは触っていない）
- **余白を四辺で1つの値（16px）にする。** `16px 14px 4px` と割れていたのが、負のマージンとの噛み合わせを分かりにくくしていた
- **チップの間隔を `gap`（12px）に移す。** チップ自身のマージンで作ると、行末と最終行のぶんだけ右と下に余分な空きが出て四辺が揃わない（#2864 の「間隔は4の倍数を `gap` で持つ」）

## 2. 「すべてのタグを見る」を足した

パネルに出るのは人気順10件の抜粋なので、全件への行き先を添える。
形は**ヘッダーのナビの「連載の一覧を見る」と同じ部品**（`.header-dropdown-more`）で、色・線・hover の面はそちらが持つ。この面では行の左右の `padding` だけ落として、ラベルとチップの左端に文字をそろえた（あちらは行そのものが左右に12px 持つ並び）。

`.more-link`（ホームの全件導線）は使わなかった。右寄せ・リンクの青で、**同じヘッダーの中に別の見え方の全件導線が2つ**できてしまう。

## 3. 全件導線の hover が青くなっていたのを直した

`.header-dropdown-more` は hover で面を一段変える部品なのに、土台の `a:hover, a:focus` の青も当たっていた。**面と文字色の両方が動いていた**（#2859 で禁じている形）ので、色を `ink-mute` のまま止めた。
`.header-nav-link` などは当たる箇所で明示して外してあったが、全件導線だけ漏れていた。中に span を持つ他の行は span 側が色を決めているため、青が見えるのはここだけだった。

**ヘッダーのナビの「連載の一覧を見る」も同じ値を共有しているので、あちらも同時に直る。** #2877 由来の漏れで、この PR で拾った。

## 実測（ヘッドレス Chrome、パネルの外縁からの距離）

| 幅 | | チップの左端 | 面の下端まで | ラベルの左端 | パネルの高さ |
| --- | --- | --- | --- | --- | --- |
| 1280px | before | **2px** | 33px | 15px | 186.8px |
| | after | **17px** | **17px** | 17px | 201.5px |
| 375px | before | **2px** | 33px | 15px | 226.9px |
| | after | **17px** | **17px** | 17px | — |
| 320px | before | **2px** | 33px | 15px | 267.1px |
| | after | **17px** | **17px** | 17px | — |

`17px` は枠1px ＋ padding 16px。**ラベルの左端・チップの左端・「すべてのタグを見る」の文字と枠の左端・面の右端・面の下端がすべて 17px** に揃った。
チップと全件導線の間は12px（`margin-top`）。3幅とも横スクロールは出ていない（`scrollWidth === clientWidth`）。

### ナビの「連載の一覧を見る」との突き合わせ

計算後の値を1つずつ比べ、`padding` 以外はすべて一致:

| 項目 | 検索パネル | ナビ |
| --- | --- | --- |
| `color` | `rgb(97,97,97)` | `rgb(97,97,97)` |
| `font-size` / `font-weight` | 12px / 400 | 12px / 400 |
| `line-height` | 16.8px | 16.8px |
| `border-top` | `1px solid rgb(236,235,235)` | `1px solid rgb(236,235,235)` |
| `text-align` / `text-decoration` | start / none | start / none |
| `padding` | `8px 0` | `8px 12px` |
| `margin-top` | 12px | 4px |

`padding` と `margin-top` だけ意図して違う（上記2の理由）。

3状態の反応も両方で同値:

| 状態 | 文字色 | 面 | 下線 |
| --- | --- | --- | --- |
| 静止 | `rgb(97,97,97)` | 透明 | なし |
| hover | `rgb(97,97,97)` | `rgb(238,238,238)` | なし |
| focus | `rgb(97,97,97)` | `rgb(238,238,238)` | なし |

## 影響範囲の確認

同じ `ul.tag-list` を使うホーム本文の「人気のタグから記事を探す」は**1pxも動いていない**（セレクタを `.header-search-hint` 配下に限っているため）。公開中のサイトとローカルで実測して同値を確認:

| 項目 | 公開中 | ローカル |
| --- | --- | --- |
| `ul` の `margin-left` | -13px | -13px |
| チップの枠の左端（囲みからの差） | -9px | -9px |
| チップの**文字**の左端 | 0px | 0px |
| チップのマージン | `4px 6px 7px 4px` | `4px 6px 7px 4px` |
| 折り返しの行数 | 1行 | 1行 |

## 確認したこと

- `make css` … `site.css` 99KB。コンパイル後のルールを直接読んで確認
- `textlint`（`.ejs` プラグイン）… `search-hint.ejs` で0件
- 幅 1280 / 375 / 320px、静止 / hover / focus の3状態で実測（上表）

新しい変数・クラス・色は足していない。値は `space-step`（4px）の倍数で書いた。

Closes #2887
