### PR TITLE
<main> と #main の形を B（兼用）に寄せる (#2953)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1040,6 +1040,13 @@ bootstrap-subset → theme-styles.styl の順で `/css/site.css` に連結する
     - サイドバー（`<aside>`）は `<main>` の**兄弟**に置く。本文ではないため
     - パンくずは `<main>` の外なので、`_partial/breadcrumb.ejs` 側が
       `<nav aria-label="パンくず">` で自前のランドマークになる
+    - **全18ページ種がこの形**（#2953）。以前は `<main>` と `#main` を別要素に
+      分けた形が9本あり、着地点が `<main>` の内側（8本）と外側（1本＝記事ページ）に
+      割れていた。余白のための入れ物は `<div class="margin-top-30">` として残っている
+      （`<section>` のままだと見出しを持たない節に見える）
+    - 記事ページの `id="main"` は `_partial/article.ejs` の `<main>` が持つ。
+      **この partial は1ページに1回しか描かない**（`_partial/archive.ejs` の
+      `pagination == 2` の枝がループで呼ぶ形だが、`config.archive` が undefined で通らない）
   - `position: fixed` にする。絶対配置だと押される前にブラウザがページを
     先頭まで送ってしまい、読んでいた位置を失う
   - 検索パネルのリンクをタブ順から外す案は採らない。キーボードだけの読者が

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -1,5 +1,9 @@
 <div class="row">
-  <main class="col-md-9 blog-posts">
+  <%# id="main" はここが持つ (#2953)。ランドマークとスキップリンクの着地点を
+      同じ要素にするため。**この partial は1ページに1回しか描かない。**
+      `_partial/archive.ejs` の pagination == 2 の枝がループで呼ぶ形になっているが、
+      `_config.yml` に archive: の指定が無く config.archive は undefined なので通らない %>
+  <main id="main" tabindex="-1" class="col-md-9 blog-posts">
     <% if (!index) { %>
     <%# 受賞記事の印 (#2422)。タイトルの上に置く。メタ情報の行に混ぜると
         日付やタグと同列の属性に見えてしまい、称号として読まれない。

--- a/themes/future/layout/advent-calendar.ejs
+++ b/themes/future/layout/advent-calendar.ejs
@@ -17,8 +17,8 @@
       ]}) %>
   <%# 記事・トップページと同じ「本文 + サイドバー」の幅にする %>
   <div class="row">
-    <main class="col-md-9 blog-posts">
-  <section id="main" tabindex="-1" class="margin-top-30">
+    <main id="main" tabindex="-1" class="col-md-9 blog-posts">
+  <div class="margin-top-30">
     <div class="footer-gap">
       <h1 class="list-page margin-bottom-20">アドベントカレンダー</h1>
       <p class="specials-text">フューチャーは2015年から毎年 Qiita Advent Calendar に参加しています。IT技術であること以外はフリーテーマで、毎年12月に社員がリレー形式で記事を公開しています。参加記事は原則として Qiita 側に投稿しています。</p>
@@ -101,7 +101,7 @@
       %>
       <%- partial('_partial/post-panel-grid', {posts: revivalPosts}) %>
     </div>
-  </section>
+  </div>
     </main>
     <aside class="col-md-3 blog-sidebar">
       <%- partial('_partial/sidebar', {specialsToc: [

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -8,8 +8,8 @@
         {label: page.current + 'ページ目'}
       ])}) %>
   <div class="row">
-    <main class="col-xs-12 col-sm-12 col-md-9 blog-posts">
-  <section id="main" tabindex="-1" class="margin-top-30">
+    <main id="main" tabindex="-1" class="col-xs-12 col-sm-12 col-md-9 blog-posts">
+  <div class="margin-top-30">
     <h1 class="list-page"><%- partial('_partial/svg-icon', {icon: 'user'}) %><%- page.author %><span class="list-sub-text">さんのページ</span></h1>
     <% if (page.current === 1) { %>
     <% const as = author_stats(page.author); %>
@@ -144,7 +144,7 @@
     <% } %>
     <%# 見出しの語彙はホーム・カテゴリ・タグページに合わせる %>
     <%- partial('_partial/archive', {pagination: config.author, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧'}) %>
-  </section>
+  </div>
     </main>
     <%# サイドバーの中身はこのページでは出さない（読者は既にこの軸で絞り込んでいる
         #2880 / #2885）が、列は残す。畳むと本文の幅がこのページだけ広くなり、

--- a/themes/future/layout/category-without.ejs
+++ b/themes/future/layout/category-without.ejs
@@ -9,8 +9,8 @@
         {label: page.current + 'ページ目'}
       ])}) %>
   <div class="row">
