### PR TITLE
記事のメタ行からタグを外し、記事末へ移す (#2907)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2480,26 +2480,15 @@ code {
 .blog-tags li {
   display: inline-block;
 }
-/* 記事メタ行のタグ。間隔は親の gap で持ち、縦横とも同じ 8px にする。
-   metronic の `.blog-info li { display: inline-block }` に勝つ詳細度が要る。
-   単一クラスで書くと display が inline-block のままで gap が効かず、
-   折り返したチップの行間が 0 になる */
-.blog-info .blog-info-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  /* 既定の stretch だと、余白を持つチップが1つ混じるだけで行の全チップが
-     その高さまで伸びる。行の他の項目と同じ baseline に揃える (#2764) */
-  align-items: baseline;
+/* 記事末のタグ (#2907)。上の空きは著者紹介・共有ボタンと同じ 16px で、
+   下は持たない（帯までの空きは .article-appendix が1箇所で持つ）。
+   左は、チップの枠ではなく文字の左端を本文にそろえる補正
+   （4px のマージン + 1px の枠 + 8px のパディング。ul.tag-list と同じ #2429 / #2453）*/
+.article-tags {
+  margin: 16px 0 0 -13px;
 }
-/* 1記事だけのタグは非リンクの .tag-list-text で描かれる。
-   どちらも margin を落とさないと gap に上乗せされる (#2764) */
-.blog-info-tags .tag-list-link,
-.blog-info-tags .tag-list-text {
-  margin: 0;
-}
-/* 狭い画面では記事のメタ行を3行に分ける (#2738)。1行目「いつ・誰が」、
-   2行目「何の話か」、3行目「どれだけ書かれ、読まれたか」。
+/* 狭い画面では記事のメタ行を2行に分ける (#2738)。1行目「いつ・誰が」、
+   2行目「どれだけ書かれ、読まれたか」。タグの行は #2907 で記事末へ移した。
    切れ目と行間は空の li（.blog-info-break）が持つ。PC では1行に収めるので出さない。
    metronic の `.blog-info li { display: inline-block }` に勝つ詳細度が要る。
    単一クラスで書くと PC でも表示され、項目の間隔が gap の2つ分に開く */
@@ -2514,11 +2503,6 @@ code {
     display: block;
     flex-basis: 100%;
     height: 10px;
-  }
-  /* 残り幅を取り、チップは中で折り返す。行の途中で切れるとカテゴリと別の行に落ちる */
-  .blog-info-tags {
-    flex: 1 1 0;
-    min-width: 0;
   }
 }
 /* チップは枠の内側に文字があるぶん、囲みの左端に対して右へずれて見える。

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -33,15 +33,15 @@
       <div class="article-inner">
         <% if (post.link || post.title){ %>
         <header class="article-header">
-          <%# 読み手にとっての重要度が高い順: 日付 -> 著者 -> タグ -> PV。
+          <%# 読み手にとっての重要度が高い順: 日付 -> 著者 -> 文字数 -> PV。
               カテゴリはパンくずが持つので、ここには置かない (#2837)。
-              一覧カード（archive-post）は同じページに複数の記事が並ぶうえ
-              パンくずが記事のカテゴリを指さないので、あちらには残す %>
+              タグは記事末へ移した (#2907)。読み始める前には効かない軸で、
+              似た記事を探すのは読み終えた後だから。
+              一覧カード（archive-post）はカテゴリを残す。同じページに複数の
+              記事が並ぶうえ、パンくずが個々の記事のカテゴリを指さない %>
           <ul class="blog-info">
             <li class="blog-info-item"><%- partial('post/date', {class_name: 'archive-article-date', date_format: 'YYYY.MM.DD'}) %></li>
             <%- post_author_link(post) %>
-            <li class="blog-info-break" aria-hidden="true"></li>
-            <li class="blog-info-item blog-info-tags"><%- partial('post/tag') %></li>
             <%# 読了時間ではなく文字数。読む速度は個人差が大きく、分数で示すと誠実さを欠く。
                 コードブロックと <details> の中身は除外している（scripts/char_count.js）。
                 PV より前に置く。文字数は記事を書き換えない限り変わらないが、
@@ -149,6 +149,18 @@
               共有した直後に来るのが「誰が書いたか」で、機械が選んだ記事より
               人の情報を先に出す (#2567) %>
           <%- partial('author-box', {post: post}) %>
+          <%# タグは記事末に置く (#2907)。読み終えた読者が似た記事を探すための
+              軸なので、関連記事の帯の直前に置く。帯には入れない——タグはこの記事
+              自身の属性で、本文への従属が弱いもの（関連記事・被参照）を外に出す
+              #2874 の線引きの内側にある。
+              見出しは置かない。チップの形がサイト全体で「タグの印」なので (#2892)、
+              「タグ」の1行は場所を取るだけになる（著者紹介と同じ判断 #2567）。
+              支援技術には aria-label で名前を渡す %>
+          <% if (post.tags && post.tags.length) { %>
+          <section class="article-tags" data-nosnippet aria-label="タグ">
+            <%- partial('post/tag') %>
+          </section>
+          <% } %>
         </footer>
       </div>
     </article>


### PR DESCRIPTION
記事冒頭のメタ行は「これは何で、いつ、誰が書いたか」までを担う。**タグは読み始める前には効かない軸**で、似た記事を探すのは読み終えた後なので、関連記事の帯の直前へ移した。

| | 変更前 | 変更後 |
| --- | --- | --- |
| 記事冒頭のメタ行 | 日付・著者・**タグ**・文字数・PV | 日付・著者・文字数・PV |
| 記事末 | （なし） | **タグ**（著者紹介の下、関連記事の帯の直前） |
| 狭い画面のメタ行 | 3行 | **2行**（「いつ・誰が」「どれだけ書かれ、読まれたか」） |

## PV は冒頭に残す

issue の案3（PV をシェアボタンの並びへ移す）は**入れない。**

一覧カードに PV を出していないぶん、**書き手が自分の記事の反響を見られる場所がここしかない。** シェアボタンの並び（反響の明細）とは役が違うので寄せない。技術ブログは書き手のボランティアで成り立っていて、継続がいちばん重要という判断（#2915 と同じ線）。

## 一覧カードへの PV 追加は入れない

issue の案4。検討して見送った。

- **issue の前提が事実と違った。** 「一覧で ♡ を出しているのに PV を出していない理由が無い」とあるが、**一覧カードに ♡ は無い。** ♡（`snscount`）は `scripts/lib/post_list.js` の部品で、関連記事・被参照・ランキング・連載だけが使う。一覧カードが出しているのはサービスごとのシェア数
- **シェア数は 0 なら黙る**（`post_list.js`「0と表示されると寂しく見えるため」）。**PV は 0 にならない**ので全カードに必ず数字が付く。一覧1ページ目で **16個 → 41個**（25枚中9枚は今は数字が1つも出ない）
- **1ページ目に並ぶのは新着なので、サイトで最も小さい数字が並ぶ。** 新着25本の PV は中央値 **600**、19/25 が1,000未満、9枚が100〜200（サイト全体の中央値は1,300、最大103,100）。0 を隠して寂しさを避けている設計と方向が逆
- **PV は主題や質より露出と経過時間を反映する。** 3ヶ月未満の中央値 500 に対し 2〜4年は 1,800（ただし順位相関は +0.17 でばらつきが大きく、個々の記事では読み取れない）
- **「よく読まれている」の役はランキング枠が既に担っている。** `popular_posts` は PV 順に並べていて、数字を出さずに順序で伝えている

これで issue コメントにあった **#2915 との順序依存も消える**（#2915 は既にクローズ済み）。

## 置き場所の判断

- **帯（`article-appendix`）には入れない。** 帯は本文への従属が弱いもの（関連記事・被参照・We're hiring）を `<article>` の外に出す場所で（#2874）、**タグはこの記事自身の属性**なので内側に置く
- **見出しは付けない。** チップの形がサイト全体で「タグの印」なので（#2892）、「タグ」の1行は場所を取るだけになる。**著者紹介が見出しを置かないのと同じ判断**（#2567「『著者』の1行は場所を取るだけだった」）。支援技術には `aria-label="タグ"` で名前を渡す
- 並びは 連載ナビ → 共有 → 著者紹介 → **タグ** → 〔帯〕関連記事。タグが関連記事の直前に来て「次に読むものを探す」塊になる

## CSS

メタ行のタグ用の3ルールを、記事末用の1ルールに置き換えた。**新しい値は足していない。**

```styl
.article-tags {
  margin: 16px 0 0 -13px;
}
```

- 上の空き **16px** は著者紹介・共有ボタンと同じ
- **下は持たない。** 帯までの空きは `.article-appendix` が1箇所で持つ（#2874 の「著者紹介の有無で空きが変わらないようにした」を壊さない）
- 左の **-13px** はチップの枠ではなく文字の左端を本文にそろえる補正（マージン4px + 枠1px + パディング8px。`ul.tag-list` と同じ内訳 #2429 / #2453）

## 測ったこと

- **タグの文字の左端 82px / 本文の左端 82px（差 0px）** — 実測で一致
- **幅375のメタ行は2行**（1行目 `2026.06.12 / 真野隼記`、2行目 `約 5,600 文字 / 700 View`）
- **並び順**を連載あり・なし・著者紹介あり・なしの4通りで確認。すべて 連載ナビ → 共有 → 著者紹介 → タグ → 帯
- **axe（全ルール・7ページ × 幅 375/1280）**: 幅375 は全ページ clean、幅1280 は記事ページの `region` のみ。この `region` は変更前から出ているもの（#2926 の作業時に同じページで計測済み）
- 1記事だけのタグ（非リンクの `.tag-list-text`）も同じ並びで描かれることを確認

## lint

- textlint（`_partial/article.ejs`）0件
- `scripts/` は触っていないので prettier の対象に変化なし

Closes #2907