### PR TITLE
一覧の記事タイトルを節見出しの下の h3 にする (#2919)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1693,6 +1693,15 @@ body {
   bottom: -40px;
   border-bottom: 1px solid rule-weak;
 }
+/* 縦積みになる幅では、サムネイルとタイトルの間に空きが無い（.row の gutter-y は 0、
+   見出しの margin も上は 0）。`.blog-posts h2 { padding-top: 15px }` が代わりを
+   務めていたが、記事タイトルが h3 になって外れた (#2919)。
+   中の空き（タイトル→概要 10px / 概要→メタ 12px）と同じ段に置く */
+@media (max-width: 575px) {
+  .archives > .article-card > .card-thumb {
+    margin-bottom: 12px;
+  }
+}
 /* 列が横に並ぶ幅では、サムネイルの高さを本文列に合わせる (#2747)。
    シェアボタンは本文列の最後にあるので、これで画像の下辺とボタンの下辺が
    そろう。以前は画像が OGP 比で止まり、ボタンだけが下にはみ出していた。

--- a/themes/future/layout/_partial/post/title.ejs
+++ b/themes/future/layout/_partial/post/title.ejs
@@ -1,5 +1,6 @@
-<%# 記事ページではタイトルがページの主見出しなので h1、一覧ページでは記事が並ぶので h2 にする %>
-<% const titleTag = is_post() ? "h1" : "h2" %>
+<%# 記事ページではタイトルがページの主見出しなので h1、一覧ページでは
+    節見出し（section-heading の h2）の中に並ぶので h3 にする (#2919) %>
+<% const titleTag = is_post() ? "h1" : "h3" %>
 <<%= titleTag %> class="<%= class_name %>"><%= post.title %>
   <% if (is_post()) {%>
     <a href="<%= edit_url(page.source) %>" title="Suggest Edits" aria-label="この記事をGitHubで編集する" class="github-edit"><i class="github-edit-icon"></i></a>


### PR DESCRIPTION
Closes #2919

## やったこと

`_partial/post/title.ejs` の一覧側の見出しレベルを **h2 → h3** にした。節見出し（`_partial/section-heading` の h2）の中に並ぶものなので、階層を1つ下げる。記事ページの h1 は変えていない。

## before / after

生成 HTML の見出しの数（`hexo server` の出力を数えた）:

| ページ | before | after |
| --- | --- | --- |
| トップ1ページ目 | h1 1 / **h2 34** / h3 0 | h1 1 / **h2 9** / **h3 25** |
| `/categories/Programming/` | h1 1 / h2 36 / h3 0 | h1 1 / h2 11 / h3 25 |
| `/tags/Go/` | h1 1 / h2 33 / h3 2 | h1 1 / h2 8 / h3 27 |
| `/authors/真野隼記/` | h1 1 / h2 33 / h3 0 | h1 1 / h2 8 / h3 25 |
| 記事ページ | h1 1 / h2 12 | **変化なし** |

トップの見出しの並びが「新着記事（h2）→ 記事×25（h3）→ カテゴリー（h2）」になり、**節の終わりが見出しレベルで分かる**ようになった。

`/tags/Go/` の h3 が before から2つあるのは既存の `.panels-label`（「隣接するタグを探す」「もっと詳しいタグで探す」）で、これも節の中の小見出しなので階層が揃った形になる。

issue 本文の「トップの h2 は36個 / 節見出し5個」は 2026-08-27 のビルドを数えた値。#2892（連載をサイドバーの軸へ）以降、ホームの節は「よく読まれている記事 / 特集 / 新着記事」の3つになっているので、現在の main では **34個**が正しい。指摘の向きは変わらない。

## 見た目は変えていない（1箇所を除く）

`.archive-post-title` の宣言（`font-size: 20px` / `font-weight: bold`、詳細度 0,1,0）が `h3` の bootstrap 既定（0,0,1）に勝つので、**サイズ・太さ・行間・マージンは h2 のときと同じ**。生成後の `site.css` でカスケードを確認した:

| 性質 | 効いている宣言 | 値 |
| --- | --- | --- |
| font-size | `.archive-post-title` | 20px |
| font-weight | `.archive-post-title` | bold |
| line-height | `h1, h2, h3, h4, h5, h6` | `leading-heading` = 1.3 |
| margin | `h1, h2, h3, h4, h5, h6` | `0 0 10px` |

**1箇所だけ、空きの持ち主を移した。**

`@media (max-width: 576px) { .blog-posts h2 { padding-top: 15px } }`（purifycss 由来の残骸。#2920 で整理予定）が、**縦積みの幅でサムネイルとタイトルの間の唯一の空き**になっていた（`.row` の `gutter-y` は 0、見出しの上マージンも 0）。h3 にすると外れて画像とタイトルがくっつくので、カード側に移した。

```styl
@media (max-width: 575px) {
  .archives > .article-card > .card-thumb {
    margin-bottom: 12px;
  }
}
```

- **15px ではなく 12px。** 間隔は4の倍数だけを使う（#2864）。カードの中の空きは最大12px（概要→メタ）で、外の80px がその6倍以上という #2747 の前提を崩さない値でもある。**幅375pxで1枚3px・25枚で75px 縮む**
- 境目を `575px` にしたのは、元の `max-width: 576px` が `min-width: 576px`（横並びに切り替わる側）と**ちょうど576pxで両方当たっていた**ため。横並びの列で縦積み用の空きが乗ることが無くなる
- 節見出し側の15pxはそのまま。`.bottom-content-header` は自前で `margin: 48px 0 20px` を持っているので、この15pxは節見出しには要らないが、落とすかどうかは #2920 の範囲

## 範囲外にしたもの

- `.blog-posts h2 { padding-top: 15px }` そのものの削除、ページャの `float` の残骸 → **#2920**
- カードの縦の長さ（概要文の行数・外の空き80px） → **#2914**
- サムネの縦横比 → **#2916**

## 確認したこと

- `post/title` の呼び出しは2箇所（`_partial/article.ejs` = 記事ページの h1、`_partial/archive-post.ejs` = 一覧カード）。一覧を出す5レイアウト（index / category / category-without / tag / author）はすべて `_partial/archive` → `archive-post` を通り、いずれも `list_heading` で節見出しを出しているので、h3 の親が必ず存在する
- `archive-post-title` を参照しているのは CSS の2箇所（`palt` とサイズ）だけ。`scripts/` からは参照していない
- `.ejs` の textlint（`no-unmarked-external-link`）を通した（0件）
- `scripts/` と記事は触っていないので prettier / 記事の textlint は対象外
