### PR TITLE
「よく読まれている記事」のカードのサムネをタブ順から外す (#2936)

### DIFF
--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -133,8 +133,9 @@ hexo.extend.helper.register('popular_posts_in', function (posts, limit, decay) {
   // マークアップはホームの「連載から探す」と同じカード。2列で並べる
   const cards = ranked
     .map(({ post }) => {
+      // サムネはタイトルと同じ行き先なので、タブ順と読み上げから外す (#2845 / #2936)
       const thumb = post.thumbnail
-        ? `<a href="/${post.path}" title="${post.title}" class="thumb-link panel-thumb"><img src="${post.thumbnail}" alt="" width="200" height="135" loading="lazy"></a>`
+        ? `<a href="/${post.path}" title="${post.title}" class="thumb-link panel-thumb" tabindex="-1" aria-hidden="true"><img src="${post.thumbnail}" alt="" width="200" height="135" loading="lazy"></a>`
         : '';
       return (
         `<div class="col-12 col-md-6"><div class="article-card post-panel h-100">${thumb}` +


### PR DESCRIPTION
Closes #2936

## やったこと

`scripts/ga4_pv.js` の「よく読まれている記事」のカードで、サムネイルの `<a>` に `tabindex="-1"` と `aria-hidden="true"` を足した。#2845 で決めた「同じ行き先のリンクを1つのカードに2つ置かない」がこの1箇所だけ漏れていた。

```diff
+      // サムネはタイトルと同じ行き先なので、タブ順と読み上げから外す (#2845 / #2936)
       const thumb = post.thumbnail
-        ? `<a href="/${post.path}" title="${post.title}" class="thumb-link panel-thumb"><img ...></a>`
+        ? `<a href="/${post.path}" title="${post.title}" class="thumb-link panel-thumb" tabindex="-1" aria-hidden="true"><img ...></a>`
         : '';
```

`<img>` の `alt=""` は既にあるので触っていない。

## before / after

配信中の HTML で、同じ `href` を持つ `<a>` のうち `tabindex="-1"` が付いていないものが近接して2つ以上ある箇所を全20ページ種で数えた。

| ページ種 | before | after |
| --- | --- | --- |
| カテゴリ個別（`/categories/Programming/`） | 6件 | **0件** |
| タグ個別（`/tags/Go/`） | 6件 | **0件** |
| 著者個別 | 6件 | **0件** |
| すべての記事（`/articles/`） | 6件 | **0件** |
| 年別（`/articles/2026/`） | 6件 | **0件** |
| 月別（`/articles/2026/08/`） | 6件 | **0件** |

**6ページ種で 36箇所の余分なタブ停止が消える。**

マウスでは今までどおり画像を押せて、キーボードと支援技術ではタイトルの1回だけ止まる。

## 漏れていた理由

**リンクを組み立てているのが JS だから。** #2845 は `.thumb-link` を使う EJS を洗ったが、`scripts/` の中で文字列として組んでいるものは同じ grep に出てこない。外部リンクの印を JS に書かず EJS 側に置く判断（#2729）と同じ構図で、**JS の中の HTML は検査の網の外に出る。**

ホームの「よく読まれている記事」は `postListItem`（`scripts/lib/post_list.js`）で描かれ、そちらは `post-list-icon` に `tabindex="-1" aria-hidden="true"` を持っていた。同じ見出しの枠なのに部品が違い、片方だけ直っていた。

## 見つかったが直さないもの

- **ページャ**（`/page/2/` の「2」と「次のページ」が同じ href）。カードではなく、番号と前後送りは別の操作
- **`/specials/httf/`** の `.panel-title` と `.panel-meta` の「予選」が同じ href。サムネイルは既に `tabindex="-1"` を持っており、「予選」は「本選」と対になるラベル
- **`/doctor/`** の同じタグへの複数リンク。運営ページで、表の性質上同じタグが複数の節に出る

## 確認したこと

- 変更後の配信 HTML で、上の6ページ種の重複タブ停止が0件になったこと（残るのはページャ・httf・doctor の上記3種だけ）
- サムネイルの `<a>` が `tabindex="-1" aria-hidden="true"` を持ち、タイトルの `<a class="panel-title">` は持たないこと
- `npx prettier --check "scripts/**/*.js" "*.mjs"` が通ること
- `scripts/` を触ったので `hexo server` を再起動して確かめた（起動時にしか読まれないため）