-    <main class="col-xs-12 col-sm-12 col-md-9 blog-posts">
-  <section id="main" tabindex="-1" class="margin-top-30">
+    <main id="main" tabindex="-1" class="col-xs-12 col-sm-12 col-md-9 blog-posts">
+  <div class="margin-top-30">
     <h1 class="list-page"><%- partial('_partial/category-icon', {name: page.category}) %><%- page.category %> <span class="list-sub-text">カテゴリの <%- page.excludedTag %> 以外の記事</span></h1>
     <%# 構成はカテゴリページと同じ。統計・タグ・ランキングは絞り込んだ後の集合で数える %>
     <% if (page.current === 1) { %>
@@ -54,7 +54,7 @@
          + `${page.excludedTag}の記事は<a href="${url_for('tags/' + page.excludedTag + '/')}">${page.excludedTag}タグ</a>にまとまっています`
          + `</p>`; %>
     <%- partial('_partial/archive', {pagination: config.category, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧', list_note: backLink}) %>
-  </section>
+  </div>
     </main>
     <aside class="col-xs-12 col-sm-12 col-md-3 blog-sidebar">
       <%- partial('_partial/sidebar') %>

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -12,8 +12,8 @@
         {label: page.current + 'ページ目'}
       ])}) %>
   <div class="row">
-    <main class="col-xs-12 col-sm-12 col-md-9 blog-posts">
-  <section id="main" tabindex="-1" class="margin-top-30">
+    <main id="main" tabindex="-1" class="col-xs-12 col-sm-12 col-md-9 blog-posts">
+  <div class="margin-top-30">
     <%# カテゴリ単位の購読導線 (#2294)。見出しの行の右端に RSS アイコンを置く %>
     <div class="list-page-header">
       <h1 class="list-page"><%- partial('_partial/category-icon', {name: page.category}) %><%- page.category %> <span class="list-sub-text">カテゴリ</span></h1>
