### PR TITLE
見出しとロゴを段に寄せ、#2971 を完了する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -469,8 +469,8 @@ bootstrap-subset → theme-styles.styl の順で `/css/site.css` に連結する
   | `body` | 13px | `theme-styles.styl` |
   | 本文（`p` / `li` / `summary`） | `1.2em` = 15.6px | 〃 |
   | 記事タイトル | `clamp(26px, 1.325rem + 0.9vw, 32px)` ＋ `text-wrap: pretty`（#2655。均等化すると「列幅の半分×2行」に縮む） | 〃（1箇所のみ） |
-  | クラス無しの `h2`（関連記事・We're hiring 等） | `1.85em` = 24.05px | 〃 |
-  | サイドバーの `h2` | `1.4em` = 18.2px | 〃 |
+  | クラス無しの `h2`（関連記事・We're hiring 等） | `text-display`（#2971。`1.85em` = 24.05px から） | 〃 |
+  | サイドバーの `h2` | `text-lead`（#2971。`1.4em` = 18.2px から） | 〃 |
   | 本文見出し h2〜h6 | `1.85 / 1.5 / 1.3 / 1.2 / 1.1em` = 24.05 / 19.5 / 16.9 / 15.6 / 14.3px（太さは全て700。直前の空きは h2 56px / h3 32px / h4 以下 24px）。`text-wrap: balance` は**幅768px以上だけ**（#2776 / #2822。狭い列では2行になる見出しが h2 の19.8%に達し、均等に割ると1行目が列の65%しか埋めず折り返しが早く見える） | 〃 |
   | 本文見出し h1（`.article-entry h1`） | 記事タイトルと同じ（`.article-title` / `.list-page` と同一ルール。直前の空き 64px・罫線 2px はここで持つ） | 〃 |
   | 一覧ページの見出し `.list-page` | 記事タイトルと同じ（`.article-title` と同一ルール） | 〃 |
@@ -482,7 +482,7 @@ bootstrap-subset → theme-styles.styl の順で `/css/site.css` に連結する
   | 記事概要文 `.lede`（一覧 / We're hiring カード） | `1.2em` = 15.6px / 継承 = 13px | 〃 |
   | 特設ページの本文 `.specials-text` | `1.2em` = 15.6px（`.article-entry` 外なので明示） | 〃 |
   | コードブロック | 13px（`line-height` は `font-size × leading-row` で追従） | `highlight.styl` の変数 |
