### PR TITLE
ga4_pv.js のサムネのコメントの重複を落とす

### DIFF
--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -130,8 +130,7 @@ hexo.extend.helper.register('popular_posts_in', function (posts, limit, decay) {
 
   if (ranked.length === 0) return '';
 
-  // マークアップはホームの「連載から探す」と同じカード。2列で並べる。
-  // サムネはタイトルと同じ行き先なので、タブ順と読み上げから外す (#2845 / #2923)
+  // マークアップはホームの「連載から探す」と同じカード。2列で並べる
   const cards = ranked
     .map(({ post }) => {
       // サムネはタイトルと同じ行き先なので、タブ順と読み上げから外す (#2845 / #2936)


### PR DESCRIPTION
## 何が起きたか

`scripts/ga4_pv.js` のサムネのリンクを **#2937（issue #2936）と #2940（issue #2923）が別々に直し、両方マージされた**。issue も PR も同じ1行が対象で、内容も同じ（`tabindex="-1" aria-hidden="true"` の追加）。

属性は同じものなので**出力は正しい**が、同じことを言うコメントが2行並んだ。

```js
  // マークアップはホームの「連載から探す」と同じカード。2列で並べる。
  // サムネはタイトルと同じ行き先なので、タブ順と読み上げから外す (#2845 / #2923)   ← これを落とす
  const cards = ranked
    .map(({ post }) => {
      // サムネはタイトルと同じ行き先なので、タブ順と読み上げから外す (#2845 / #2936)  ← 残す
```

## やったこと

**コードの直上にある `map` の中のコメントを残し**、外側に足された方を落として元の1行に戻した。挙動の変更は無い（コメントのみ、+1/-2 行）。

`npx prettier --check "scripts/**/*.js" "*.mjs"` は通る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