@@ -122,7 +122,7 @@
     <%# 「◯以外の記事を見る」の導線は related-categories 側が持つ (#2252) %>
     <%- partial('_partial/archive', {pagination: config.category, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧'}) %>
 
-  </section>
+  </div>
     </main>
     <aside class="col-xs-12 col-sm-12 col-md-3 blog-sidebar">
       <%- partial('_partial/sidebar') %>

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -22,8 +22,8 @@
     const heading = (id) => partial('_partial/section-heading', SECTIONS.find(s => s.id === id));
   %>
   <div class="row">
-    <main class="col-md-9 blog-posts">
-  <section id="main" tabindex="-1" class="margin-top-30">
+    <main id="main" tabindex="-1" class="col-md-9 blog-posts">
+  <div class="margin-top-30">
     <div class="footer-gap">
       <h1 class="list-page margin-bottom-20">記事ドクター</h1>
       ※運営向けの画面です。人の判断が要る候補だけを並べます（提案であって、正とは限りません）。タグ無し・カテゴリと同名のタグ・未登録のカテゴリは PR の検査が止めるので、ここには出ません。タグの3節（統合候補・1記事タグ・親子の候補）は直近1年間に記事のあるタグ、タグ付け漏れ候補は直近1年間の記事だけを対象にします
@@ -243,7 +243,7 @@
       <p>該当なし</p>
       <% } %>
     </div>
-  </section>
+  </div>
     </main>
     <aside class="col-md-3 blog-sidebar">
       <%- partial('_partial/sidebar', {specialsToc: SECTIONS}) %>

--- a/themes/future/layout/guidelines.ejs
+++ b/themes/future/layout/guidelines.ejs
@@ -11,8 +11,8 @@
   <%# 記事・トップページと同じ「本文 + サイドバー」の幅にする（レビューで確定）。
       本文の行長もこの列幅が抑える %>
   <div class="row">
-    <main class="col-md-9 blog-posts">
-  <section id="main" tabindex="-1" class="margin-top-30">
+    <main id="main" tabindex="-1" class="col-md-9 blog-posts">
+  <div class="margin-top-30">
     <div class="footer-gap">
       <h1 class="list-page margin-bottom-20">フューチャーのガイドライン</h1>
       <%# 3つの実体はこのブログとは別のサイト（同じ future-architect.github.io だが別リポジトリ）。
@@ -64,7 +64,7 @@
         </ul>
       </div>
     </div>
-  </section>
+  </div>
     </main>
     <aside class="col-md-3 blog-sidebar">
       <%- partial('_partial/sidebar', {specialsToc: [

--- a/themes/future/layout/httf.ejs
+++ b/themes/future/layout/httf.ejs
@@ -11,8 +11,8 @@
   <%# 記事・トップページと同じ「本文 + サイドバー」の幅にする（レビューで確定）。
       本文の行長もこの列幅が抑える %>
   <div class="row">
-    <main class="col-md-9 blog-posts">
-  <section id="main" tabindex="-1" class="margin-top-30">
+    <main id="main" tabindex="-1" class="col-md-9 blog-posts">
+  <div class="margin-top-30">
     <div class="footer-gap">
       <h1 class="list-page margin-bottom-20">HACK TO THE FUTURE</h1>
       <%# 冒頭のロゴはコンテスト一覧のアイキャッチと同じ絵で冗長になるため置かない（レビューで確定） %>
@@ -66,7 +66,7 @@
       %>
       <%- partial('_partial/post-panel-grid', {posts: kyoproPosts}) %>
     </div>
-  </section>
+  </div>
     </main>
     <aside class="col-md-3 blog-sidebar">
       <%- partial('_partial/sidebar', {specialsToc: [

--- a/themes/future/layout/post.ejs
+++ b/themes/future/layout/post.ejs
@@ -15,10 +15,10 @@
         url: cat.path,
         icon: partial('_partial/category-icon', {name: cat.name}).trim()
       }] : [])}) %>
-  <section id="main" tabindex="-1" class="margin-top-30">
+  <div class="margin-top-30">
     <%# 受賞記事の印とタイトルは本文と同じ列の中にある（_partial/article #2570）%>
     <%- partial('_partial/article', {post: page, index: false}) %>
-  </section>
+  </div>
 </div>
 <%# 自動生成の推薦は記事の外なので container の外に置く (#2874)。
     全幅の面でフッターに接する帯にする %>

--- a/themes/future/layout/tag.ejs
+++ b/themes/future/layout/tag.ejs
@@ -8,8 +8,8 @@
         {label: page.current + 'ページ目'}
       ])}) %>
   <div class="row">
-    <main class="col-xs-12 col-sm-12 col-md-9 blog-posts">
-  <section id="main" tabindex="-1" class="margin-top-30">
+    <main id="main" tabindex="-1" class="col-xs-12 col-sm-12 col-md-9 blog-posts">
+  <div class="margin-top-30">
     <%# タグはページ種別を表す統一アイコン。カテゴリと違って個別の絵柄は割り当てない (#2336) %>
     <h1 class="list-page"><%- partial('_partial/svg-icon', {icon: 'tag'}) %><%- page.tag %> <span class="list-sub-text">タグ</span></h1>
     <% if (page.current === 1) { %>
@@ -109,7 +109,7 @@
     <% } %>
     <%# 見出しの語彙はホーム・カテゴリページに合わせる %>
     <%- partial('_partial/archive', {pagination: config.tag, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧'}) %>
-  </section>
+  </div>
     </main>
     <%# サイドバーの中身はこのページでは出さない（読者は既にこの軸で絞り込んでいる
         #2880 / #2885）が、列は残す。畳むと本文の幅がこのページだけ広くなり、

--- a/themes/future/layout/techcast.ejs
+++ b/themes/future/layout/techcast.ejs
@@ -13,8 +13,8 @@
       ]}) %>
   <%# 記事・トップページと同じ「本文 + サイドバー」の幅にする %>
   <div class="row">
-    <main class="col-md-9 blog-posts">
-  <section id="main" tabindex="-1" class="margin-top-30">
+    <main id="main" tabindex="-1" class="col-md-9 blog-posts">
+  <div class="margin-top-30">
     <div class="footer-gap">
       <h1 class="list-page margin-bottom-20">Future Tech Cast</h1>
       <p class="specials-text">「Future Tech Cast」は、フューチャー技術ブログから派生したポッドキャストです。Spotify で配信しており、業務で使っているテクノロジーの深掘りトーク、ブログ記事のサマリトーク、社員のキャリアやチームの仕事の話をお届けしています。</p>
