### PR TITLE
記法ガイドの見本画像に代替テキストを書く

### DIFF
--- a/source/specials/markdown/index.md
+++ b/source/specials/markdown/index.md
@@ -322,7 +322,7 @@ fmt.Println("コードブロックも書けます")
 ![代替テキスト](/images/2026/20260114a/thumbnail.jpg)
 ```
 
-![](/images/2026/20260114a/thumbnail.jpg)
+<img src="/images/2026/20260114a/thumbnail.jpg" alt="EDIFACTの文字列を字句解析してから構文解析し、構造化データにする流れ図" width="300" height="93">
 
 公開時にこちらで `<img>` へ変換し、**実寸の `width` と `height`** を付けます。読み込み中に本文が動くのを防ぐためで、書き手が意識する必要はありません。
 
@@ -335,11 +335,11 @@ fmt.Println("コードブロックも書けます")
 画像の直下の行を `*` で挟むと、キャプションになります。
 
 ```markdown
-![](/images/2026/20260114a/thumbnail.jpg)
+![代替テキスト](/images/2026/20260114a/thumbnail.jpg)
 *図1: キャプションの文*
 ```
 
-![](/images/2026/20260114a/thumbnail.jpg)
+<img src="/images/2026/20260114a/thumbnail.jpg" alt="EDIFACTの文字列を字句解析してから構文解析し、構造化データにする流れ図" width="300" height="93" loading="lazy">
 *図1: キャプションの文*
 
 代替テキストとキャプションは役割が違います。代替テキストは画像が見えない人への説明、キャプションは全員に向けた補足なので、同じ文を両方に書く必要はありません。


### PR DESCRIPTION
## やったこと

`/specials/markdown/`（記法ガイド）の**見本画像2枚に代替テキストを書いた**。

```diff
-![](/images/2026/20260114a/thumbnail.jpg)
+<img src="/images/2026/20260114a/thumbnail.jpg" alt="EDIFACTの文字列を字句解析してから構文解析し、構造化データにする流れ図" width="300" height="93">
```

## alt を足すだけにしなかった理由

**この2行はすでに textlint の `no-markdown-image` エラーだった。** ルール自身の説明にこう書いてある。

> **寄稿者に書き方を強いるルールではない。** 記法ガイド（`/specials/markdown/`）は `![alt](url)` で書いてもらう案内で、公開するときにこちらで HTML へ変換する（#2559）。つまりリポジトリに入った時点では変換済みのはずで、ここで拾えるのは変換漏れになる。

つまりこの2枚は**変換漏れ**で、ガイドが「公開時にこちらで `<img>` へ変換し、実寸の `width` と `height` を付けます」と約束している形になっていなかった。約束どおりの形に直すと、3つの指摘が同時に消える。

| 指摘 | before | after |
| --- | --- | --- |
| axe `image-alt`（critical） | 2件 | **0** |
| `width` / `height` の無い img | 2件 | **0** |
| textlint `no-markdown-image` | 2件 | **0** |
| **ページ全体の axe violation** | 3種 | **0** |

**コードフェンスの中の見本は Markdown 記法のまま。** 寄稿者に書いてもらうのはそちらなので変えない（`no-markdown-image` はフェンスの中を見ない）。

## alt の文言

同じ図を本文に載せている記事（`20260114a_EDIFACTメッセージ処理をJavaでスクラッチ実装した試行錯誤`）の説明から書いた。

> ストリームパーサであるStaediで字句解析、アプリケーション側で構文解析するアプローチ

→ `EDIFACTの文字列を字句解析してから構文解析し、構造化データにする流れ図`

## 先頭画像の loading

先頭の1枚だけ `loading="lazy"` を持たない。textlint の `no-img-without-lazy` が「先頭画像には付けない（LCP 候補になる）」と指摘し、`--fix` で外した。`lcp_image_priority.js` も描画時に外すので、書いても消える。

## キャプションの見本も直した

キャプション側の見本の記法が `![](...)` で alt が空だった。直後の本文は

> 代替テキストとキャプションは役割が違います。代替テキストは画像が見えない人への説明、キャプションは全員に向けた補足なので、同じ文を両方に書く必要はありません。

と説明しているのに、**見本がそれを示せていない**ので `![代替テキスト](...)` にした。

## 確認したこと

配信中のページで:

- 本文の img 2枚とも `alt` / `width` / `height` あり、alt 無し 0件
- **キャプションが `<figure>` + `<figcaption>` になることを確認**（`figure_caption.js` は生の `<img>` も受ける。記事本文は元から生 `<img>` が主流）
- フェンスの中の見本2箇所は `![代替テキスト](/images/…)` のまま
- axe（WCAG 2.0/2.1/2.2 A+AA ＋ best-practice）で **violation なし**
- `textlint source/specials/markdown/index.md` が通る

## 残っている同じ形

`source/_posts/2026/20260612a_Mermaid_Live_Editor_のTips_9選.md:240` に `[![](https://mermaid.ink/img/…)](https://mermaid.live/edit#…)` があり、**外部画像1枚が alt 無し**のまま。この PR では触っていない（別ページで、alt の文言は図の中身を読まないと書けない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
