### PR TITLE
人気の連載を経過年ペナルティで並べる

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -866,7 +866,7 @@ bootstrap-subset → theme-styles.styl の順で `/css/site.css` に連結する
       「リソース」「アクティビティ」は**手で選んだページ3件**＋説明文1行。
       「カテゴリ」は **`/categories/` と同じ全件**（`category_groups()` の群と並び）で、
       18件を5つの群に束ねて2列に並べる。「連載」は
-      **`recent_popular_series(6)` の6件**。どちらも説明は持たず名前だけで、
+      **`popular_series(6)` の6件**。どちらも説明は持たず名前だけで、
       カテゴリだけ累計本数を添える。名前が主題そのものだからで、
       カテゴリの一言説明は `source/_data/categories.yml` を読む個別ページが持つ
     - **全件でないことはラベルが名乗り、条件は `title` が持つ**（#2670）。

--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -55,31 +55,38 @@ hexo.extend.helper.register('recent_popular_tags', function (limit = 10, minRece
   return tags;
 });
 
-// 検索窓のパネルの「人気の連載」(#2855)。物差しは人気のタグと揃える。
-// 同じ面に並ぶ3つの入口が別々の基準で選ばれていると、どれが「いま」を
-// 指しているのか読者には区別できない。
+// ヘッダーのドロップダウンとサイドバーの「人気の連載」(#2855)。
+// **物差しはランキング記事（popular_posts_in）と同じ経過年ペナルティ**。
+// 以前は「直近1年に公開された記事の PV 合計」で、古さで減点する仕組みは無く
+// 1年の窓を出た瞬間に候補から消えていた。窓の中では逆に古い方が有利で
+// （PV を積む時間があるため）、10か月前の連載が最新の連載を上回っていた。
+// 窓を外して1本ずつ 1/(1+経過年^2) で割れば、境目で顔ぶれが飛ばず、
+// 新しさと読まれ方が同じ式の中で釣り合う。
 // 行き先は索引記事（無ければ1本目）で、/series/ の一覧と同じ規則
 const popularSeriesCache = new Map();
 
