### PR TITLE
部品ギャラリーで見えた不整合を直す (#2995)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,16 @@ URL は読者向け、コード配置は保守者向けの分類なので、鏡�
   - **EJS の partial は中身を差し込むスロットを持たない。** ページの骨格のような
     「包む部品」は作れないので、規則として書く側に回す
 
+**ページの骨格は `container > breadcrumb > row > main#main.col-md-9.blog-posts >
+aside.col-md-3.blog-sidebar`**（#2995）。サイドバーを持たないページは
+`main#main.margin-top-30`。
+
+- **`col-xs-*` は書かない。** Bootstrap 5 に無く、`site.css` にも定義が無い。
+  11箇所あったが1つも効いていなかった
+- **`col-sm-12` も足さない。** `.row > *` の既定が `width: 100%` なので、
+  `col-md-9` だけで 768px 未満は全幅になる。`.row` の直下で明示が要るところ
+  （`_partial/archive-post.ejs`）は `col-12`
+
 ## 記事の書き方
 
 ファイル名は `source/_posts/<年>/YYYYMMDD<postid>_<タイトル>.md`。

--- a/themes/future/layout/_partial/archive-post.ejs
+++ b/themes/future/layout/_partial/archive-post.ejs
@@ -7,7 +7,7 @@
   </a>
   <div class="col-sm-8 col-md-8">
   <% } else { %>
-  <div class="col-xs-12">
+  <div class="col-12">
   <% } %>
     <div class="archive-post-item">
       <a href="<%- url_for(post.path) %>">

--- a/themes/future/layout/_partial/featured-post.ejs
+++ b/themes/future/layout/_partial/featured-post.ejs
@@ -1,5 +1,0 @@
-<!-- BEGIN FEATURED POSTS -->
-<div class="widget-wrap">
-  <%- featured_posts(page.permalink, 20, limit) %>
-</div>
-<!-- END FEATURED POSTS -->

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -8,7 +8,7 @@
         {label: page.current + 'ページ目'}
       ])}) %>
   <div class="row">
-    <main id="main" tabindex="-1" class="col-xs-12 col-sm-12 col-md-9 blog-posts">
+    <main id="main" tabindex="-1" class="col-md-9 blog-posts">
   <div class="margin-top-30">
     <h1 class="list-page"><%- partial('_partial/svg-icon', {icon: 'user'}) %><%- page.author %><span class="list-sub-text">さんのページ</span></h1>
     <% if (page.current === 1) { %>
@@ -91,7 +91,7 @@
         出すのはこのページ自身の統計だけ (#2911)。
         列そのものは中身が無くても残す。畳むと本文の幅がこのページだけ広くなり、
         一覧を行き来したときにカードの幅が揃わない (#2944) %>
-    <aside class="col-xs-12 col-sm-12 col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar">
       <%- partial('_partial/sidebar', {showStats: true}) %>
     </aside>
   </div>

--- a/themes/future/layout/category-without.ejs
+++ b/themes/future/layout/category-without.ejs
@@ -9,7 +9,7 @@
         {label: page.current + 'ページ目'}
       ])}) %>
   <div class="row">
-    <main id="main" tabindex="-1" class="col-xs-12 col-sm-12 col-md-9 blog-posts">
+    <main id="main" tabindex="-1" class="col-md-9 blog-posts">
   <div class="margin-top-30">
     <h1 class="list-page"><%- partial('_partial/category-icon', {name: page.category}) %><%- page.category %> <span class="list-sub-text">カテゴリの <%- page.excludedTag %> 以外の記事</span></h1>
     <%# 構成はカテゴリページと同じ。統計・タグ・ランキングは絞り込んだ後の集合で数える %>
@@ -20,7 +20,7 @@
       <li><span class="summary-count"><%= page.withoutPosts.length %></span><br><span class="summary-label">投稿</span></li>
       <li><span class="summary-count"><%= summary.authors %></span><br><span class="summary-label">著者数</span></li>
       <li><span class="summary-count"><%= summary.total %></span><br><span class="summary-label">総シェア数</span></li>
