### PR TITLE
カテゴリの同点は新しい記事を出した方を上にし、並びの規則を1箇所に集める (#2959)

### DIFF
--- a/scripts/category_chart_helpers.js
+++ b/scripts/category_chart_helpers.js
@@ -105,9 +105,7 @@ hexo.extend.helper.register('get_monthly_category_data', function (year) {
   // 並びはその年の多い順ではなく、全期間ページと同じサイト累計の多い順で
   // 固定する。年ごとに入れ替わると、年を移動したとき凡例と積み上げの
   // 色の位置が動いて比較しにくい (#2201)
-  const series = this.site.categories
-    .toArray()
-    .sort((a, b) => b.length - a.length || (a.name < b.name ? -1 : 1))
+  const series = orderedCategories(this.site)
     .filter((c) => byCat.has(c.name))
     .map((c) => ({ name: c.name, data: byCat.get(c.name) }));
   return JSON.stringify({ months, series });
@@ -131,12 +129,54 @@ hexo.extend.helper.register('get_weekly_category_data', function (year, month) {
   });
   const weeks = Array.from({ length: weekCount }, (_, i) => `第${i + 1}週`);
   // 並びは年ページと同じサイト累計の多い順で固定 (#2201)
-  const series = this.site.categories
-    .toArray()
-    .sort((a, b) => b.length - a.length || (a.name < b.name ? -1 : 1))
+  const series = orderedCategories(this.site)
     .filter((c) => byCat.has(c.name))
     .map((c) => ({ name: c.name, data: byCat.get(c.name) }));
   return JSON.stringify({ weeks, series });
+});
+
+// カテゴリの並びはサイト全体で1つ (#2959)。累計の多い順で、同点は
+// **より新しい記事を出した方を上**にする。同点のカテゴリは次に記事が出た側の
+// 累計が先に進むので、そのとき順位が入れ替わる向きに最初から並べておく。
+// 最後に名前で決めるのは、最新記事の時刻まで同じだったときの保険
+// （同日複数投稿は date を秒でずらす規約があるので実際には起きない）。
+//
+// 同点は3組ある: DevOps / Frontend（134）、DB / Infrastructure（70）、
+// IaC / Mobile（57）。決着が無いと toArray() の順序次第でビルドごとに
+// 入れ替わっていた (#2959)。
+//
+// 記事数を鍵にして持ち回る。18カテゴリ×所属記事を毎ページ4回舐めると
+// その分ビルドが伸びる（呼ぶのはヘッダー・サイドバー・ポータル・グラフ）。
+// 記事数が変わったら作り直すので server での編集にも追随する
+const categoryOrderCache = new Map();
+
+function latestPostTime(category) {
+  let latest = 0;
+  category.posts.forEach((post) => {
+    const t = post.date.valueOf();
+    if (t > latest) latest = t;
+  });
+  return latest;
+}
+
+function orderedCategories(site) {
+  const key = String(site.posts.length);
+  if (categoryOrderCache.has(key)) return categoryOrderCache.get(key);
+  const latest = new Map();
+  const cats = site.categories.toArray();
+  cats.forEach((c) => latest.set(c.name, latestPostTime(c)));
+  const sorted = cats.sort(
+    (a, b) =>
+      b.length - a.length || latest.get(b.name) - latest.get(a.name) || (a.name < b.name ? -1 : 1),
+  );
+  categoryOrderCache.set(key, sorted);
+  return sorted;
+}
+
+// サイドバー（_widget/category.ejs）から呼ぶ。並びを1箇所に保つため、
+// テンプレート側で sort し直さない
+hexo.extend.helper.register('category_order', function () {
+  return orderedCategories(this.site);
 });
 
 /**
@@ -183,14 +223,9 @@ function buildCategoryStats(category) {
 }
 
 // /categories/ の一覧用データ (#2056)。ヘッダーのドロップダウン (#2877) も呼ぶ。
-// 同点は名前で決める（このファイルのグラフ2箇所と同じ式。#2959）。
-// 同点は3組あり、決着が無いとビルドごとに入れ替わっていた:
-// DevOps / Frontend（134）、DB / Infrastructure（70）、IaC / Mobile（57）
+// 並びは orderedCategories が1箇所で持つ
 hexo.extend.helper.register('category_index', function () {
-  return this.site.categories
-    .toArray()
-    .sort((a, b) => b.length - a.length || (a.name < b.name ? -1 : 1))
-    .map((category) => buildCategoryStats.call(this, category));
+  return orderedCategories(this.site).map((category) => buildCategoryStats.call(this, category));
 });
 
 // 絞り込んだ一覧用。カテゴリと同じ統計を、記事の部分集合に対して出す (#2038)
@@ -248,10 +283,7 @@ function monthlyBuckets(posts) {
 
 /** 積む順（＝凡例の順）はサイト累計の多い順で固定する (#2201) */
 function siteCategoryOrder() {
-  return this.site.categories
-    .toArray()
-    .sort((a, b) => b.length - a.length || (a.name < b.name ? -1 : 1))
-    .map((c) => c.name);
+  return orderedCategories(this.site).map((c) => c.name);
 }
 
 /**

--- a/themes/future/layout/_widget/category.ejs
+++ b/themes/future/layout/_widget/category.ejs
@@ -1,11 +1,10 @@
 <div class="widget">
   <ul class="nav sidebar-categories margin-bottom-40">
   <%
-    // 同点の決着が無いとビルドごとに並びが変わる。
-    // slice() するのは site.categories.data を直接 sort すると他のページに響くため
-    const compareFunc = (a, b) =>
-      b.posts.length - a.posts.length || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
-    const categoryRanks = site.categories.data.slice().sort(compareFunc)
+    // 並びは category_order() が1箇所で持つ (#2959)。累計の多い順で、同点は
+    // より新しい記事を出した方が上。ここで sort し直すと、ヘッダーの
+    // ドロップダウンと /categories/ のポータルと並びが割れる
+    const categoryRanks = category_order();
 
     let categoryListHTML = "";
     categoryRanks.forEach(function(c) {


### PR DESCRIPTION
#2959 の続き。同点のタイブレークを「**より新しい記事を出した方を上**」に変え、あわせて散っていた並びの規則を1箇所に集めました。

## 規則は3段

```js
b.length - a.length ||                          // 累計の多い順
  latest.get(b.name) - latest.get(a.name) ||    // 最新記事の新しい順
  (a.name < b.name ? -1 : 1)                    // 名前順（保険）
```

同点のカテゴリは**次に記事が出た側の累計が先に進む**ので、そのとき順位が入れ替わる向きに最初から並べておく、という考え方です。3段目は最新記事の時刻まで同じだったときの保険で、同日複数投稿は `date` を秒でずらす規約があるので実際には起きません。

## 並びの規則を1箇所に集めた

**5箇所に散っていました。**

| 場所 | before | after |
| --- | --- | --- |
| `get_monthly_category_data` の系列（#2201） | 自前の sort | `orderedCategories()` |
| `get_weekly_category_data` の系列 | 自前の sort | 〃 |
| `category_index()`（ヘッダー #2877 ／ `/categories/` #2056） | 自前の sort | 〃 |
| `siteCategoryOrder()` | 自前の sort | 〃 |
| **`_widget/category.ejs`（サイドバー）** | **EJS の中で自前の sort** | **新しい helper `category_order()` を呼ぶだけ** |

#2959 では「3箇所のうち1箇所だけ抜けていた」と書きましたが、テンプレート側と `siteCategoryOrder()` も数えると**5箇所**でした。3段の規則を5箇所に書き写すのは無理があるので、`orderedCategories()` に集めています。

**18カテゴリ×所属記事を毎ページ4回舐める**ことになるので、記事数を鍵にして持ち回ります（`recent_popular_tags` #2358 と同じ形。記事数が変わったら作り直すので `hexo server` での編集にも追随します）。

## いまの並びは変わりません

実データの同点3組は、**すべて「新しい側が名前順でも先」**でした。

| 本数 | カテゴリ | 最新記事 |
| --- | --- | --- |
| 134 | **DevOps** | 2026/08/21 |
| 134 | Frontend | 2026/07/27 |
| 70 | **DB** | 2026/08/17 |
| 70 | Infrastructure | 2026/06/17 |
| 57 | **IaC** | 2026/06/01 |
| 57 | Mobile | 2025/10/22 |

なので**出力は #2959 のときと同じ**で、効くのは次に同点が生まれたときからです。

## 検証

### 規則が効いていることを Node で確かめた

出力が変わらないので、`hexo` をスタブして `category_order()` を直接叩き、**名前順と逆になる合成データ**で確かめました。

| 場面 | 結果 |
| --- | --- |
| 件数が違えば件数で決まる | ✅ |
| **同点で `Zulu` の方が新しい → 名前順では後ろだが上に来る** | ✅ |
| 3つ同点 → 新しい順に並ぶ | ✅ |
| 同点かつ最新も同日 → 名前順（保険） | ✅ |
| 実データに近い形（同点3組） | ✅ 名前順と同じ結果 |
| **入力の順序を3通り変えても同じ並び** | ✅ |

### 配信 HTML

- **5箇所すべて同順**（18件）: ヘッダーのドロップダウン / サイドバー / `/categories/` のポータル / `/categories/` のグラフの系列 / 月ページのグラフの系列
- 並びが「累計降順 → 最新の新しい順 → 名前順」になっていること、および累計本数がフロントマターの直接集計と一致すること
- `prettier --check` 通過、`_widget/category.ejs` の textlint 0件
- `scripts/` を触ったのでサーバを再起動して確認しました

## 直した自分の間違い

コード中のコメントに**存在しない issue 番号（`#2966`）を書いていました**。#2959 に直しています。
