### PR TITLE
数式に代替テキストを付ける (#2927)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "image-size": "^2.0.2",
         "js-yaml": "^4.3.1",
         "markdown-it": "^14.2.0",
+        "mathjax-full": "3.2.2",
         "node-fetch": "^2.7.0",
         "rss-parser": "^3.13.0"
       },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "image-size": "^2.0.2",
     "js-yaml": "^4.3.1",
     "markdown-it": "^14.2.0",
+    "mathjax-full": "3.2.2",
     "node-fetch": "^2.7.0",
     "rss-parser": "^3.13.0"
   },

--- a/scripts/mathjax_a11y.js
+++ b/scripts/mathjax_a11y.js
@@ -1,0 +1,97 @@
+'use strict';
+
+/**
+ * 数式に代替テキストを与えるフィルター (#2927)。
+ *
+ * hexo-filter-mathjax は MathJax の SVG 出力しか持たず、出てくる
+ * <svg role="img"> は title も aria-label も持たない。代替テキストを出す設定も
+ * 公開していない（extension_options は TeX 入力側にしか渡らない）ため、
+ * 数式が読み上げられない状態になっている。
+ *
+ * 同じ数式から MathML を作り、SVG の隣に .sr-only で置く。SVG は aria-hidden で
+ * 読み上げから外す。MathJax がブラウザ側で既定にしている assistive MathML と
+ * 同じ形で、見た目は変わらない。
+ *
+ * **見た目の SVG もここで描く**（プラグインの優先度5より前の4で走り、$ を消費するので
+ * プラguin 側は素通りになる）。プラグインの出力に後から MathML を当てる形は採れない。
+ * 文書順で対応づけるしかなく、区切り記号の対応が崩れた記事（`$` の迷子）では
+ * findMath が見つける数と実際に出る mjx-container の数がずれて、
+ * **別の式の読み上げを付けてしまう**。描画そのものを持てば、式と MathML は
+ * 同じ item 経由で結び付く。
+ */
+
+const { mathjax } = require('mathjax-full/js/mathjax.js');
+const { TeX } = require('mathjax-full/js/input/tex.js');
+const { SVG } = require('mathjax-full/js/output/svg.js');
+const { LiteAdaptor } = require('mathjax-full/js/adaptors/liteAdaptor.js');
+const { RegisterHTMLHandler } = require('mathjax-full/js/handlers/html.js');
+const { AllPackages } = require('mathjax-full/js/input/tex/AllPackages.js');
+const { SerializedMmlVisitor } = require('mathjax-full/js/core/MmlTree/SerializedMmlVisitor.js');
+
+// MathML は文字列でしか手に入らず、アダプタは要素しか足せない。いったん目印を
+// 置いて直列化後に差し替える。目印は連番なので、式との対応は描画結果のまま保たれる
+const MARK = (i) => `@@mathml-a11y-${i}@@`;
+
+// プラグインと同じ設定で読む必要があるので、初期化は描画時まで遅らせる
+// （hexo.config.mathjax の既定値はプラグインの読み込み時に入る）
+let jax = null;
+const setup = () => {
+  if (jax) return jax;
+  const config = hexo.config.mathjax || {};
+  const adaptor = new LiteAdaptor({
+    fontSize: 16,
+    cjkCharWidth: config.cjk_width,
+    unknownCharWidth: config.normal_width,
+  });
+  RegisterHTMLHandler(adaptor);
+  const tex = new TeX(
+    Object.assign(
+      {
+        packages: Array.isArray(config.packages)
+          ? AllPackages.concat(config.packages)
+          : AllPackages,
+        tags: config.tags,
+        inlineMath: config.single_dollars === false ? {} : { '[+]': [['$', '$']] },
+      },
+      config.extension_options,
+    ),
+  );
+  jax = { adaptor, tex, visitor: new SerializedMmlVisitor() };
+  return jax;
+};
+
+hexo.extend.filter.register(
+  'after_post_render',
+  (data) => {
+    if (!data.mathjax && !(hexo.config.mathjax || {}).every_page) return;
+
+    const { adaptor, tex, visitor } = setup();
+    const doc = mathjax.document(data.content, {
+      InputJax: tex,
+      OutputJax: new SVG({ fontCache: 'none' }),
+    });
+    doc.render();
+
+    const mathml = [];
+    for (const item of doc.math) {
+      const container = item.typesetRoot;
+      const svg = container && adaptor.firstChild(container);
+      // 何も出なかった式（`$` の迷子で拾われた空の領域）は container を持たない
+      if (!svg || adaptor.kind(svg) !== 'svg') continue;
+
+      adaptor.setAttribute(svg, 'aria-hidden', 'true');
+      const label = adaptor.node('span', { class: 'sr-only' });
+      adaptor.append(label, adaptor.text(MARK(mathml.length)));
+      adaptor.append(container, label);
+      // 改行を潰すのは、隠し要素の中で余分な空白を読み上げさせないため
+      mathml.push(visitor.visitTree(item.root).replace(/\n\s*/g, ''));
+    }
+    if (mathml.length === 0) return;
+
+    data.content = adaptor
+      .innerHTML(adaptor.body(doc.document))
+      .replace(/@@mathml-a11y-(\d+)@@/g, (_, i) => mathml[Number(i)]);
+    return data;
+  },
+  4,
+);


