### PR TITLE
記事の meta description に lede を使う (#2963)

### DIFF
--- a/themes/future/layout/_partial/head.ejs
+++ b/themes/future/layout/_partial/head.ejs
@@ -63,6 +63,11 @@
     } else if (page.path === 'authors/index.html') {
       title = '著者一覧';
       description = '著者一覧 | ' + config.description;
+    } else if (is_post() && page.lede) {
+      // 記事は lede を使う (#2963)。渡さないと Hexo が本文の先頭200文字で埋め、
+      // 「〜連載の7日目です。」のような前置きが検索結果に出る。lede は一覧カードの
+      // 概要文として書き手が手で書いており、1,481本のうち1,479本が持っている
+      description = page.lede;
     }
 
     // 2ページ目以降は同じタイトルのタブが並ばないよう、パンくずと同じ語で区別する


### PR DESCRIPTION
## やったこと

記事ページの `meta description` に **フロントマターの `lede` を使う**（#2963 の案1）。`_partial/head.ejs` に1分岐。

```js
} else if (is_post() && page.lede) {
  description = page.lede;
}
```

## before / after

| 記事 | before（本文の先頭200文字） | after（lede） |
| --- | --- | --- |
| `/articles/20250903a/` | **198文字** `夏の自由研究2025ブログ連載の7日目です。 フューチャー技術ブログの「関連記事…` | **41文字** `フューチャー技術ブログの「関連記事」の表示ロジックの変遷と今後についてまとめます。` |
| `/articles/20260730a/` | 200文字 | **53文字** `Go 1.27 より導入されるジェネリックメソッド (generic methods)について紹介します` |
| `/articles/20260518a/` | 200文字 | **97文字** `今年もフューチャー技術ブログでは、Terraformを題材とした連載を開催します。…` |

**「〜連載の7日目です。」のような前置きが検索結果の先頭を占めるのをやめられる。** 日本語の検索結果で表示されるのは概ね120文字までなので、before は主題に届く前に切れていた。

## なぜ lede か

**既にある資産だから。** `lede` は一覧カードの概要文（`.lede`）として書き手が手で書いている。

| | 値 |
| --- | --- |
| `lede` を持つ記事 | **1,479 / 1,481本** |
| 2025〜2026年の記事 | **293 / 293本**（全部持っている） |
| 長さの中央値 | 101文字 |
| 120文字以内 | 944本 |
| 最短 / 最長 | 13 / 318文字 |

## 確認したこと

- 記事3本で `meta description` と `og:description` が lede に変わることを確認（両方同じ値）
- **`lede` を持たない2本**（`/articles/20160216/`・`/articles/20160323/`）は `description` を渡さないままなので**今までと同じ既定に落ちる**（42文字・90文字）
- トップ（44文字）・カテゴリ個別（68文字）・タグ個別（57文字）は変わらない
- `head.ejs` は `description` を JSON-LD にも渡しているので、構造化データの説明も同じ値になる

## 範囲外

**特設ページの description は触っていない。** `/specials/styleguide/`（195文字）と `/specials/markdown/`（199文字）は見出しと本文がつながる問題（`スタイルガイドこのブログの…`）を抱えているが、直す場所が別（フロントマターかレイアウトから明示的に渡す）なので #2963 の案2として残す。

**#2963 は閉じない。** 案2（特設ページ）が残るので、部分対応で閉じないようにする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
