### PR TITLE
横に溢れる表をキーボードでもスクロールできるようにする (#2961)

### DIFF
--- a/scripts/table_filter.js
+++ b/scripts/table_filter.js
@@ -7,7 +7,7 @@
 // https://github.com/markedjs/marked/blob/e5796ecc435a30f96939e6a7b2229c14264b4bf8/src/Renderer.js#L92
 hexo.extend.filter.register('marked:renderer', function (renderer) {
   renderer.table = function (header, body) {
-    return `<div class="scroll">${table(header, body)}</div>\n`;
+    return `<div class="scroll" tabindex="0" role="region" aria-label="${regionLabel(header)}">${table(header, body)}</div>\n`;
   };
 });
 
@@ -15,4 +15,36 @@ const table = (header, body) => {
   if (body) body = '<tbody>' + body + '</tbody>';
 
   return '<table>\n' + '<thead>\n' + header + '</thead>\n' + body + '</table>';
+};
+
+/**
+ * 横スクロールする器の読み上げ名を、1行目の見出しから組む (#2961)。
+ *
+ * `.scroll` は overflow-x: auto なので、tabindex が無いとキーボードだけでは
+ * 横に振れない（WCAG 2.1.1・レベル A）。全727件の表に付けるのは、
+ * **どの表が溢れるかをビルド時に判定できない**ため。表の中には CSS で寸法を
+ * 持つ要素（スタイルガイドの色見本など）が入り、Markdown からは幅が分からない。
+ * 実際、溢れる幅を Markdown から見積もる案は実測（12個中2個が溢れる）に
+ * 対して0個と外れた。
+ *
+ * 表を持つ記事は374本（全体の25%）で、その中の中央値は1個。増えるタブ停止は
+ * 1記事あたり中央値1個で、溢れていない表でも「表がある」ことは読み上げられる。
+ *
+ * 名前を列名から作るのは、1ページに複数の表があると「表」だけでは区別できないため。
+ */
+const regionLabel = (header) => {
+  const names = (header.match(/<th[^>]*>([\s\S]*?)<\/th>/g) || [])
+    .map((cell) =>
+      cell
+        .replace(/<[^>]*>/g, '')
+        .replace(/\s+/g, ' ')
+        .trim(),
+    )
+    .filter(Boolean);
+  if (!names.length) return '表';
+  // 長い見出しが並ぶ表もあるので頭を取る。
+  // **& は再エスケープしない。** header は marked が出した HTML で、本文の & は
+  // すでに &amp; になっている。もう一度潰すと &amp;amp; になって読み上げに出る
+  const joined = names.join(' / ').slice(0, 60);
+  return `表 ${joined}`.replace(/"/g, '&quot;').replace(/</g, '&lt;');
 };


### PR DESCRIPTION
Closes #2961

**案1（JS）は使わない**方針をいただいたので、案2（全部の表に静的に付ける）で実装しました。

```diff
-    return `<div class="scroll">${table(header, body)}</div>\n`;
+    return `<div class="scroll" tabindex="0" role="region" aria-label="${regionLabel(header)}">${table(header, body)}</div>\n`;
```

`aria-label` は**1行目の見出しから作ります**（1ページに複数の表があると「表」だけでは区別できないため）。

```html
<div class="scroll" tabindex="0" role="region" aria-label="表 段 / 値 / 使うところ">
```

## 「溢れる表だけに付ける」は成立しませんでした

JS を使わずに絞る道として、**ビルド時に min-content 幅を見積もって「溢れうる表だけ」に付ける**案を検討しました。min-content は中身の性質で画面幅に依らないので、理屈は通ります。

**実測で外れました。** issue が測った `/specials/styleguide/`（幅375pxで12個中2個が溢れ、中身は 380px / 451px）に対して、私の推定は最大302pxで **0個**でした。

原因は、**表の中に CSS で寸法を持つ要素**（スタイルガイドの色見本のスウォッチなど）が入っていて、Markdown からは幅が分からないことです。同じ理由で「案3（セル内で長いトークンを折り返す）」もこのケースを直せません（折り返しの対象がテキストではないため）。

したがって**全件に付ける以外に、JS 無しで確実な方法はありません。**

## 増えるタブ停止

| | |
| --- | --- |
| 表の総数 | 727件 |
| 表を持つ記事 | 374本（全1,481本の **25%**） |
| 表を持つ記事の中での表の数 | **中央値 1個** / 平均 1.9 / 最大 15 |
| 表を持たない記事 | 1,107本（**75%** は影響なし） |

1記事あたりの分布は 1個が245本・2個が62本・3個が21本で、**89%が3個以下**です。12個以上は4本だけ（スタイルガイドはこの側の外れ値）。

**溢れていない表でも無駄ではありません。** `role="region"` ＋ 名前が付くので、支援技術の読者には「ここに『段 / 値 / 使うところ』の表がある」と伝わり、ランドマークとして飛べます（Adrian Roselli の responsive table の形と同じ）。目で見るキーボード利用者にとっては、溢れていない表でフォーカスリングが出るのが増分のコストです。

## 検証

`marked:renderer` は記事の描画結果（`db.json` にキャッシュ）に効くので、`hexo generate` ではなく **renderer を直接叩いて**確かめました（`hexo.post.render` は `source` を実ファイルとして解決するため、フィルタ単体の確認には `hexo.render.render({text, engine:'md'})` を使っています）。

| 入力 | 出た `aria-label` | |
| --- | --- | --- |
| 普通の表（3列） | `表 段 / 値 / 使うところ` | ✅ |
| 見出しにインラインコードとリンク | `表 --on-dark / 参考 / 説明` | ✅ タグを剥がす |
| 見出しに `&` | `表 A &amp; B / C` | ✅ 二重エスケープしない |
| 見出しが空 | `表` | ✅ |
| 60文字を超える見出し | 先頭で切る | ✅ 64文字以内 |

各ケースで `tabindex="0"` / `role="region"` / `aria-label` があること、属性値に生の `"` `<` が入らないこと、`<table>` が中にあることも確認しました。

**`&` を再エスケープするバグを1つ潰しました。** 最初の実装は `&amp;amp;` を出していました（`header` は marked が出した HTML で、本文の `&` はすでに `&amp;` になっている）。

`prettier --check` 通過。

## マージ後に必要なこと

**`marked:renderer` は記事の描画結果に効くので、`hexo clean` してからビルドしないと既存記事に反映されません**（CLAUDE.md の「`scripts/` のフィルタを足したり直したら `make clean` してからビルドする」）。デプロイのワークフローは毎回クリーンな環境で `hexo generate` するので本番は問題ありませんが、手元で確認するときは `make clean` が必要です。

## 残る論点

Chrome は 2025年に「フォーカス可能なスクロールコンテナ」（中にフォーカス可能な要素が無いスクローラを自動でフォーカス可能にする）を入れています。将来 Safari / Firefox も追随すれば `tabindex` は冗長になりますが、いまは axe も指摘するので付けておく形です。
