### PR TITLE
特設ページを「リソース / コミュニティ / このブログについて」の3節に分ける (#2897)

### DIFF
--- a/source/specials/index.md
+++ b/source/specials/index.md
@@ -7,9 +7,23 @@ layout: page
 
 フューチャー技術ブログの特設ページの一覧です。
 
-- [記法ガイド](/specials/markdown/) — 記事に使える記法と、その表示結果の見本
-- [スタイルガイド](/specials/styleguide/) — 色・文字・形・部品の決まりと、その実物
+## リソース
+
+フューチャーが社外へ公開している知識資産です。
+
 - [フューチャーのガイドライン](/specials/guidelines/) — 設計ガイドライン・コーディング規約・TypeScript 教材の入口
+
+## コミュニティ
+
+技術を通じた社外との接点です。
+
 - [HACK TO THE FUTURE](/specials/httf/) — フューチャー主催のプログラミングコンテストと、競技プログラミング記事の入口
 - [アドベントカレンダー](/specials/advent-calendar/) — 2015年から毎年参加している Qiita Advent Calendar の歴代一覧
 - [Future Tech Cast](/specials/techcast/) — 技術ブログから派生したポッドキャストの番組紹介とエピソード一覧
+
+## このブログについて
+
+このブログの書き方と見た目の決まりです。
+
+- [記法ガイド](/specials/markdown/) — 記事に使える記法と、その表示結果の見本
+- [スタイルガイド](/specials/styleguide/) — 色・文字・形・部品の決まりと、その実物


### PR DESCRIPTION
## 何を直したか

`/specials/` は6ページのフラットな箇条書きで、分類を持っていませんでした。
一方で**サイトには既に「リソース」「コミュニティ」という語彙があり、2箇所で使われています。**
ヘッダーのドロップダウン（`_partial/header.ejs`）とフッターの列（`_partial/footer-columns.ejs`）です。

| ページ | ヘッダー | フッター | `/specials/`（before） | 直近1年のPV |
| --- | --- | --- | --- | --- |
| フューチャーのガイドライン | リソース | リソース | 分類なし | 100 |
| HACK TO THE FUTURE | コミュニティ | コミュニティ | 分類なし | 100 |
| アドベントカレンダー | コミュニティ | コミュニティ | 分類なし | 100 |
| Future Tech Cast | コミュニティ | コミュニティ | 分類なし | 100未満 |
| 記法ガイド | — | — | 分類なし | 200 |
| スタイルガイド | — | — | 分類なし | 100未満 |

**6件中4件は、既に2箇所で一致した分類が付いていました。** `/specials/` だけがその語彙を持っていません。
残る2件は「このブログに書くときの決まり」「このブログの見た目の決まり」で、外向きの2つとは性質が違います。

## after

```text
## リソース          フューチャーが社外へ公開している知識資産です。
  フューチャーのガイドライン

## コミュニティ      技術を通じた社外との接点です。
  HACK TO THE FUTURE
  アドベントカレンダー
  Future Tech Cast

## このブログについて  このブログの書き方と見た目の決まりです。
  記法ガイド
  スタイルガイド
```

- **新しい分類語を作っていません。** 「リソース」「コミュニティ」はヘッダーとフッターから借りた語で、
  これでサイトの3箇所が同じ語彙になります
- 3つ目は「このブログについて」。リソース（社外への知識資産）・コミュニティ（社外との接点）と
  並べたときに、内向きの節として座ります
- コミュニティの並び（HTTF → アドベントカレンダー → Tech Cast）は**フッターの列と同じ順**です
- **リソースが1件だけの節になる**のは承知のうえです。ガイドラインのページ自身が3つの外部サイトへの
  入口を持つので、中身が薄いわけではありません

## 副次的に直ったこと

このページには **h2 が1つも無かったので目次が出ていませんでした。** 3節に分けたことで、
サイドバーに「リソース / コミュニティ / このブログについて」の目次が出ます。

## やらなかったこと（#2897 に残しています）

- **フッターが持つ完全な目録を `/specials/` へ移していません。** リソース7件・コミュニティ8件のうち
  外部の行き先（コーディング規約・TypeScript・OSS 4つ・connpass・YouTube・登壇・出版）はフッターのままで、
  `/specials/` の定義を「特設ページの一覧」から変えていません
- **ページ名「特設ページ」は変えていません。** h1・パンくずの「特設」・ホームの枠の見出し・
  「すべての特設ページを見る」に波及するため、今回は分類だけに絞りました

## 別に判断すること

- **ヘッダーにもフッターにも `/specials/` への行き先がありません。** 入る道はホームの特設枠の
  「すべての特設ページを見る」と各ページのパンくずの2つだけで、トップ自体のPVも100です
- **記法ガイドとスタイルガイドは、ヘッダーからもフッターからも1本もリンクされていません。**
  `/specials/` と互いのページからしか辿れません
- 完全な目録がフッターにしかなく、ポータルが部分集合という関係が逆立ちしています

## 検証

- `hexo server` で配信して、見出しが `特設ページ / リソース / コミュニティ / このブログについて` の順に出ること、
  6ページすべてが節の下に並ぶこと、サイドバーの目次に3節が入ることを確認
- `textlint` 0件

Closes #2897

🤖 Generated with [Claude Code](https://claude.com/claude-code)