### PR TITLE
添えの文字を text-meta（12px）に寄せる (#2971)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -475,7 +475,7 @@ bootstrap-subset → theme-styles.styl の順で `/css/site.css` に連結する
   | 本文見出し h1（`.article-entry h1`） | 記事タイトルと同じ（`.article-title` / `.list-page` と同一ルール。直前の空き 64px・罫線 2px はここで持つ） | 〃 |
   | 一覧ページの見出し `.list-page` | 記事タイトルと同じ（`.article-title` と同一ルール） | 〃 |
   | 一覧ページの統計（数値 / ラベル） | 16px / 12px（#2911。サイドバーの内寸 208〜298px では 20px が行の6割を占めた。統計は一覧ページの主役ではないので #1927 の 25px → 20px と同じ向きにもう一段。16px は `.header-search input` と同値） | 〃 |
-  | 全件への導線（`.more-link`） | 14px（#2893。押す対象なので「行として並ぶもの」の段。`.panel-meta` 11.7px と分ける） | 〃 |
+  | 全件への導線（`.more-link`） | `text-row`（#2893。押す対象なので「行として並ぶもの」の段。添えの `text-meta` と分ける） | 〃 |
   | 目次の項目（`.toc-section ol`。サイドバー・モバイル共通） | 14px（字下げの `1em` もこの値に追従する） | 〃 |
   | 目次のラベル「目次」（`.toc-section h2` / `.toc-mobile summary`） | 14px（サイドバーの `h2` の例外。見出しではなくブロックのラベル） | 〃 |
   | 脚注（`#footnotelist li`） | `1em` = 13px | 〃 |
@@ -508,6 +508,8 @@ bootstrap-subset → theme-styles.styl の順で `/css/site.css` に連結する
     404 の 128px・タグの件数の 6.5px
   - **`font-size` でアイコンの実寸を決めている箇所は段の外**（`.svg-icon` が `1em` なので、
     親の `font-size` がそのまま絵の大きさになる）。文字ではないので役の名前が付かない
+  - **添えの小さい数字・注記は `ink-mute` × `text-meta`。** 以前は `0.85em`（11.05px）・
+    `0.9em`（11.7px）・`10px`・`11px` に分かれていたが、#2971 で1つに寄せた
   - **`em` は親に掛かる。** `1em` は「サイズを決める」のではなく
     **親の倍率を打ち消す**指定（`.article-entry details p` の親は `1.2em`）。
     `.summary-count` の「em の連鎖をやめて px で書く」（#1927 / #1928）は
@@ -906,7 +908,7 @@ bootstrap-subset → theme-styles.styl の順で `/css/site.css` に連結する
   - **節の見出しは置かない。** 「累計」「直近1年」のラベルと数字が並んでいれば何のブロックかは
     見て分かる。目で見えない読者には `<section aria-label="統計">` が名乗る。
     **時間軸のラベルを強めない。** 主役は数値（16px 太字）で、箱の名前はその上に
-    小さく添えるもの。本文の統計と同じ `summary-panel-label`（`ink-mute` × `0.85em`）の
+    小さく添えるもの。本文の統計と同じ `summary-panel-label`（`ink-mute` × `text-meta`）の
     ままにして、サイドバー用の上書きを持たない
   - **グラフの凡例は出さない。** カテゴリ別の積み上げは最長の `DataEngineering` だけで
     117.9px あり、`type: scroll` の横送りになって場所だけ取る。どの色が何かは
@@ -976,7 +978,7 @@ bootstrap-subset → theme-styles.styl の順で `/css/site.css` に連結する
         #2892 で足した。人を表す `users` / `users-group` は著者一覧と Management
         カテゴリが使っているので、アクティビティには当てない
       - 太字なのは、すぐ下の `.panel-meta` が同じ `ink-mute` で、役の違いが
-        大きさ（12px 対 11.7px）では読み取れないため
+        大きさでは読み取れないため（どちらも `text-meta` #2971）
     - ラベルはリンクの**外**に置く。種別はカードの属性であって導線ではなく、
       同じ行き先のリンクを1枚のカードに2つ置かない (#2845) 決まりにも合う
     - **ラベルが名乗るぶん、説明文からは種別を落とす**（連載の `全9本・2026.08 更新` に

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -428,7 +428,7 @@ Header and header elements
 /* 右肩の件数は「総数」の意味 (#2129)。押す対象ではない添えなので薄い段に置く */
 .header-dropdown-count {
   margin-left: space-step;
-  font-size: 0.75em;
+  font-size: text-meta;
   font-weight: normal;
   color: ink-faint;
 }
@@ -859,7 +859,7 @@ Footer
   background-color: var(--navy-raised);
   color: var(--on-dark-mute);
   font-family: font-mono;
-  font-size: 10px;
+  font-size: text-meta;
   vertical-align: 1px;
   transition: background-color hover-speed ease, color hover-speed ease;
 }
@@ -924,7 +924,7 @@ Footer
 .footer-count {
   color: var(--on-dark-mute);
   font-family: font-mono;
-  font-size: 11px;
+  font-size: text-meta;
   /* 桁が変わってもアイコンの中心からずれない */
   font-variant-numeric: tabular-nums;
   line-height: 1;
@@ -943,7 +943,7 @@ Footer
 }
 .footer-label {
   color: var(--on-dark-mute);
-  font-size: 11px;
+  font-size: text-meta;
   font-weight: 700;
   letter-spacing: 0.05em;
 }
@@ -1032,7 +1032,7 @@ Footer
   margin: 0;
   color: var(--on-dark-mute);
   font-family: font-mono;
-  font-size: 11px;
+  font-size: text-meta;
 }
 /* 飾りの記号。いいねの ♡（#2755 で塗らないと決めたもの）とは別物で、
    押せる部品ではないため塗ってよい */