-hexo.extend.helper.register('recent_popular_series', function (limit = 6, minRecent = 3) {
-  const cacheKey = `${limit}:${minRecent}:${this.site.posts.length}`;
+hexo.extend.helper.register('popular_series', function (limit = 6, minPosts = 3) {
+  const cacheKey = `${limit}:${minPosts}:${this.site.posts.length}`;
   if (popularSeriesCache.has(cacheKey)) return popularSeriesCache.get(cacheKey);
   const YEAR = 365 * 24 * 60 * 60 * 1000;
   const now = Date.now();
+  // popular_posts_in と同じ式（1年落ち=1/2、2年=1/5、4年=1/17）。
+  // 連載は記事の集まりなので、1本ずつ割ってから足す
+  const score = (post) => {
+    const years = (now - post.date.valueOf()) / YEAR;
+    return getGA4PV('/' + post.path) / (1 + years * years);
+  };
   const series = allSeries(this.site)
-    .map((s) => {
-      const recent = s.posts.filter((p) => now - p.date.valueOf() <= YEAR);
-      return {
-        name: s.name,
-        path: s.index.path,
-        total: s.total,
-        recent: recent.length,
-        pv: recent.reduce((sum, p) => sum + getGA4PV('/' + p.path), 0),
-      };
-    })
-    .filter((s) => s.recent >= minRecent && s.pv > 0)
+    .map((s) => ({
+      name: s.name,
+      path: s.index.path,
+      total: s.total,
+      pv: s.posts.reduce((sum, p) => sum + getGA4PV('/' + p.path), 0),
+      score: s.posts.reduce((sum, p) => sum + score(p), 0),
+    }))
+    .filter((s) => s.total >= minPosts && s.score > 0)
     // 同点は名前で決める（決着が無いとビルドごとに並びが変わる）
-    .sort((a, b) => b.pv - a.pv || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+    .sort((a, b) => b.score - a.score || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
     .slice(0, limit);
   popularSeriesCache.set(cacheKey, series);
   return series;

--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -76,13 +76,18 @@ hexo.extend.helper.register('popular_series', function (limit = 6, minPosts = 3)
     const years = (now - post.date.valueOf()) / YEAR;
     return getGA4PV('/' + post.path) / (1 + years * years);
   };
+  // **足したあと √本数 で割る。** 単純な合計だと本数がそのまま効き、27本の
+  // 「春の入門祭り2025」のような大型連載が上位を占める。本数が多い連載は
+  // 実際に盛り上がっているので有利のままにしたいが、効きは弱めたい。
+  // √で割ると効きが指数の半分（N から √N）になり、27本と6本の差は
+  // 4.5倍から2.1倍に縮む。平均にすると本数の効きが完全に消えるので採らない
   const series = allSeries(this.site)
     .map((s) => ({
       name: s.name,
       path: s.index.path,
       total: s.total,
       pv: s.posts.reduce((sum, p) => sum + getGA4PV('/' + p.path), 0),
-      score: s.posts.reduce((sum, p) => sum + score(p), 0),
+      score: s.posts.reduce((sum, p) => sum + score(p), 0) / Math.sqrt(s.total),
     }))
     .filter((s) => s.total >= minPosts && s.score > 0)
     // 同点は名前で決める（決着が無いとビルドごとに並びが変わる）

--- a/themes/future/layout/_partial/header.ejs
+++ b/themes/future/layout/_partial/header.ejs
@@ -86,12 +86,12 @@
 						</details>
 						<p class="header-nav-label">連載</p>
 						<div class="header-dropdown">
-							<%# 連載の行き先は索引記事（/series/ の一覧と同じ規則）。物差しはタグと同じ
-							    「直近1年のPV」(#2855)。カテゴリと違って一覧ページが読者向けにあるので、
-							    最後に全件への導線を置く %>
+							<%# 連載の行き先は索引記事（/series/ の一覧と同じ規則）。物差しはランキング記事と
+							    同じ経過年ペナルティ（#2855 の直近1年の窓から変更）。カテゴリと違って
+							    一覧ページが読者向けにあるので、最後に全件への導線を置く %>
 							<p class="header-dropdown-label"><%- partial('svg-icon', {icon: 'run-baton'}) %>人気の連載</p>
-							<% recent_popular_series(6).forEach(function(s){ %>
-							<a class="header-dropdown-item" href="<%- url_for(s.path) %>" title="<%= s.name %> 連載 全<%= s.total %>本（直近1年 <%= s.recent %>本・<%= s.pv.toLocaleString() %> View）">
+							<% popular_series(6).forEach(function(s){ %>
+							<a class="header-dropdown-item" href="<%- url_for(s.path) %>" title="<%= s.name %> 連載 全<%= s.total %>本・累計 <%= s.pv.toLocaleString() %> View">
 								<span class="header-dropdown-row"><%= s.name %></span>
 							</a>
 							<% }) %>

--- a/themes/future/layout/_widget/series.ejs
+++ b/themes/future/layout/_widget/series.ejs
@@ -1,15 +1,16 @@
-<%# 「人気の連載」(#2892)。物差しは隣の「人気のタグ」とヘッダーのドロップダウンに
-    揃えた直近1年のPV (#2855)。行き先は索引記事で、/series/ の一覧と同じ規則。
+<%# 「人気の連載」(#2892)。物差しはヘッダーのドロップダウンと同じで、ランキング記事と
+    同じ経過年ペナルティ。行き先は索引記事で、/series/ の一覧と同じ規則。
+    **隣の「人気のタグ」はまだ直近1年の窓**なので、2つの枠で基準が違う。
     タグと違ってチップにしないのは、連載名が最長137pxあり142pxの列では
     ほとんどが1行を占めてしまうため（カテゴリと同じ行リストにする） %>
 <%# 3件。ヘッダーのドロップダウンが6件なのに対して半分なのは、カテゴリ18行の下に
     積む場所だから。全件は下の「連載一覧へ」が持つ %>
-<% const series = recent_popular_series(3); %>
+<% const series = popular_series(3); %>
 <% if (series.length){ %>
 <div class="widget">
   <ul class="nav sidebar-series-list">
     <% series.forEach(function(s){ %>
-    <li><a href="<%- url_for(s.path) %>" title="<%= s.name %> 連載 全<%= s.total %>本（直近1年 <%= s.recent %>本・<%= s.pv.toLocaleString() %> View）"><%= s.name %> (<%= s.total %>)</a></li>
+    <li><a href="<%- url_for(s.path) %>" title="<%= s.name %> 連載 全<%= s.total %>本・累計 <%= s.pv.toLocaleString() %> View"><%= s.name %> (<%= s.total %>)</a></li>
     <% }) %>
   </ul>
 </div>


### PR DESCRIPTION
## 何が起きていたか

「人気の連載」（ヘッダーのドロップダウンとサイドバー）は **`recent_popular_series`** が選んでいて、中身はこうでした。

1. 連載ごとに**直近1年に公開された記事だけ**を取る
2. その記事の **PV を単純合計**する
3. 直近1年に3本未満、または PV 0 を捨てる
4. PV の多い順に上位6件

**古さで減点する仕組みは無く、1年より前の記事は最初から数に入りません。** そのため2つの歪みがありました。

- **窓の中では古い方が有利。** 公開から時間が経つほど PV を積めるので、10か月前の連載が最新の連載に勝つ
- **窓を出た瞬間に消える。** 9月末には「秋のブログ週間2025」が丸ごと候補から外れ、顔ぶれが飛ぶ

実際、`秋のブログ週間2025` は 1本あたり 3,867 PV（6本で 23,200）で、`Go1.27リリース` の 1,389 PV/本 を大きく上回っていました。

## やったこと

**ランキング記事（`popular_posts_in`）と同じ経過年ペナルティ `1/(1+経過年²)` を1本ずつ掛けて足す形**にしました（1年落ち=1/2、2年=1/5、4年=1/17）。窓は撤廃しています。

- helper 名を **`recent_popular_series` → `popular_series`** に変更（直近1年で絞らなくなったため）
- 第2引数も `minRecent`（直近1年の本数）→ `minPosts`（全本数の下限）
- `title` の「直近1年 N本・PV View」→「全N本・累計 PV View」

## 並びの変化

**足したあと `√本数` で割っています。** 単純な合計だと本数がそのまま効き、27本の連載が上位を占めるためです。本数が多い連載は実際に盛り上がっているので有利のままにし、効きだけ弱めました（指数が N から √N になり、27本と6本の差は 4.5倍 → 2.1倍）。

| 順 | before（直近1年PV） | after（経過年ペナルティ ÷ √本数） |
| --- | --- | --- |
| 1 | 秋のブログ週間2025（23,200） | **秋のブログ週間2025**（6本） |
| 2 | Go1.26リリース（16,900） | Go1.26リリース（7本） |
| 3 | PostgreSQL18リリース（12,600） | Go1.27リリース（9本） |
| 4 | Go1.27リリース（12,500） | 春の入門祭り2025（**27本**） |
| 5 | 夏の自由研究2025（11,500） | 春の入門祭り2024（**17本**・2.3年前） |
| 6 | Vue.js2025（6,100） | AI Tips（12本） |

**本数の多い連載（27本・17本）は上位に残るので、有利さは保たれています。**

`秋のブログ週間2025` は1位のままですが、理由が変わりました。before は「窓の中で古いほど PV を積める」という仕組みの歪みでしたが、after は **1本あたり 3,867 PV が候補中で最も高い**という実力です（`Go1.27リリース` は 1,389 PV/本）。

### 検討した他の案

| 並べ方 | 1位 | 本数の効き |
| --- | --- | --- |
| 合計のみ | 春の入門祭り2025（27本） | 最大（N） |
| **合計 ÷ √本数（採用）** | **秋のブログ週間2025** | **半分（√N）** |
| 上位5本だけ合計 | 秋のブログ週間2025 | 5本で頭打ち（恣意的な K が要る） |
| 平均 | 秋のブログ週間2025 | なし |

## 揃っていないもの

**隣の「人気のタグ」（`recent_popular_tags`）は直近1年の窓のまま**です。#2855 は「同じ面に並ぶ入口が別々の基準だと読者が区別できない」として2つを揃えていたので、**今は割れています**。

タグも同じ式にすると性格が変わります（実測）。

| | 今（直近1年PV） | 経過年ペナルティ |
| --- | --- | --- |
| 上位 | ガイドライン / Go / 設計 / PostgreSQL / **Claude** / **MCP** | Go / ガイドライン / 設計 / **AWS** / **Python** / **Docker** |

「いま読まれているタグ」から「通算で強いタグ」に変わり、`Claude` や `MCP` が上位から落ちます。**揃えるかどうかは判断が要る**ので、この PR では触っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
