### PR TITLE
点検スキル: 本文に届かないタブ走査を所見にする

### DIFF
--- a/.claude/skills/site-audit/audit.mjs
+++ b/.claude/skills/site-audit/audit.mjs
@@ -223,7 +223,7 @@ const inspect = () => {
 };
 
 // ---- キーボードでタブ順を辿る ----
-const tabWalk = async (page, limit = 45) => {
+const tabWalk = async (page, limit = 80) => {
   await page.evaluate(() => {
     document.body.focus();
     if (document.activeElement && document.activeElement.blur) document.activeElement.blur();
@@ -378,11 +378,15 @@ for (const [urlPath, name] of targets) {
       const stops = await tabWalk(page);
       const reached = !!(stops.at(-1) && stops.at(-1).inMain);
       walks.push({where, stops: stops.length, reached});
-      // スキップリンクがあっても、押さずに Tab を送る読者は全部踏む
-      if (reached && stops.length > 10) {
-        const byClass = new Map();
-        for (const s2 of stops.slice(0, -1)) byClass.set(s2.el, (byClass.get(s2.el) || 0) + 1);
-        const top = [...byClass.entries()].sort((a, b) => b[1] - a[1]).slice(0, 3).map(([k, v]) => `${k}×${v}`).join(' / ');
+      const byClass = new Map();
+      for (const s2 of stops) byClass.set(s2.el, (byClass.get(s2.el) || 0) + 1);
+      const top = [...byClass.entries()].sort((a, b) => b[1] - a[1]).slice(0, 4).map(([k, v]) => `${k}×${v}`).join(' / ');
+      // スキップリンクがあっても、押さずに Tab を送る読者は全部踏む。
+      // **到達しなかった走査を黙って捨てない。** 上限まで踏んでも本文に届かないのが
+      // いちばん重い状態なのに、以前は所見にせず数字の一覧にだけ出していた
+      if (!reached) {
+        add('ERROR', `Tab を ${stops.length} 回押しても本文に届かない`, where, `内訳: ${top}`);
+      } else if (stops.length > 10) {
         add('WARN', `本文まで ${stops.length} 回タブ停止する`, where, `内訳: ${top}`);
       }
       const first = stops[0];


### PR DESCRIPTION
## 何を取りこぼしていたか

キーボード走査（Tab を押して本文まで辿る）に2つの穴があった。

1. **上限が45停止**だった。ヘッダーのドロップダウン4枚は `:focus-within` で開くので、Tab で送ると中身30項目を通る。実測でトップは**51停止**で、45では通り切れずに打ち切られていた
2. **到達しなかった走査を所見にしていなかった。** `if (reached && stops.length > 10)` の形だったので、打ち切られたページは `[ERROR]` にも `[WARN]` にも出ず、末尾の数字の一覧に「（本文に到達せず）」と書かれるだけだった

結果として、**いちばん重い状態（Tab で本文に辿り着けない）が所見として上がらない**状態だった。#2945 はこの穴のせいで見つけるのが遅れている。

## 直したこと

- 上限を 45 → **80**
- 到達しなかったら **`[ERROR]` 「Tab を N 回押しても本文に届かない」**
- 到達したときの「本文まで N 回タブ停止する」は従来どおり `[WARN]`（10回超）
- 内訳（クラス別の停止数）はどちらの場合も出す。上限4件に増やした

## 確認したこと

配信中のサーバに対して:

| | 結果 |
| --- | --- |
| 上限80（この PR） | `[WARN] 本文まで 51 回タブ停止する`（トップ）/ `53 回`（タグ個別）。内訳に `header-dropdown-item×30` が出る |
| 上限20に落とした版 | `[ERROR] Tab を 20 回押しても本文に届かない` が出る（到達しない経路の確認） |

`npx prettier --check` は通る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