@@ -1918,7 +1918,7 @@ body {
 }
 .panel-meta {
   color: ink-mute;
-  font-size: 0.9em;
+  font-size: text-meta;
 }
 /* 種別が混ざる回だけ、全件導線がパネルの中に入る (#2892)。p の既定の下マージンは
    カードの底に空きを作るだけなので落とす */
@@ -2126,7 +2126,7 @@ button.share-btn {
   border-radius: radius-small;
   background: var(--brand-navy);
   color: #fff;
-  font-size: 11px;
+  font-size: text-meta;
   font-weight: bold;
   white-space: nowrap;
   opacity: 0;
@@ -2151,7 +2151,7 @@ button.share-btn {
    押せる部分ではないので hover では動かさない（反応はボタンが持つ #2686） */
 .share-count {
   color: var(--brand-navy);
-  font-size: 11px;
+  font-size: text-meta;
   line-height: 1;
   /* 太字にしない。ネイビーは ink-mute の2.6倍濃い（6.19 → 16.34）ので、
      11px で bold にすると線が潰れて数字が太って見えた */
@@ -2981,7 +2981,7 @@ ul.tag-list {
 .archive-list-count {
   display: block;
   color: ink-mute;
-  font-size: 0.85em;
+  font-size: text-meta;
 }
 .archive-list-count:after {
   content: "本";
@@ -3030,7 +3030,7 @@ ul.tag-list {
 }
 .tendency-panel-count {
   color: ink-mute;
-  font-size: 0.85em;
+  font-size: text-meta;
   white-space: nowrap;
 }
 /* 関連タグは目的ごとに群を分けており、ラベルが目的を名乗る (#2569)。
@@ -3117,13 +3117,13 @@ ul.tag-list {
 .doctor-note {
   display: block;
   color: ink-mute;
-  font-size: 0.9em;
+  font-size: text-meta;
 }
 /* 名前の直後に添える注記。横に流したい列で使う（#2418）。
    行ごとに区切り線が入るので、行間・項目間は開けすぎない */
 .doctor-note-inline {
   color: ink-mute;
-  font-size: 0.9em;
+  font-size: text-meta;
   margin: 0 5px 0 2px;
 }
 .doctor-list .doctor-inline-row {
@@ -3172,13 +3172,13 @@ ul.tag-list {
 }
 .ontology-count {
   color: ink-mute;
-  font-size: 0.85em;
+  font-size: text-meta;
   margin-left: 5px;
 }
 .ontology-versions {
   display: block; /* Go は版が12個並ぶので、名前と同じ行に置くと折り返して階層が崩れる */
   color: ink-mute;
-  font-size: 0.85em;
+  font-size: text-meta;
 }
 .author-list {
   padding-inline-start: 0px;
@@ -3287,7 +3287,7 @@ ul.tag-list {
 .category-index-meta {
   flex: none;
   color: ink-mute;
-  font-size: 0.9em;
+  font-size: text-meta;
   white-space: nowrap;
   /* 名前の次の行に並ぶチップ (#2405)。下のタグチップ（塗り）とは
      枠線だけ・グレー文字で性質の違いを示す */
@@ -3437,7 +3437,7 @@ ul.tag-list {
   border: 1px solid rule-base;
   border-radius: radius-small;
   color: ink-mute;
-  font-size: 10px;
+  font-size: text-meta;
   font-weight: normal;
   line-height: leading-row;
   vertical-align: middle;
@@ -3448,7 +3448,7 @@ ul.tag-list {
   flex: none;
   margin: 0;
   color: ink-mute;
-  font-size: 0.9em;
+  font-size: text-meta;
   white-space: nowrap;
 }
 /* 索引へは連載名そのものから辿る。別途「索引を見る」を置くと導線が二重になる */
@@ -3495,7 +3495,7 @@ a.series-nav-item:hover .series-nav-item-title {
   display: flex;
   align-items: center;
   color: ink-mute;
-  font-size: 0.9em;
+  font-size: text-meta;
 }
 .series-nav-next.series-nav-end {
   justify-content: flex-end;
@@ -3518,7 +3518,7 @@ a.series-nav-item:hover .series-nav-item-title {
   display: block;
   margin-bottom: 0.2em;
   color: ink-mute;
-  font-size: 0.85em;
+  font-size: text-meta;
 }
 .series-nav-prev .series-nav-dir:before {
   content: '‹ ';
@@ -3758,7 +3758,7 @@ a.series-nav-item:hover .series-nav-item-title {
   padding: 0.5em 0;
   border-top: 1px solid rule-weak;
   color: ink-mute;
-  font-size: 0.9em;
+  font-size: text-meta;
   cursor: pointer;
 }
 .reference-post-more > summary:hover,
@@ -3791,7 +3791,7 @@ a.series-nav-item:hover .series-nav-item-title {
 .post-meta {
   display: inline-block;
   margin-left: 0.6em;
-  font-size: 0.85em;
+  font-size: text-meta;
   color: ink-mute;
   white-space: nowrap;
 }
@@ -3857,7 +3857,7 @@ a.series-nav-item:hover .series-nav-item-title {
 .summary-note {
   margin: 0 0 8px;
   color: ink-mute;
-  font-size: 0.9em;
+  font-size: text-meta;
 }
 /* そのページ自身の統計とグラフ (#2911)。カテゴリ・タグ・著者ページで
    本文の先頭からサイドバーへ移した。読者の目的は「その記事を読む」ことで、
@@ -3935,7 +3935,7 @@ a.series-nav-item:hover .series-nav-item-title {
   display: block;
   margin-bottom: 2px;
   color: ink-mute;
-  font-size: 0.85em;
+  font-size: text-meta;
 }
 .summary-panel .summary-note {
   margin: 12px 0;
@@ -4029,7 +4029,7 @@ a.series-nav-item:hover .series-nav-item-title {
   padding: 3px 10px 3px 8px;
   border-radius: 999px;
   background: rgba(255,255,255,0.75);
-  font-size: 0.95em;
+  font-size: text-meta;
   font-weight: bold;
   color: #7a5f16;
 }
@@ -4561,7 +4561,7 @@ a.award-badge:focus {
   border: 1px solid rule-base;
   border-radius: radius-small;
   font-weight: normal;
-  font-size: 10px;
+  font-size: text-meta;
   line-height: leading-row;
   vertical-align: middle;
 }
@@ -5242,7 +5242,7 @@ note-alert-bg = #ffdbdb
 }
 
 .link-preview-card-description {
-  font-size: 0.85em;
+  font-size: text-meta;
   color: ink-mute;
   line-height: leading-row;
   display: -webkit-box;
@@ -5255,7 +5255,7 @@ note-alert-bg = #ffdbdb
 .link-preview-card-meta {
   display: flex;
   align-items: center;
-  font-size: 0.75em;
+  font-size: text-meta;
   color: ink-faint;
   margin-top: 8px;
   white-space: nowrap;


### PR DESCRIPTION
#2971 の2本目。**添えの文字27件を `text-meta`（12px）に寄せます。** 4本のうち**いちばん見た目が動く**回です。

## 寄せたもの

| 前 | 件数 | 部品 |
| --- | --- | --- |
| `0.75em`（9.75px） | 2 | `.header-dropdown-count` `.link-preview-card-meta` |
| `10px` | 3 | `.footer-tag`（OSS の印）`.newitem`（NEW）`.series-nav-kicker`（前の記事 / 次の記事） |
| `11px` | 5 | `.footer-count` `.footer-label` `.footer-credo` `.share-copied` `.share-count` |
| `0.85em`（11.05px） | 8 | `.archive-list-count` `.tendency-panel-count` `.ontology-count` `.ontology-versions` `.post-meta` `.series-nav-dir` `.summary-panel-label` `.link-preview-card-description` |
| `0.9em`（11.7px） | 8 | `.panel-meta` `.doctor-note` `.doctor-note-inline` `.category-index-meta` `.series-nav-count` `.series-nav-end` `.ranking-more > summary` `.summary-note` |
| `0.95em`（12.35px） | 1 | `.awards-hall-medal` |

**6種類・2.6px の幅に散っていたものが1つになります。** `.footer-count` 11.00px と
`.archive-list-count` 11.05px の 0.05px 差が消えます。

## 見た目がどう動くか

| | 変化 |
| --- | --- |
| NEW バッジ・フッターの OSS・連載ナビのキッカー | 10px → 12px（**+20%**） |
| フッターの件数・ラベル・クレド、♡ の数 | 11px → 12px（+9%） |
| メタ行・パネルの説明・件数・注記 | 11.05 / 11.7px → 12px（+2.5〜8.6%） |
| 表彰のメダル | 12.35px → 12px（−2.8%） |

**上がる方向が大半です。** これまで「いちばん小さい文字」が6通りあり、そのうち4通りが
12px より小さかったためです。

## 範囲外にしたもの

**`bootstrap-subset.css` の `.875em` / `.75em` は触っていません。** `code` `kbd` `pre` `small`
`sub` `sup` の指定で、**vendor の reset** です。`combine_css.js` が先頭に連結するファイルで、
段に寄せるなら「そもそもこの reset が要るか」から見る話になります。#2971 に残します。

段の外に置いた3つもそのままです。`.blog-tags li a span` の `0.5em`（タグの件数の上付き）・
コード行番号の `0.95em`（コードブロックの大きさに対する相対）・404 の 128px。

## 検証

**コンパイル後の差分が `font-size` の54行だけ**（27件の削除 ＋ 27件の追加）であることを確かめました。
`font-size` 以外の宣言は1行も動いていません。

配信中の CSS で、**12.5px 以下の px 指定が `12px`（46件）だけ**になったことも確認しています。
1em 未満の `em` 指定として残るのは、bootstrap の `.75em` / `.875em`（3件）と、
段の外に置いた `0.5em` / `0.95em` の2件だけです。

**溢れが出ないことを実寸で確かめました**（Noto Sans CJK）。

| | 前 | 後 |
| --- | --- | --- |
| フッターの最長行「Cheetah Grid + OSS」 | 134.0px | **137.8px**（列幅は250px以上） |
| フッターのクレド | 232.0px | 252.9px |
| 「記事への問い合わせ」 | 99.0px | 108.0px |
| NEW バッジ | 21.9px | 26.3px |

`.newitem` と `.series-nav-kicker` は `inline-block` ＋ `padding: 0 4px` で幅を持たないので、
文字なりに広がります。器の固定幅や `overflow: hidden` はありません。

CLAUDE.md で `.panel-meta` の 11.7px を名指ししていた2箇所も直しました。

## この後

1. ~~段の定義とスタイルガイド~~（#2975 マージ済み）
2. **添え 27件を `text-meta` へ**（この PR）
3. 行・本文 — 13.65 / 14.3 / 14.95 / 16px が寄る
4. 見出し・ロゴ — 16.9 / 17 / 18.2 / 19.5 / 20.8 / 24.7px が寄る

Refs #2971

🤖 Generated with [Claude Code](https://claude.com/claude-code)
