### PR TITLE
記事ページの #main を div にしてサイドバーを complementary に戻す (#2962)

### DIFF
--- a/themes/future/layout/post.ejs
+++ b/themes/future/layout/post.ejs
@@ -15,10 +15,14 @@
         url: cat.path,
         icon: partial('_partial/category-icon', {name: cat.name}).trim()
       }] : [])}) %>
-  <section id="main" tabindex="-1" class="margin-top-30">
+  <%# div にする (#2962)。section は sectioning content なので、この中に入った
+      _partial/article の <aside> が complementary ではなく generic に落ちる。
+      一覧系は section#main が <main> の内側にあり aside が外に出るので影響が無い。
+      スキップリンクの着地点 (#2846) は id と tabindex が持つので変わらない %>
+  <div id="main" tabindex="-1" class="margin-top-30">
     <%# 受賞記事の印とタイトルは本文と同じ列の中にある（_partial/article #2570）%>
     <%- partial('_partial/article', {post: page, index: false}) %>
-  </section>
+  </div>
 </div>
 <%# 自動生成の推薦は記事の外なので container の外に置く (#2874)。
     全幅の面でフッターに接する帯にする %>


### PR DESCRIPTION
`section` は sectioning content なので、HTML-AAM では中に入った `<aside>` が `complementary` ではなく generic になる。`post.ejs` だけ `section#main` が `div.row` の**外側**にあり、`_partial/article` のサイドバーがその中に入っていた。

```diff
-  <section id="main" tabindex="-1" class="margin-top-30">
+  <div id="main" tabindex="-1" class="margin-top-30">
```

一覧系は `section#main` が `<main>` の**内側**にあって `aside` が外に出るので影響が無い。

## 測ったこと

### 読み上げのランドマーク（CDP の `Accessibility.getFullAXTree`）

`/articles/20260612a/`。DOM で `div#main` を `section#main` に差し替えた対照と並べた。

| | ランドマーク |
| --- | --- |
| **変更前** | banner / navigation「パンくず」 / **complementary「関連情報」** / contentinfo / main / navigation×3 / region「著者」 |
| **変更後** | banner / navigation「パンくず」 / **complementary「関連情報」** / contentinfo / main / **complementary**（サイドバー）/ navigation×3 / region「著者」 |

### axe（全ルール）

| ページ | 変更前 | 変更後 |
| --- | --- | --- |
| `/articles/20260612a/` | **region x1** | **clean** |
| `/articles/20260806a/` | **region x1** | **clean** |

他のページ種は変更なし（`/`・カテゴリ・タグ・著者・`/series/` は clean、スタイルガイドは `empty-table-header x6` が残るが #2964 の別件）。

### スキップリンク（#2846）

Tab → Enter で **`div#main` にフォーカスが移り**、次の Tab が本文（記事の編集リンク）に入ることを確認。挙動は変わらない。

## issue の記述で1点違ったところ

> **前例がある**: `archive.ejs` は既に `<div id="main" tabindex="-1" class="margin-top-30">`

`archive.ejs` は実際には **`<main id="main">`** だった。`id="main"` を持つ17ファイルのうち `<div>` は1つも無く、`<main>` が7・`<section>` が10。

**ここで `div` を選ぶ理由は別にある。** `_partial/article` が内側に `<main class="col-md-9">` を持っているので、`post.ejs` 側を `<main>` にすると main が入れ子になる。`div` が唯一の選択肢。

## 残る論点（この PR では触っていない）

**記事ページの complementary が2つになり、片方に名前が無い。**

| | 名前 |
| --- | --- |
| 記事末の帯（`article-appendix` #2874） | 「関連情報」 |
| サイドバー | **無し** |

記事ページのサイドバーは中身が目次だけ（`<h2>目次</h2>` ＋ TOC。カテゴリ・連載・タグは記事ページでは出さない #2880）なので、`aria-label="目次"` を付ける手はある。

**この PR では付けていない。** トップ・カテゴリ・タグ・著者のサイドバーも同じく名前を持っておらず、記事ページだけ名付けるとページ種で扱いが割れるため。サイト全体でサイドバーに名前を付けるかどうかは別に判断したい（axe の `landmark-unique` は名前の有無で区別が付くので通っている）。

## lint

textlint（`post.ejs`）0件。`scripts/` も `.md` も触っていないので prettier の対象に変化なし。

Closes #2962