-  | ヘッダーのサイト名 `.header-title` / 和文 `.header-title-sub` | 17px / 12px（#2877。写真の上に置いていた 80px / 20px から。字間 0.35em と影は白地では役が無い） | 〃 |
+  | ヘッダーのサイト名 `.header-title` / 和文 `.header-title-sub` | `text-lead` / `text-meta`（#2877 で写真の上の 80px / 20px から。#2971 で 17px → 段の 18px へ。字間 0.35em と影は白地では役が無い） | 〃 |
   | ヘッダーのナビ `.header-nav-link` / ドロップダウン（見出し / 説明） | 14px / 13px / 12px | 〃 |
   | パンくず（`.breadcrumb`） | 14px | `theme-styles.styl` 冒頭（土台の塊）の `font:` 一括指定。フォント名だけ後方で上書き |
 

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -248,7 +248,7 @@ Header and header elements
    幾何学グロテスク）と Segoe UI Variable Display（Win11 の見出し用）を優先し、
    無い環境は従来のシステムスタックに落ちる。固定の英字なので絵文字フォントは要らない */
 .header-title {
-  font-size: 17px;
+  font-size: text-lead;
   line-height: leading-heading;
   font-family: "Avenir Next", "Segoe UI Variable Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
   font-weight: 700;
@@ -2031,11 +2031,11 @@ body {
    .article-entry h2（0,1,1）・.article-title（0,1,0）・.list-page（0,1,0）は
    いずれも詳細度で勝つため、この指定には影響されない */
 h2 {
-  font-size: 1.85em;
+  font-size: text-display;
 }
 /* サイドバーは記事本文の導線ではなく添え物なので、本文の見出しより一段抑える */
 .blog-sidebar h2 {
-  font-size: 1.4em;
+  font-size: text-lead;
 }
 
 /******************************
@@ -3376,7 +3376,7 @@ ul.tag-list {
   border-radius: 50%;
   background: var(--brand-navy);
   color: #fff;
-  font-size: 1.6em;
+  font-size: text-title;
   font-weight: bold;
   /* 字を丸の中心に置く。行の高さが残ると下寄りに見える */
   line-height: 1;
@@ -4013,7 +4013,7 @@ a.series-nav-item:hover .series-nav-item-title {
 .awards-hall-name {
   display: block;
   margin: 8px 0 12px;
-  font-size: 1.9em;
+  font-size: text-display;
   font-weight: bold;
   color: ink-strong;
   text-decoration: none;
@@ -4070,7 +4070,7 @@ a.series-nav-item:hover .series-nav-item-title {
 .award-years .award-year {
   flex: none;
   min-width: 3.2em;
-  font-size: 1.5em;
+  font-size: text-title;
   font-weight: bold;
   color: ink-faint;
   letter-spacing: -0.01em;


### PR DESCRIPTION
#2971 の4本目、最後です。**見出しとロゴの6件を段に寄せます。**

| 部品 | 前 | 後 | 差 |
| --- | --- | --- | --- |
| `.header-title`（サイト名） | 17px | `text-lead` 18px | **+1.00px** |
| `.blog-sidebar h2` | 18.2px | `text-lead` 18px | −0.20px |
| `.author-box-initial`（著者の頭文字） | 20.8px | `text-title` 20px | −0.80px |
| `.award-years .award-year` | 19.5px | `text-title` 20px | +0.50px |
| `h2`（クラス無し。節見出し） | 24.05px | `text-display` 24px | −0.05px |
| `.awards-hall-name`（殿堂の名前） | 24.7px | `text-display` 24px | −0.70px |

**動くのはサイト名の +1px だけ**で、残りは 1px 未満です。

**ヘッダーの帯（64px）に収まることを確かめました。** サイト名 18px ＋ 和文 12px を行間 1.3 で
2段にすると **39.0px**、上下に **12.5px ずつ**残ります（17px のときは 37.7px / 13.1px ずつ）。

`h2`（クラス無し）は `.article-entry h2` とは**別のルール**です。本文見出しの梯子は触っていません。

## これで #2971 の寄せは完了です

残る `font-size` の値は次のとおりで、**すべて段か、段の外と決めたものです**。

| | 件数 | |
| --- | --- | --- |
| **段（7つ）** | 12px 46 / 15.6px 20 / 14px 16 / 13px 11 / 20px 7 / 18px 4 / 24px 3 | — |
| 本文見出しの梯子 | `1.85 / 1.5 / 1.3 / 1.2 / 1.1em` 各1 | 比が階層を作る列 |
| 親の倍率を打ち消す | `1em` 12 / `inherit` 4 | サイズを決めていない |
| `bootstrap-subset.css` | `.875em` 2 / `.75em` 1 / `calc(1.275rem + .3vw)` 1 | vendor の reset |
| 機能で決まる値 | 16px 2（`.header-search input` / `button`） | iOS のズーム下限 |
| アイコンの実寸 | `1.15em` 1（`.snscount-icon`） | ♡ の線が潰れないための相対指定 |
| 一点もの | `clamp(26px, …)` / 128px / `0.5em` / `0.95em` | 記事タイトル・404・タグの件数・コード行番号 |

起票時の **26種類が7段になりました**。`.footer-count` 11.00px と `.archive-list-count` 11.05px の
0.05px 差のような、**見分けの付かない差に別の役が割り当たっている組は残っていません**。

## 検証

- **`font-size` 以外の宣言は1行も動いていません**（置き換え前後の `site.css` を正規化して突き合わせ）
- 値が変わった6ルールを1件ずつ列挙して確認
- 本文見出しの梯子（`.article-entry h2`〜`h6`）が `em` のまま残っていること
- ヘッダーの帯に2段のサイト名が収まること（実測 39.0px / 64px）

Closes #2971

🤖 Generated with [Claude Code](https://claude.com/claude-code)
