### PR TITLE
タグ・著者ページの本文列を他の一覧に揃える (#2944)

### DIFF
--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -8,7 +8,7 @@
         {label: page.current + 'ページ目'}
       ])}) %>
   <div class="row">
-    <main class="col-xs-12 col-sm-12 col-md-10 blog-posts">
+    <main class="col-xs-12 col-sm-12 col-md-9 blog-posts">
   <section id="main" tabindex="-1" class="margin-top-30">
     <h1 class="list-page"><%- partial('_partial/svg-icon', {icon: 'user'}) %><%- page.author %><span class="list-sub-text">さんのページ</span></h1>
     <% if (page.current === 1) { %>
@@ -146,7 +146,10 @@
     <%- partial('_partial/archive', {pagination: config.author, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧'}) %>
   </section>
     </main>
-    <aside class="col-xs-12 col-sm-12 col-md-2 blog-sidebar">
+    <%# サイドバーの中身はこのページでは出さない（読者は既にこの軸で絞り込んでいる
+        #2880 / #2885）が、列は残す。畳むと本文の幅がこのページだけ広くなり、
+        一覧を行き来したときにカードの幅が揃わない (#2944) %>
+    <aside class="col-xs-12 col-sm-12 col-md-3 blog-sidebar">
       <%- partial('_partial/sidebar') %>
     </aside>
   </div>

--- a/themes/future/layout/tag.ejs
+++ b/themes/future/layout/tag.ejs
@@ -8,7 +8,7 @@
         {label: page.current + 'ページ目'}
       ])}) %>
   <div class="row">
-    <main class="col-xs-12 col-sm-12 col-md-10 blog-posts">
+    <main class="col-xs-12 col-sm-12 col-md-9 blog-posts">
   <section id="main" tabindex="-1" class="margin-top-30">
     <%# タグはページ種別を表す統一アイコン。カテゴリと違って個別の絵柄は割り当てない (#2336) %>
     <h1 class="list-page"><%- partial('_partial/svg-icon', {icon: 'tag'}) %><%- page.tag %> <span class="list-sub-text">タグ</span></h1>
@@ -111,7 +111,10 @@
     <%- partial('_partial/archive', {pagination: config.tag, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧'}) %>
   </section>
     </main>
-    <aside class="col-xs-12 col-sm-12 col-md-2 blog-sidebar">
+    <%# サイドバーの中身はこのページでは出さない（読者は既にこの軸で絞り込んでいる
+        #2880 / #2885）が、列は残す。畳むと本文の幅がこのページだけ広くなり、
+        一覧を行き来したときにカードの幅が揃わない (#2944) %>
+    <aside class="col-xs-12 col-sm-12 col-md-3 blog-sidebar">
       <%- partial('_partial/sidebar') %>
     </aside>
   </div>


### PR DESCRIPTION
## やったこと

タグページ（`tag.ejs`）と著者ページ（`author.ejs`）を `col-md-9` ＋ `col-md-3` にして、**本文列の幅を他の一覧ページに揃えた。**

**issue に書いた案1（`aside` を畳んで本文を 12/12 にする）は採らない。** サイドバーに出すものが無いことは、本文の幅をこのページだけ変える理由にならない。読者は一覧を行き来するので、カードの幅が変わる方が困る。

## 測ったこと

配信中のサーバで、`main` と `aside` の実効内寸（padding を引いた値）を取った。

**before**

| ページ | 1100px | 1300px | 1500px |
| --- | --- | --- | --- |
| トップ・カテゴリ個別・カテゴリ除外・記事 | 684 | 819 | 954 |
| **タグ個別・著者個別** | **764** | **914** | **1064** |

**after**

| ページ | 1100px | 1300px | 1500px |
| --- | --- | --- | --- |
| トップ・カテゴリ個別・カテゴリ除外・記事 | 684 | 819 | 954 |
| **タグ個別・著者個別** | **684** | **819** | **954** |

サイドバー側も 208 / 253 / 298px で他と同じ。`col-md-10` と `col-md-2` はテーマから無くなった。

- 全ページで横スクロールなし
- 1024px 以下の縦積み（#2044）は変わらず
- 点検スキル（`.claude/skills/site-audit`）を回して、新しい所見が出ないことを確認

## 空の列が残ることについて

サイドバーの中身は `_partial/sidebar.ejs` が `!is_tag() && !page.author` で出しており、この2ページでは空のまま（#2880 / #2885 の判断。読者は既にその軸で絞り込んでいる）。**列だけが残るので、両レイアウトにその理由をコメントで書いた。** 書かないと「空だから消す」に戻される。

`<aside>` は中身の無い complementary ランドマークとして支援技術に見える（axe は指摘しない）。`div` に替えれば消せるが、そうすると「このページにサイドバーの中身は無い」という判断が `sidebar.ejs` とレイアウトの2箇所に散る。今回は `sidebar.ejs` を単一の置き場所として残した。

## 範囲外にしたこと

**アーカイブと索引ページはまだ本文が広い。** これらは `aside` を持たない1列レイアウト。

| ページ | 1100px | 1300px | 1500px |
| --- | --- | --- | --- |
| `/articles/`・`/articles/2026/08/`・`/categories/`・`/tags/`・`/authors/`・`/series/` | 936 | 1116 | 1296 |

一覧系（684px）との差は 252〜342px。ただしここに空の列を足すのは筋が違って、**幅を揃えるなら本文列に上限を持たせる話**になるので #2918（記事本文に行長の上限が無い）と同じ土俵。この PR では触らない。

Closes #2944

🤖 Generated with [Claude Code](https://claude.com/claude-code)