@@ -67,7 +67,7 @@
       %>
       <%- partial('_partial/post-panel-grid', {posts: podcastPosts}) %>
     </div>
-  </section>
+  </div>
     </main>
     <aside class="col-md-3 blog-sidebar">
       <%- partial('_partial/sidebar', {specialsToc: [


### PR DESCRIPTION
Closes #2953

**全18ページ種が形 B（`<main id="main" tabindex="-1">`）に統一されました。** 見た目は変わりません。

## やったこと

**箱を1つも動かさない形で寄せました。** issue の案は `<main>` と `<section id="main">` を1つの要素にまとめるものでしたが、それだと `margin-top-30` が「flex アイテムの外マージン」に変わるので、レイアウトへの影響を実測できないこの環境では危ない。要素の入れ替えと属性の移動だけに絞りました。

```diff
-<main class="col-md-9 blog-posts">
-<section id="main" tabindex="-1" class="margin-top-30">
+<main id="main" tabindex="-1" class="col-md-9 blog-posts">
+<div class="margin-top-30">
 …
-</section>
+</div>
 </main>
```

`section` も `div` も UA スタイルを持たない block なので、**入れ替えても箱は同じ**です。`section` のままにしないのは、見出しを持たない `<section>` が「節」に見えるため（HTML-AAM 上も名前が無い `section` は `generic` にマップされ、ランドマークにはなりません）。

**記事ページ（形 D）**は `post.ejs` の入れ物を `div` にし、`id` を `_partial/article.ejs` の `<main>` へ移しました。

## before / after

| 形 | before | after |
| --- | --- | --- |
| **B: 兼用**（`<main id="main">`） | 9種 | **18種** |
| C: `<main>` ⊃ `#main` | 8種 | **0種** |
| D: `#main` ⊃ `<main>` | 1種（記事） | **0種** |

触ったのは11ファイル（`category` / `category-without` / `tag` / `author` / `guidelines` / `techcast` / `httf` / `advent-calendar` / `doctor` / `post` / `_partial/article`）。

## 検証

**「箱が動いていない」ことを配信 HTML で確かめました。** `section` / `div` の別と `id="main"` / `tabindex="-1"` を正規化して、19ページ種を `origin/main` と `HEAD` で切り替えて比較 → **完全一致**。

そのほか:

- 19ページ種で **`<main>` がちょうど1つ**、`div` / `main` / `section` / `nav` / `aside` / `ul` の開始・終了タグ数が一致
- スキップリンクの着地点: 全ページで `#main` → `<main>` 要素、`tabindex="-1"` が1つだけ
- **`#main` を参照する CSS は0件**（`site.css` の全規則を走査）
- 変更した `.ejs` 11本の textlint 0件（終了コードで確認）、`CLAUDE.md` の markdownlint 0件

CLAUDE.md のスキップリンクの節に「全18ページ種がこの形」「余白の入れ物は `<div class="margin-top-30">` として残っている」「記事ページの `id` は `_partial/article.ejs` が持つ」を追記しました。

## 検証中に見つけた別の不具合（この PR では直していません）

**`category_index()` に同点の決着が無く、ヘッダーのカテゴリの並びがビルドごとに変わります。**

```js
// scripts/category_chart_helpers.js:189
.sort((a, b) => b.length - a.length)
```

`DevOps`（134本）と `Frontend`（134本）が同数で、入力の順序が変わると入れ替わります。実際、同じソースでページを取り直すとヘッダーのドロップダウンの並びが変わり、**私の検証が実行ごとに違う結果を出す原因になりました**（差分の正体を追って判明）。

このリポジトリは他の5箇所で「同点は名前で決める（決着が無いとビルドごとに並びが変わる）」として名前のタイブレークを入れているので、同じ形にすれば直ります。影響は `/categories/` とヘッダーのドロップダウンの2箇所。別 issue を立てます。

## 環境の話（レビューには影響しません）

`textlint` がローカルで動いていなかったので、`node_modules/textlint-rule-no-bare-url-in-list` へのシンボリックリンクを手で張って動かしました（#2939 の `file:` 依存が未インストールだったため。PR #2954 で報告した件）。**`npm install` を1回走らせるのが本来の直し方**です。
