### PR TITLE
フッターの企業情報に PR TIMES STORY を足す

### DIFF
--- a/themes/future/layout/_partial/footer-columns.ejs
+++ b/themes/future/layout/_partial/footer-columns.ejs
@@ -89,6 +89,9 @@
           <ul class="footer-list footer-list-inline">
             <li><a class="footer-link" href="https://www.future.co.jp/recruit/recruit/rec-career/" target="_blank" rel="noopener">採用情報<span class="sr-only">（外部サイト）</span><%- partial('svg-icon', {icon: 'external-link', class_name: 'svg-icon-trailing'}).trim() %></a></li>
             <li><a class="footer-link" href="https://note.future.co.jp/" target="_blank" rel="noopener">未来報<span class="sr-only">（外部サイト）</span><%- partial('svg-icon', {icon: 'external-link', class_name: 'svg-icon-trailing'}).trim() %></a></li>
+            <%# 会社のストーリー（現在11本）。行き先は個別の記事ではなく一覧（?tab=story）。
+                未来報の隣に置くのは、どちらも会社が出している読み物だから %>
+            <li><a class="footer-link" href="https://prtimes.jp/main/html/searchrlp/company_id/4374?tab=story" target="_blank" rel="noopener">PR TIMES STORY<span class="sr-only">（外部サイト）</span><%- partial('svg-icon', {icon: 'external-link', class_name: 'svg-icon-trailing'}).trim() %></a></li>
             <li><a class="footer-link" href="https://www.future.co.jp/lttf/" target="_blank" rel="noopener">LEAD TO THE FUTURE<span class="sr-only">（外部サイト）</span><%- partial('svg-icon', {icon: 'external-link', class_name: 'svg-icon-trailing'}).trim() %></a></li>
           </ul>
         </div>


### PR DESCRIPTION
## やったこと

フッターの「企業情報」に **PR TIMES STORY** を足した（`_partial/footer-columns.ejs` に1行）。

```
企業情報
  採用情報 ↗   未来報 ↗   PR TIMES STORY ↗   LEAD TO THE FUTURE ↗
```

## 決めたこと3つ

**1. 行き先は一覧。** 個別の記事（`/story/detail/zrPKdkuMw8x`）ではなく会社のストーリー一覧（`/main/html/searchrlp/company_id/4374?tab=story`、**現在11本**）。一覧にすれば本数が増えてもリンクが古くならない。

**2. 置き場所は未来報の隣。** どちらも会社が出している読み物で、採用情報とは役が違う。

**3. ラベルは `PR TIMES STORY`。** PR TIMES 側のページタイトルは「フューチャー株式会社のストーリー｜PR TIMES」で、ブランドは `PR TIMES`（スペースあり）。既存の `LEAD TO THE FUTURE` と同じく行き先自身の名前を出す形に合わせた。表記を変えるならこの1箇所です。

## 確認したこと

配信中のページで、企業情報の4リンクすべてに次が付いていること:

| リンク | `rel="noopener"` | `sr-only`（外部サイト） | 矢印アイコン | ラベルの折り返し |
| --- | --- | --- | --- | --- |
| 採用情報 | ○ | ○ | ○ | 1行 |
| 未来報 | ○ | ○ | ○ | 1行 |
| **PR TIMES STORY** | ○ | ○ | ○ | 1行 |
| LEAD TO THE FUTURE | ○ | ○ | ○ | 1行 |

- **外部リンクの印は #2839 の形**（矢印＋読み上げ用の「（外部サイト）」）。フッターはテキストを持つ外部リンク全部に印を付ける決まりなので、ブランド名でも例外にしない
- `textlint themes/future/layout/_partial/footer-columns.ejs` が通る（`no-unmarked-external-link` は EJS の直書き URL を検査するので、印の付け忘れはここで止まる）
- インラインの並びは幅1280pxで 2行 → **3行**、幅375pxで 1行 → **2行** に増える。ラベルの途中で折り返すものは無い
- リンク先2つ（一覧・個別記事）とも HTTP 200 を確認

## issue はありません

依頼を直接いただいた分なので issue は立てていません。慣習（1 issue 1 PR）に合わせるなら後追いで立てられます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
