### PR TITLE
ヘッダーのドロップダウンを details で畳む (#2945)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -293,6 +293,25 @@ Header and header elements
   align-items: center;
   height: header-height;
 }
+/* details は帯の中では箱としてだけ働く。高さを引き継がないと引き金が上に寄る */
+.header-nav-disclosure {
+  display: flex;
+  align-items: center;
+  height: 100%;
+}
+/* 引き出し用の組ラベル。帯では summary が引き金を兼ねるので出さない */
+.header-nav-label {
+  display: none;
+  margin: 0;
+}
+/* summary の既定の三角は消す。開閉の向きは .header-nav-caret が示す */
+.header-nav-trigger {
+  list-style: none;
+  cursor: pointer;
+}
+.header-nav-trigger::-webkit-details-marker {
+  display: none;
+}
 .header-nav-link,
 .header-nav-trigger {
   display: flex;
@@ -321,7 +340,7 @@ Header and header elements
   transition: transform hover-speed ease;
 }
 .header-nav-item:hover .header-nav-caret,
-.header-nav-item:focus-within .header-nav-caret {
+.header-nav-disclosure[open] .header-nav-caret {
   transform: rotate(180deg);
 }
 /* 畳んだ行き先。影は持たない (#2747) ので、白い面と枠で本文から浮かせる。
@@ -353,10 +372,21 @@ Header and header elements
   gap: 0 (space-step * 2);
 }
 .header-nav-item:hover .header-dropdown,
-.header-nav-item:focus-within .header-dropdown {
+.header-nav-disclosure[open] ~ .header-dropdown {
   visibility: visible;
   opacity: 1;
   transition: opacity 0.12s ease;
+}
+/* 開いたままカーソルもフォーカスも離れたら畳んで見せる（open 属性は残る）。
+   これが無いと、別の引き金にカーソルを乗せたときに2枚が同じ位置で重なる。
+   引き金へ戻れば また出るので、開いた読者の意図は保たれる。
+   **幅で囲むのは、引き出し（1024px 以下）ではパネルを常時開いて並べているため。**
+   囲まないとこの規則の詳細度が勝ち、引き出しで引き金を押した瞬間に消える */
+@media (min-width: 1025px) {
+  .header-nav-item:not(:hover):not(:focus-within) .header-nav-disclosure[open] ~ .header-dropdown {
+    visibility: hidden;
+    opacity: 0;
+  }
 }
 /* 行として並ぶものなので、反応は面を一段 (#2686) */
 .header-dropdown-item {
@@ -553,15 +583,19 @@ Header and header elements
     display: block;
     height: auto;
   }
-  /* 引き金は畳みの引き金ではなく、組のラベルとして残る。
-     中身は常に開いているので三角は出さない */
-  .header-nav-trigger {
+  /* 中身は常に並ぶので畳みの引き金は出さず、組のラベルに替える (#2945)。
+     summary のままにすると open が false のまま中身が見えていて、
+     支援技術に「折りたたみ（閉）」と読まれる */
+  .header-nav-disclosure {
+    display: none;
+  }
+  .header-nav-label {
+    display: block;
     padding: (space-step * 2) (space-step * 3);
+    font-size: 14px;
+    line-height: leading-row;
     font-weight: 700;
     color: ink-strong;
-  }
-  .header-nav-caret {
-    display: none;
   }
   .header-nav-link {
     padding: (space-step * 2) (space-step * 3);

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -293,11 +293,14 @@ Header and header elements
   align-items: center;
   height: header-height;
 }
-/* details は帯の中では箱としてだけ働く。高さを引き継がないと引き金が上に寄る */
+/* details は帯の中では箱としてだけ働く。高さを引き継がないと引き金が上に寄る。
+   padding を戻すのは、本文の折りたたみ用に素の details が padding-bottom: 24px を
+   持っているため。そのぶん中身の箱が縮んで、引き金が 12px 上にずれる */
 .header-nav-disclosure {
   display: flex;
   align-items: center;
   height: 100%;
+  padding: 0;
 }
 /* 引き出し用の組ラベル。帯では summary が引き金を兼ねるので出さない */
 .header-nav-label {

--- a/themes/future/layout/_partial/header.ejs
+++ b/themes/future/layout/_partial/header.ejs
@@ -43,6 +43,15 @@
 			    ラベルに対応する1枚のページが無いので button で、リンクにはしない。
 			    並びはサイドバー（カテゴリ → 人気のタグ #2885）に合わせて、記事へ届く軸を先に置く (#2906)。
 			    行き先の網羅はフッター4列 (#2839) が持ち、リソースとアクティビティは各3件に絞る %>
+			<%# ドロップダウンは details で畳む (#2945)。Tab では開かず、Enter / Space で開いて
+			    から中へ入る。閉じているあいだパネルは visibility: hidden なのでタブ順に出ない。
+			    以前は :focus-within で開いていたため、Tab を送るだけで4枚すべてが開き、
+			    中身30項目を通って本文まで51停止していた。マウスの :hover は変えていない。
+			    パネルを details の中に入れないのは、閉じているあいだ UA が中身を隠すので
+			    hover で開く指定を CSS から書けなくなるため。
+			    引き出し（1024px 以下）ではパネルを常に並べるので、引き金は畳みの引き金ではなく
+			    組のラベルになる。summary を使い回すと open が false のまま中身が見えている
+			    状態になり、支援技術に「折りたたみ（閉）」と読まれる。幅ごとに要素を出し分ける %>
 			<nav class="header-nav" aria-label="サイト内の行き先">
 				<ul class="header-nav-list">
 					<%# カテゴリと連載は行き先そのものを畳む。
@@ -51,7 +60,10 @@
 					    /categories/ へも送らない。あの一覧は運営用で、読者向けには作っていない %>
 				
 					<li class="header-nav-item">
-						<button type="button" class="header-nav-trigger">カテゴリ<%- partial('svg-icon', {icon: 'chevron-down', class_name: 'svg-icon-trailing header-nav-caret'}).trim() %></button>
+						<details class="header-nav-disclosure">
+							<summary class="header-nav-trigger">カテゴリ<%- partial('svg-icon', {icon: 'chevron-down', class_name: 'svg-icon-trailing header-nav-caret'}).trim() %></summary>
+						</details>
+						<p class="header-nav-label">カテゴリ</p>
 						<div class="header-dropdown header-dropdown-grid">
 							<% category_index().forEach(function(c){ %>
 							<a class="header-dropdown-item" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事 累計<%= c.count %>本（直近1年 <%= c.recent %>本）">
@@ -61,7 +73,10 @@
 						</div>
 					</li>
 					<li class="header-nav-item">
-						<button type="button" class="header-nav-trigger">連載<%- partial('svg-icon', {icon: 'chevron-down', class_name: 'svg-icon-trailing header-nav-caret'}).trim() %></button>
+						<details class="header-nav-disclosure">
+							<summary class="header-nav-trigger">連載<%- partial('svg-icon', {icon: 'chevron-down', class_name: 'svg-icon-trailing header-nav-caret'}).trim() %></summary>
+						</details>
+						<p class="header-nav-label">連載</p>
 						<div class="header-dropdown">
 							<%# 連載の行き先は索引記事（/series/ の一覧と同じ規則）。物差しはタグと同じ
 							    「直近1年のPV」(#2855)。カテゴリと違って一覧ページが読者向けにあるので、
@@ -76,7 +91,10 @@
 						</div>
 					</li>
 					<li class="header-nav-item">
-						<button type="button" class="header-nav-trigger">リソース<%- partial('svg-icon', {icon: 'chevron-down', class_name: 'svg-icon-trailing header-nav-caret'}).trim() %></button>
+						<details class="header-nav-disclosure">
+							<summary class="header-nav-trigger">リソース<%- partial('svg-icon', {icon: 'chevron-down', class_name: 'svg-icon-trailing header-nav-caret'}).trim() %></summary>
+						</details>
+						<p class="header-nav-label">リソース</p>
 						<div class="header-dropdown">
 							<a class="header-dropdown-item" href="/specials/guidelines/">
 								<span class="header-dropdown-name">フューチャーのガイドライン</span>
@@ -93,7 +111,10 @@
 						</div>
 					</li>
 					<li class="header-nav-item">
-						<button type="button" class="header-nav-trigger">アクティビティ<%- partial('svg-icon', {icon: 'chevron-down', class_name: 'svg-icon-trailing header-nav-caret'}).trim() %></button>
+						<details class="header-nav-disclosure">
+							<summary class="header-nav-trigger">アクティビティ<%- partial('svg-icon', {icon: 'chevron-down', class_name: 'svg-icon-trailing header-nav-caret'}).trim() %></summary>
+						</details>
+						<p class="header-nav-label">アクティビティ</p>
 						<div class="header-dropdown">
 							<a class="header-dropdown-item" href="/specials/httf/">
 								<span class="header-dropdown-name">HACK TO THE FUTURE</span>


### PR DESCRIPTION
## やったこと

ヘッダーのドロップダウンの引き金を `<button>` から **`<details>` / `<summary>`** に替えた（**案1**）。**Tab では開かず、Enter / Space で開いてから中へ入る。**

- **マウスの `:hover` で開く挙動は変えていない**
- **JS も使わない**（#2877 の前提を守る）

## 数字

トップページで Tab を押し続け、本文（`#main` の中）に最初に到達するまでの停止数。

| 幅 | before | after |
| --- | --- | --- |
| 375px（引き出し） | 16 | **16** |
| 768px（引き出し） | 17 | **17** |
| **1100px** | **51** | **20** |
| **1280px** | **51** | **20** |

内訳の差は `header-dropdown-item×30` と `header-dropdown-more×1` が消えた分。残る20は スキップリンク1・ロゴ1・検索の入力欄1・ボタン1・検索ヒントのタグ10・ヒントの more 1・**引き金4**・本文の最初の1。

引き金4つは「畳まれた行き先が4つある」ことを示す停止なので、これは残す（#2846 が「検索パネルのリンクをタブ順から外す案は採らない」と決めたのと同じ理由で、到達できなくはしない）。

## 実装の判断

**パネルは `<details>` の中に入れず、兄弟に置いた。** 中に入れると閉じているあいだ UA が中身を隠すので、**hover で開く指定を CSS から書けなくなる**（`content-visibility` の扱いがブラウザで違い、外から上書きできない）。兄弟にすれば可視性を自前の CSS で全部持てる。

```html
<li class="header-nav-item">
  <details class="header-nav-disclosure">
    <summary class="header-nav-trigger">カテゴリ<caret></summary>
  </details>
  <p class="header-nav-label">カテゴリ</p>   <!-- 引き出し用 -->
  <div class="header-dropdown">…</div>
</li>
```

```styl
.header-nav-item:hover .header-dropdown,
.header-nav-disclosure[open] ~ .header-dropdown { visibility: visible }
```

**セレクタは隣接（`+`）ではなく一般兄弟（`~`）。** 引き出し用のラベルが `details` とパネルの間に入るため。`+` で書いて `open` になってもパネルが出ない状態を一度作ったので、ここは実際に踏んだ罠。

**引き出し（1024px 以下）は幅ごとに要素を出し分けた。** あちらはパネルを常に並べるので、引き金は畳みの引き金ではなく**組のラベル**。`summary` を使い回すと `open` が false のまま中身が見えていて、**支援技術に「折りたたみ（閉）」と読まれる**（実測で確認）。`@media` で `details` を隠して `<p>` を出す。見た目は before と同じ。

**開いたパネルは、カーソルもフォーカスも離れたときに畳んで見せる**（`open` 属性は残る）。これが無いと、別の引き金にカーソルを乗せたときに2枚が同じ位置で重なる。引き金へ戻ればまた出るので、開いた読者の意図は保たれる。この規則は `@media (min-width: 1025px)` で囲った。囲まないと詳細度で勝ってしまい、引き出しで引き金を押した瞬間にパネルが消える。

## 確認したこと

| | 結果 |
| --- | --- |
| Tab で引き金に止まる | 開かない（パネル4枚すべて `visibility: hidden`） |
| Enter | 開く（`open=1`、パネルが `visible`） |
| Space | 開く |
| 開いた後の Tab | パネルの中（`header-dropdown-item`）へ入る |
| マウスの hover | 開く。外すと閉じる |
| 引き出し（375px） | `details` は `display: none`、ラベルが出る。一覧の見た目は before と同じ |
| 点検スキル | 新しい所見なし。`本文まで51回` が消えて 20/22回（1280px）・16/18回（375px）に |

**副産物**: `<summary>` は開閉の状態を支援技術に伝える。以前の `<button>` は `aria-expanded` を持っていなかったので、状態が読めない状態だった。

## 残る制約

- **Escape では閉じない**（`<details>` の素の挙動）。フォーカスが外れれば見た目は畳まれるので、実用上は Tab で抜ければ閉じる
- 一度開いたドロップダウンは `open` を保つので、**Shift+Tab で引き金に戻ると再び開く**。その状態で前方へ Tab するとそのパネルの中を通る。開いた読者の意図としては自然なので、そのままにした

Closes #2945

🤖 Generated with [Claude Code](https://claude.com/claude-code)
