### PR TITLE
category_index() の同点を名前で決める (#2959)

### DIFF
--- a/scripts/category_chart_helpers.js
+++ b/scripts/category_chart_helpers.js
@@ -182,11 +182,14 @@ function buildCategoryStats(category) {
   };
 }
 
-// /categories/ の一覧用データ (#2056)
+// /categories/ の一覧用データ (#2056)。ヘッダーのドロップダウン (#2877) も呼ぶ。
+// 同点は名前で決める（このファイルのグラフ2箇所と同じ式。#2959）。
+// 同点は3組あり、決着が無いとビルドごとに入れ替わっていた:
+// DevOps / Frontend（134）、DB / Infrastructure（70）、IaC / Mobile（57）
 hexo.extend.helper.register('category_index', function () {
   return this.site.categories
     .toArray()
-    .sort((a, b) => b.length - a.length)
+    .sort((a, b) => b.length - a.length || (a.name < b.name ? -1 : 1))
     .map((category) => buildCategoryStats.call(this, category));
 });
 


### PR DESCRIPTION
Closes #2959

```diff
-// /categories/ の一覧用データ (#2056)
+// /categories/ の一覧用データ (#2056)。ヘッダーのドロップダウン (#2877) も呼ぶ。
+// 同点は名前で決める（このファイルのグラフ2箇所と同じ式。#2959）。
+// 同点は3組あり、決着が無いとビルドごとに入れ替わっていた:
+// DevOps / Frontend（134）、DB / Infrastructure（70）、IaC / Mobile（57）
 hexo.extend.helper.register('category_index', function () {
   return this.site.categories
     .toArray()
-    .sort((a, b) => b.length - a.length)
+    .sort((a, b) => b.length - a.length || (a.name < b.name ? -1 : 1))
     .map((category) => buildCategoryStats.call(this, category));
 });
```

## issue から2点訂正

**1. 同点は1組ではなく3組ありました。**

| 本数 | 同点のカテゴリ |
| --- | --- |
| 134 | DevOps / Frontend |
| 70 | DB / Infrastructure |
| 57 | IaC / Mobile |

**2. 同じファイルの他の2箇所には既にタイブレークが入っていました。**

`get_monthly_category_data`（110行）と `get_weekly_category_data`（136行）が
`.sort((a, b) => b.length - a.length || (a.name < b.name ? -1 : 1))` を持っていて、
**3箇所のうち `category_index()` だけが抜けている**状態でした。issue には
「他の5箇所と同じ形にすれば直る」と書きましたが、いちばん近い前例は同じファイルの中にありました。
式もそちらに合わせています（`_widget/category.ejs` の3項ネストではなく短い形。
カテゴリ名は一意なので等価で、prettier の折り返しも起きません）。

## 検証

### 並びが3箇所で一致した

| 場所 | 並び |
| --- | --- |
| ヘッダーのドロップダウン（`category_index()`） | Programming DevOps Frontend Culture DataScience Cloud DB Infrastructure IaC Mobile IoT Business AIDD Management DataEngineering Security 認証認可 VR |
| サイドバー（`_widget/category.ejs`） | 同じ |
| `/categories/` のポータル（`category_index()`） | 同じ |

**18件すべて同順**（ヘッダー == サイドバー == ポータル）。

### 並びが規則どおりか

配信 HTML の `title` から拾った累計本数と、フロントマターの直接集計が一致し、
かつ並びが「累計降順・同点は名前順」になっていることを確かめました。

```
期待: Programming(327) DevOps(134) Frontend(134) Culture(131) DataScience(100) Cloud(77)
      DB(70) Infrastructure(70) IaC(57) Mobile(57) IoT(52) Business(50) AIDD(49)
      Management(48) DataEngineering(45) Security(36) 認証認可(24) VR(20)
実際: 同じ
```

### 決定性について（正直に）

**「同じソースで5回取って一致」は before/after を区別できません。** 揺れるのは
`this.site.categories.toArray()` の順序で、これはリクエストごとではなく
**再処理（サーバの再起動・リロード）のたび**に変わります。実際 #2953 の検証中に
`.ejs` を切り替えながら取り直したときに Frontend / DevOps の入れ替わりを観測しました。

**決定的だと言える根拠は「出力が (length, name) だけで決まる形になった」ことです。**
どちらも入力順に依らないので、`toArray()` が何を返しても並びは同じになります。
5回取って一致したのは、そのうえでの確認です。

## そのほか

- `npx prettier --check "scripts/**/*.js" "*.mjs"` 通過
- `scripts/` を触ったので `hexo server` を再起動して確認しました（起動時にしか読まれないため）

## 波及

`/categories/` とヘッダーのドロップダウンで、同点3組の並びが今後固定されます。
差分の無いビルドで HTML が変わることも無くなるので、**デプロイの差分が読みやすくなります**。