### PR DESCRIPTION
## やったこと

数式の SVG に代替テキストを与える。MathJax が同じ数式から作った **MathML を `.sr-only` で SVG の隣に置き、SVG は `aria-hidden="true"` で読み上げから外す**。ブラウザ側の MathJax が既定にしている assistive MathML と同じ形で、**見た目は変わらない**。

```html
<mjx-container class="MathJax" jax="SVG">
  <svg ... role="img" aria-hidden="true">…</svg>
  <span class="sr-only"><math xmlns="…"><mfrac><mi>a</mi><mi>b</mi></mfrac>…</math></span>
</mjx-container>
```

隠し方は既存の `.sr-only`（#2839 でフッターの外部リンクに使っているもの）をそのまま使う。**CSS は1行も足していない。**

## 数字

`mathjax: true` の33ページ（記事32本＋記法ガイド）を、配信中のサーバから取って数えた。

| | before | after |
| --- | --- | --- |
| 数式（`mjx-container`） | 539 | **539**（変わらない） |
| 代替テキストを持つ数式 | **0** | **539** |
| `mjx-container` と MathML の数が食い違うページ | — | **0** |
| axe の `svg-img-alt` | 出る | **出ない** |

数式が多い順に 競技プログラミング入門 116 / 巡回セールスマン問題 94 / monotone minima 59 …。
`before` の 0 は、この変更前のサーバで `title` / `aria-label` / assistive MathML の
いずれも 0 件だったことを確認したもの。数式の数が変わらないことは、同じ検証ハーネスで
フィルタあり・なしの両方を回して突き合わせた。

## なぜ SVG の描画までこのフィルタで持つのか

**プラグインの出力に後から MathML を当てる形は採れない。** その形だと式と MathML を文書順で対応づけるしかなく、実際に33ファイルで試すと**2ファイルでずれた**。

- `20250226a_Transformerの文章生成の仕組みを理解する`: `findMath` が4件に対し `mjx-container` は3件
- `20240626b_社会人からはじめる競技プログラミング`（数式116件）でも同じずれが出た

原因は `$` の対応が崩れた箇所で、MathJax が中身が `\\` だけの空の数式領域を拾い、それが描画結果には出ないこと。**ずれたまま順に当てると、別の式の読み上げを付ける**（このときは数の食い違いを検出して差し込みを止めていたので、代わりにこの2ファイルの数式が無ラベルのまま残った。全体の2割強にあたる）。

描画をこちらで持てば、式と MathML は同じ `item` 経由で結び付くので、順序の仮定が要らない。優先度は4（プラグインは5）で、`$` を消費し終えているのでプラグイン側は素通りになる。**素通りが本当に無害か**は、自分の出力をプラグインの `mathjax()` に通してバイト単位で比較して確かめた（差分は MathML の数値実体が文字に正規化される分だけ）。プラグインには CSS の注入（`append_css`）とフロントマターの判定が残る。

## 依存

`mathjax-full` は `hexo-filter-mathjax` の推移的な依存だったが、直接 `require` するようになったので `dependencies` に入れた。**SVG と MathML を同じ版で作る必要があるのでバージョンは固定**（`3.2.2`。プラグインが依存している版と同じ）。

## 範囲外にしたこと

- **`role="img"` は消していない。** `aria-hidden="true"` があれば読み上げ側は無視するので、差分を増やさない
- **数式を MathML 出力に置き換える案は採らない。** ブラウザは MathML Core を持っているので SVG をやめる選択もあるが、**字形と行送りが変わる**ので #2598（表示数式の寄せ）と同じ「見た目の判断」になる。この PR は代替テキストだけに絞る
- **日本語を数式の中に書いた箇所は、MathML でも1文字ずつの `<mi>` になる**（`関連度 = ...` のような書き方）。読み上げは「関 連 度」と文字単位で流れる。これは記法側の話なので、直すなら記事本文か記法ガイドで扱う

## 確認したこと

- 配信中の33ページ全部で `mjx-container` と MathML の数が一致（539 対 539、不一致0）
- 同じハーネスにフィルタあり・なしを通して、数式の数が変わらないことを確認
- 表示数式のスクリーンショットで見た目が変わらないこと、`.sr-only` の実寸が 1×1 でクリップされていること、横スクロールが出ないこと
- `npx prettier --check "scripts/**/*.js" "*.mjs"` は通る（CI と同じ対象）

Closes #2927

🤖 Generated with [Claude Code](https://claude.com/claude-code)
