### PR TITLE
ヘッダーの検索ラベルの aria-label を sr-only に置き換える (#2924)

### DIFF
--- a/themes/future/layout/_partial/header.ejs
+++ b/themes/future/layout/_partial/header.ejs
@@ -117,7 +117,7 @@
 			    狭い幅では虫眼鏡だけ出し、label タップで入力欄にフォーカスして
 			    :focus-within で展開する（CSSのみ）。送信はキーボードの検索キーが担う %>
 			<form action="https://google.com/cse" target="_blank" class="header-search">
-				<label for="header-search-q" class="header-search-open" aria-label="検索を開く"><%- partial('svg-icon', {icon: 'search'}) %></label>
+				<label for="header-search-q" class="header-search-open"><%- partial('svg-icon', {icon: 'search'}) %><span class="sr-only">検索を開く</span></label>
 				<%# autocomplete: ブラウザが出す入力履歴のポップアップが、下に開く
 				    パネルと同じ場所に重なる (#2791) %>
 				<input type="text" id="header-search-q" name="q" placeholder="記事を検索" aria-label="サイト内検索キーワード" autocomplete="off" />


### PR DESCRIPTION
`label` 要素は対応する role を持たないので、`aria-label` は ARIA 仕様で使えない属性（axe の `aria-prohibited-attr` / serious）。外して、伝えたい文字は `label` の中の `sr-only` な span に置く。

```diff
-<label for="header-search-q" class="header-search-open" aria-label="検索を開く">…</label>
+<label for="header-search-q" class="header-search-open">…<span class="sr-only">検索を開く</span></label>
```

同じファイルの引き出しの引き金（`header-drawer-toggle` の「メニュー」#2852）が既にこの形。フッターの外部リンク（#2839）も同じ。**新しい書き方は増やしていない。**

## 測ったこと

ヘッドレス Chrome で、5ページ種 × 幅 375 / 768 / 1280 を、修正後の生成物に「元の形に戻す」DOM 操作を被せた対照と並べて実測した。

### axe（`aria-prohibited-attr` ほかラベル系4ルール）

| 幅 | before | after |
| --- | --- | --- |
| 375 | `aria-prohibited-attr`(serious) × 1 × 全5ページ | clean |
| 768 | clean | clean |
| 1280 | clean | clean |

**出るのは幅575px以下だけ**だった。576px 以上では `.header-search-open` が `display: none` で、axe が隠れた要素を見ないため。issue には「巡回した12ページ種すべてで出る」とあるが、正確には**全ページ種の、狭い幅のときだけ**。ヘッダーなので出るページ種が全部なのは変わらない。

### 入力欄の読み上げ名（CDP の `Accessibility.getFullAXTree`）

`label` の中のテキストは `for` で結びついた入力欄の名前計算に入るので、そこが変わらないかを見た。

| | before | after |
| --- | --- | --- |
| `textbox` | `"サイト内検索キーワード"` | `"サイト内検索キーワード"` |
| `button` | `"サイト内検索"` | `"サイト内検索"` |

入力欄が自分で持つ `aria-label` の方が優先されるので変わらない。

そのうえで `検索を開く` は `ignored=false` の `StaticText` として木に残る。引き出しの「メニュー」とまったく同じ形で、**今までどこにも効いていなかった意図（虫眼鏡が何のボタンか伝える）が初めて効くようになる。**

```
LabelText
  none (svg, aria-hidden)
  none
    StaticText name="検索を開く" ignored=false
```

### レイアウト

`sr-only` は `position: absolute` の 1×1px なので、`display: flex` の label の中でも流れに入らない。幅375px で虫眼鏡 28×28、帯 64px。**before / after で同値。**

## 範囲外

- `#2886` の畳む ✕（`aria-hidden` な span）はそのまま。フォーカスを受けないことが畳む仕組みの前提なので触らない
- 他の `aria-label` は `nav` / `button` / `input` / `a` / `aside` / `div[role=radiogroup]` に付いていて、いずれも role を持つ要素。テンプレート全体を見て `<label>` に付いていたのはここ1箇所だけ

## lint

`themes/future/layout/_partial/header.ejs` に textlint（EJS プラグイン）を回して 0 件。`scripts/` は触っていないので prettier の対象に変化なし。

Closes #2924