-      <li><span class="summary-count"><%= summary.twitter %></span><br><span class="summary-label">Twitter</span></li>
+      <li><span class="summary-count"><%= summary.twitter %></span><br><span class="summary-label">X</span></li>
       <li><span class="summary-count"><%= summary.facebook %></span><br><span class="summary-label">Facebook</span></li>
       <li><span class="summary-count"><%= summary.hatebu %></span><br><span class="summary-label">はてブ</span></li>
       <li><span class="summary-count"><%= summary.pocket %></span><br><span class="summary-label">Pocket</span></li>
@@ -56,7 +56,7 @@
     <%- partial('_partial/archive', {pagination: config.category, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧', list_note: backLink}) %>
   </div>
     </main>
-    <aside class="col-xs-12 col-sm-12 col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar">
       <%- partial('_partial/sidebar') %>
     </aside>
   </div>

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -12,7 +12,7 @@
         {label: page.current + 'ページ目'}
       ])}) %>
   <div class="row">
-    <main id="main" tabindex="-1" class="col-xs-12 col-sm-12 col-md-9 blog-posts">
+    <main id="main" tabindex="-1" class="col-md-9 blog-posts">
   <div class="margin-top-30">
     <%# カテゴリ単位の購読導線 (#2294)。見出しの行の右端に RSS アイコンを置く %>
     <div class="list-page-header">
@@ -67,7 +67,7 @@
 
   </div>
     </main>
-    <aside class="col-xs-12 col-sm-12 col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar">
       <%- partial('_partial/sidebar', {showStats: true}) %>
     </aside>
   </div>

--- a/themes/future/layout/index.ejs
+++ b/themes/future/layout/index.ejs
@@ -8,7 +8,7 @@
           {label: 'ホーム', url: '/'}
         ].concat(page.current === 1 ? [] : [{label: page.current + 'ページ目'}])}) %>
     <div class="row">
-      <main id="main" tabindex="-1" class="col-xs-12 col-sm-12 col-md-9 blog-posts">
+      <main id="main" tabindex="-1" class="col-md-9 blog-posts">
     <%# ホームにブログの説明が無く、初めて来た読者に何のサイトか伝わらなかった。
         文面はフッターの About Us と同じ theme.about を使い、二重に持たない %>
     <% if (page.current === 1) { %>
@@ -25,9 +25,13 @@
         Twitter の 27,563 に至っては全1466記事の累計 54,471 の半分にあたり、
         数字として破綻している（カウントAPI廃止前後の値が固定されたまま）。
         購読導線として意味のある Feedly だけ、性質の近いフッターの Links へ移した %>
-    <%- partial('_partial/archive', {pagination: config.archive}) %>
+    <%# 総本数は一覧の見出しの行に添える (#2911)。カテゴリ・タグ・著者のページは
+        渡していたのにホームだけ漏れていた (#2995)。2ページ目以降は
+        pagination-info が同じ数を出すので渡さない %>
+    <%- partial('_partial/archive', {pagination: config.archive,
+          list_total: page.current === 1 ? site.posts.length : null}) %>
       </main>
-      <aside class="col-xs-12 col-sm-12 col-md-3 blog-sidebar">
+      <aside class="col-md-3 blog-sidebar">
         <%- partial('_partial/sidebar') %>
       </aside>
     </div>

--- a/themes/future/layout/tag.ejs
+++ b/themes/future/layout/tag.ejs
@@ -8,7 +8,7 @@
         {label: page.current + 'ページ目'}
       ])}) %>
   <div class="row">
-    <main id="main" tabindex="-1" class="col-xs-12 col-sm-12 col-md-9 blog-posts">
+    <main id="main" tabindex="-1" class="col-md-9 blog-posts">
   <div class="margin-top-30">
     <%# タグはページ種別を表す統一アイコン。カテゴリと違って個別の絵柄は割り当てない (#2336) %>
     <h1 class="list-page"><%- partial('_partial/svg-icon', {icon: 'tag'}) %><%- page.tag %> <span class="list-sub-text">タグ</span></h1>
