### PR TITLE
記事のサイドバーを complementary ランドマークに戻す (#2962)

### DIFF
--- a/themes/future/layout/post.ejs
+++ b/themes/future/layout/post.ejs
@@ -15,10 +15,15 @@
         url: cat.path,
         icon: partial('_partial/category-icon', {name: cat.name}).trim()
       }] : [])}) %>
-  <section id="main" tabindex="-1" class="margin-top-30">
+  <%# div にするのは、この塊がサイドバーの <aside> も含んでいるため (#2962)。
+      section は sectioning content なので、中に入った <aside> は
+      complementary ロールを失う（HTML-AAM）。<main> は入れ子でも main を保つので
+      本文側は影響を受けず、サイドバーだけがランドマークから外れていた。
+      スキップリンクの着地点は id と tabindex が持つので変わらない（archive.ejs も div）%>
+  <div id="main" tabindex="-1" class="margin-top-30">
     <%# 受賞記事の印とタイトルは本文と同じ列の中にある（_partial/article #2570）%>
     <%- partial('_partial/article', {post: page, index: false}) %>
-  </section>
+  </div>
 </div>
 <%# 自動生成の推薦は記事の外なので container の外に置く (#2874)。
     全幅の面でフッターに接する帯にする %>


### PR DESCRIPTION
## やったこと

`post.ejs` の `<section id="main" tabindex="-1">` を `<div id="main" tabindex="-1">` にした。1行（＋理由のコメント）。

## なぜ section だとまずいのか

**HTML-AAM では、`<aside>` が sectioning content（`article` / `aside` / `nav` / `section`）の子孫にあるときは `complementary` ではなく generic になる。**

`post.ejs` は `#main` で `div.row` ごと包んでいて、その中に `_partial/article.ejs` の `<main>` と `<aside>` が並ぶ。つまり `<aside>` が `<section>` の中にいた。

| ページ | before の `aside` の系統 | complementary |
| --- | --- | --- |
| **記事** | `aside < div.row < **section#main** < div.container < div.wrap` | **✗** |
| 他の一覧・特設（9本） | `aside < div.row < div.container < div.wrap` | ○ |

他の9レイアウトは `section#main` が `<main>` の**内側**にあり、`<aside>` は `<main>` の兄弟なので影響が無い（静的に全部確認した）。**該当は `post.ejs` だけ。**

`<main>` はどこに入れ子になっても `main` ロールを保つので、本文側は元から無事だった。落ちていたのはサイドバーだけ。

## 確認したこと

| ページ | axe（region / landmark-one-main / landmark-unique） | `aside` の系統 | `#main` |
| --- | --- | --- | --- |
| 記事（2本） | **指摘なし**（before は `region` 1件） | `aside<div<div<div<div` | `<div tabindex="-1">` |
| カテゴリ個別 | 指摘なし | `aside<div<div<div` | `<section tabindex="-1">`（変更なし） |
| トップ | 指摘なし | `aside<div<div<div` | `<main tabindex="-1">`（変更なし） |

- **スキップリンクが本文へ飛ぶことを確認**（Tab → Enter で `#main`（DIV）にフォーカスが移る）
- 見た目の変化なし。`.margin-top-30` はクラスなのでそのまま効き、`#main` の位置も `margin-top: 30px` で変わらない
- CSS に要素セレクタの `section` を使った指定は1件（`.article-appendix section:first-child`）だけで、ここには関係しない

Closes #2962

🤖 Generated with [Claude Code](https://claude.com/claude-code)
