### PR TITLE
おすすめ記事カードのサムネをタブ順と読み上げから外す (#2923)

### DIFF
--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -130,11 +130,12 @@ hexo.extend.helper.register('popular_posts_in', function (posts, limit, decay) {
 
   if (ranked.length === 0) return '';
 
-  // マークアップはホームの「連載から探す」と同じカード。2列で並べる
+  // マークアップはホームの「連載から探す」と同じカード。2列で並べる。
+  // サムネはタイトルと同じ行き先なので、タブ順と読み上げから外す (#2845 / #2923)
   const cards = ranked
     .map(({ post }) => {
       const thumb = post.thumbnail
-        ? `<a href="/${post.path}" title="${post.title}" class="thumb-link panel-thumb"><img src="${post.thumbnail}" alt="" width="200" height="135" loading="lazy"></a>`
+        ? `<a href="/${post.path}" title="${post.title}" class="thumb-link panel-thumb" tabindex="-1" aria-hidden="true"><img src="${post.thumbnail}" alt="" width="200" height="135" loading="lazy"></a>`
         : '';
       return (
         `<div class="col-12 col-md-6"><div class="article-card post-panel h-100">${thumb}` +


### PR DESCRIPTION
## やったこと

`popular_posts_in`（`scripts/ga4_pv.js`）が組み立てるサムネのリンクに `tabindex="-1" aria-hidden="true"` を足した。#2845 で決めた形に揃えただけで、**見た目は変わらない。**

```diff
-        ? `<a href="/${post.path}" title="${post.title}" class="thumb-link panel-thumb">…</a>`
+        ? `<a href="/${post.path}" title="${post.title}" class="thumb-link panel-thumb" tabindex="-1" aria-hidden="true">…</a>`
```

`.thumb-link` を出す8箇所のうち、ここだけが漏れていた。**JS の中の HTML なので、EJS 側を見ただけでは気づけない**——それがコメントに「マークアップはホームの『連載から探す』と同じカード」と書いてあるのに実際は違っていた理由なので、その1行を足した。

## 数字

配信中のサーバから、呼び出し元5箇所（`archive.ejs` の3呼び出し・`tag.ejs`・`category.ejs`・`author.ejs`・`category_without_tag.js`）が出る7ページを取って数えた。

| ページ | `.thumb-link` | 属性あり | 属性なし |
| --- | --- | --- | --- |
| `/articles/` | 6 | 6 | **0** |
| `/articles/2026/` | 6 | 6 | **0** |
| `/articles/2026/08/` | 24 | 24 | **0** |
| `/tags/Go/` | 31 | 31 | **0** |
| `/categories/Programming/` | 31 | 31 | **0** |
| `/authors/澁川喜規/` | 31 | 31 | **0** |
| `/categories/Programming/without-go/` | 31 | 31 | **0** |
| 合計 | 160 | **160** | **0** |

before は、この枠のサムネが1ページあたり **4〜6件**（アーカイブ6 / カテゴリ個別6 / タグ個別6 / 著者個別4）タブ停止していた。

点検スキル（`.claude/skills/site-audit`）を回すと、**`サムネのリンクがタブ順に残っている` の所見が消える**。

## 確認したこと

- ヘルパーを直接呼んで出力を検査（`popular_posts_in` の4カードすべてに属性が付く。`panel-title` のリンクは4件のままで、カードあたりのリンク数は変わっていない）
- 配信中の7ページで属性なし0件（上の表）
- `npx prettier --check "scripts/**/*.js" "*.mjs"` は通る（CI と同じ対象）

Closes #2923

🤖 Generated with [Claude Code](https://claude.com/claude-code)