@@ -52,7 +52,7 @@
         出すのはこのページ自身の統計だけ (#2911)。
         列そのものは中身が無くても残す。畳むと本文の幅がこのページだけ広くなり、
         一覧を行き来したときにカードの幅が揃わない (#2944) %>
-    <aside class="col-xs-12 col-sm-12 col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar">
       <%- partial('_partial/sidebar', {showStats: true}) %>
     </aside>
   </div>


### PR DESCRIPTION
#2985 の段階②です。ギャラリー（#2993）で部品の台帳を出したときに見えた不整合を4件直します。**新しい partial は作っていません**（それは段階③）。

## 1. ホームの「新着記事」に「全N本」を出す

#2985 のもともとの動機です。`_partial/archive.ejs` は `list_total` を渡されたときだけ節見出しの右端に添えを出す作りで（#2911）、**カテゴリ・タグ・著者は渡していたのにホームだけ渡していませんでした。** 部品は既にあり、呼び出し側の漏れです。

2ページ目以降は `pagination-info` が同じ数を出すので渡しません（他の3ページと同じ条件）。

## 2. `col-xs-12` の11箇所を落とす

Bootstrap 5 に `col-xs-*` はなく、`public/css/site.css` にも**定義が1件もありません**（`grep -c` = 0）。何も効いていない死んだクラスでした。

同じ骨格が長短2つの形にも割れていたので、**短い形に揃えます。**

| | 変更前 | 変更後 |
| --- | --- | --- |
| `index` / `author` / `category` / `category-without` / `tag` | `col-xs-12 col-sm-12 col-md-9 blog-posts` | `col-md-9 blog-posts` |
| 同上（サイドバー） | `col-xs-12 col-sm-12 col-md-3 blog-sidebar` | `col-md-3 blog-sidebar` |
| `_partial/archive-post.ejs`（サムネの無い枝） | `col-xs-12` | `col-12` |

`col-sm-12` を落として差し支えないのは、**`.row > *` の既定が `width: 100%`** だからです（`site.css`）。768px 未満は `col-md-9` だけで全幅になります。`_partial/archive-post.ejs` は `.row` の直下で明示が要るので、定義のある `col-12` にしました。

残る5画面（`doctor` / `guidelines` / `httf` / `advent-calendar` / `techcast`）は元から短い形なので、これで**全10画面が同じ形**になります。

## 3. 統計タイルのラベルを `X` に揃える

同じ数字（`summary.twitter`）に `X`（`archive.ejs` の3箇所）と `Twitter`（`category-without.ejs`）の2つのラベルが付いていました。`X` に揃えます。

## 4. `_partial/featured-post.ejs` を消す

どのテンプレートからも呼ばれておらず、中で使っている **`featured_posts` ヘルパーも登録されていません**（仮に呼ぶと落ちます）。中の `.widget-wrap` もこのファイルだけの参照でした。ファイルごと消します。

## 確かめたこと

配信中の HTML をパースしました。

**節見出しの添え**（`</h2>` の直後の `section-heading-meta` だけを見る）

| ページ | 添え |
| --- | --- |
| `/` | **全1481本**（新規） |
| `/page/2/` | 添え無し |
| `/categories/Programming/` | 全327本 |
| `/tags/Go/` | 全265本 |
| `/authors/真野隼記/` | 全153本 |

**この PR で新しく出るのはホームの 1481 だけ**で、`source/_posts/**` のフロントマターを直接数えた総記事数（1481）と一致します。他の3つは元から出ていた数字です。

**骨格**

| ページ | `col-xs` | `col-sm-12` | `main` | `aside` |
| --- | ---: | ---: | --- | --- |
| `/` | 0 | 0 | `col-md-9 blog-posts` | `col-md-3 blog-sidebar` |
| `/categories/Programming/` | 0 | 0 | 同上 | 同上 |
| `/tags/Go/` | 0 | 0 | 同上 | 同上 |
| `/authors/` | 0 | 0 | `margin-top-30` | 無し |
| `/articles/2026/` | 0 | 0 | `margin-top-30` | 無し |

**ラベル** — 6ページ分の `summary-label` を集めて `X` 2件・`Twitter` 0件。

**削除** — `widget-wrap` / `featured_posts` の参照が `themes/` と `scripts/` に残っていないことを確認。

## lint

- textlint（変更した6本の `.ejs`）0件
- markdownlint（`make fmt`）0件。`scripts/` は触っていないので prettier の対象に変化なし

## この PR の範囲外

- **echarts の CDN の6重複**（integrity ハッシュまで同一）。script タグを partial にする話なので**段階③**で扱います
- **partial 化の候補1〜4**（統計タイル・傾向パネル・パネルカード・タグチップの列）。段階③で1 PR 1パターンで進めます

Closes #2995
