### PR TITLE
パネルカードを partial にする (#2999)

### DIFF
--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -124,26 +124,16 @@
     <div class="row g-4">
       <% shownPanels.forEach(function(p){ %>
       <div class="col-12 col-md-6">
-        <div class="article-card series-panel h-100">
-          <% if (p.thumb) { %>
-          <a href="<%= p.url %>" title="<%= p.title %>" class="thumb-link panel-thumb<%= p.thumb.contain ? ' panel-thumb-contain' : '' %>" tabindex="-1" aria-hidden="true">
-            <img src="<%= p.thumb.src %>" alt="" width="<%= p.thumb.width %>" height="<%= p.thumb.height %>" loading="lazy">
-          </a>
-          <% } else { %>
-          <%# 旬の2枚に専用の絵は無い。サムネの無い連載（/series/）と同じ空き枠で行頭を揃える %>
-          <span class="panel-thumb panel-thumb-empty"></span>
-          <% } %>
-          <div class="panel-body">
-            <%# ラベルはリンクの外に置く。同じ行き先のリンクを1枚のカードに
-                2つ置かない (#2845) のと、種別はカードの属性であって導線ではないため %>
-            <span class="panel-label"><%- partial('svg-icon', {icon: p.labelIcon}) %><%= p.label %></span>
-            <a href="<%= p.url %>" class="panel-title"><%= p.title %></a>
-            <div class="panel-meta"><%= p.meta %></div>
-            <% if (!sharedMore) { %>
-            <p class="more-link"><a href="<%= p.more.url %>"><%= p.more.text %><%- partial('svg-icon', {icon: 'chevron-right', class_name: 'svg-icon-trailing'}).trim() %></a></p>
-            <% } %>
-          </div>
-        </div>
+        <%# 旬の2枚に専用の絵が無いときは空き枠。サムネの無い連載（/series/）と行頭を揃える。
+            全件導線は、2枚の行き先が同じならこの節の下にまとめる (#2892) %>
+        <%- partial('panel-card', {
+              url: p.url,
+              title: p.title,
+              thumb: p.thumb,
+              label: {icon: p.labelIcon, text: p.label},
+              meta: p.meta,
+              more: sharedMore ? null : p.more,
+            }) %>
       </div>
       <% }) %>
     </div>

--- a/themes/future/layout/_partial/panel-card.ejs
+++ b/themes/future/layout/_partial/panel-card.ejs
@@ -1,0 +1,50 @@
+<%# パネルカード1枚 (#2999)。ホームの「特集」・/specials/ の記事パネル・
+    /series/ の連載・HTTF の歴代コンテストが同じ形を持つ。
+
+    **列は呼び出し側が持つ。** 2列（ホームの特集）と3列（それ以外）で違い、
+    グリッドの都合はカードの都合ではない。ここが描くのはカード1枚だけ。
+
+    引数:
+      url      行き先（必須）
+      title    題（必須）
+      thumb    {src, width, height, contain} か null。null なら空き枠を出す
+      label    {icon, text} か null。種別の名札 (#2892)
+      meta     題の下の添え。**HTML を受け取る**（HTTF はリンクを含む）
+      more     {url, text} か null。カードごとの全件導線
+      external true なら別タブで開く
+
+    **サムネのリンクは tabindex="-1" aria-hidden="true" を必ず持つ。**
+    同じ行き先のリンクを1枚のカードに2つ置かない (#2845)。4箇所で手書きしていて
+    付け忘れが起きうる場所だったので、ここに1つだけ持つ %>
+<%# 省略できる引数は既定を置く。EJS は未定義の識別子で落ちるので、
+    呼び出し側に「使わない引数も渡す」を強いない %>
+<%
+  const panelThumb = typeof thumb === 'undefined' ? null : thumb;
+  const panelLabel = typeof label === 'undefined' ? null : label;
+  const panelMeta = typeof meta === 'undefined' ? null : meta;
+  const panelMore = typeof more === 'undefined' ? null : more;
+  const panelBlank = (typeof external !== 'undefined' && external) ? ' target="_blank" rel="noopener"' : '';
+%>
+<div class="article-card series-panel h-100">
+  <% if (panelThumb) { %>
+  <a href="<%= url %>" title="<%= title %>" class="thumb-link panel-thumb<%= panelThumb.contain ? ' panel-thumb-contain' : '' %>" tabindex="-1" aria-hidden="true"<%- panelBlank %>>
+    <img src="<%= panelThumb.src %>" alt="" width="<%= panelThumb.width %>" height="<%= panelThumb.height %>" loading="lazy">
+  </a>
+  <% } else { %>
+  <%# サムネの無いものは同じ大きさの空き枠で行頭を揃える（post_list.js と同じ流儀） %>
+  <span class="panel-thumb panel-thumb-empty"></span>
+  <% } %>
+  <div class="panel-body">
+    <%# 名札はリンクの外に置く。種別はカードの属性であって導線ではない (#2892) %>
+    <% if (panelLabel) { %>
+    <span class="panel-label"><%- partial('svg-icon', {icon: panelLabel.icon}) %><%= panelLabel.text %></span>
+    <% } %>
+    <a href="<%= url %>" class="panel-title"<%- panelBlank %>><%= title %></a>
+    <% if (panelMeta) { %>
+    <div class="panel-meta"><%- panelMeta %></div>
+    <% } %>
+    <% if (panelMore) { %>
+    <p class="more-link"><a href="<%= panelMore.url %>"><%= panelMore.text %><%- partial('svg-icon', {icon: 'chevron-right', class_name: 'svg-icon-trailing'}).trim() %></a></p>
+    <% } %>
+  </div>
+</div>

--- a/themes/future/layout/_partial/post-panel-grid.ejs
+++ b/themes/future/layout/_partial/post-panel-grid.ejs
@@ -5,20 +5,13 @@
 <div class="series-panels row g-4">
   <% posts.forEach(function(p){ %>
   <div class="col-12 col-md-6 col-lg-4">
-    <div class="article-card series-panel h-100">
-      <% if (p.thumbnail) { %>
-      <a href="<%- url_for(p.path) %>" title="<%= p.title %>" class="thumb-link panel-thumb" tabindex="-1" aria-hidden="true">
-        <img src="<%= p.thumbnail %>" alt="" width="200" height="135" loading="lazy">
-      </a>
-      <% } else { %>
-      <span class="panel-thumb panel-thumb-empty"></span>
-      <% } %>
-      <div class="panel-body">
-        <a href="<%- url_for(p.path) %>" class="panel-title"><%= p.title %></a>
-        <%# 推薦パネルの日付は鮮度の目安なので年月まで (#2404) %>
-        <div class="panel-meta"><%= date(p.date, 'YYYY.MM') %></div>
-      </div>
-    </div>
+    <%# 推薦パネルの日付は鮮度の目安なので年月まで (#2404) %>
+    <%- partial('panel-card', {
+          url: url_for(p.path),
+          title: p.title,
+          thumb: p.thumbnail ? {src: p.thumbnail, width: 200, height: 135} : null,
+          meta: date(p.date, 'YYYY.MM'),
+        }) %>
   </div>
   <% }) %>
 </div>

--- a/themes/future/layout/gallery.ejs
+++ b/themes/future/layout/gallery.ejs
@@ -168,6 +168,31 @@
         <%- partial('_partial/archive-post', {post: samplePost, index: false}) %>
       </div>
       <div class="gallery-item">
+        <p class="gallery-name"><code>_partial/panel-card</code></p>
+        <%# 名札あり・サムネ無し・別タブの3通り。列は呼び出し側が持つので、
+            見本でも col を書いて並べる %>
+        <div class="series-panels row g-4">
+          <div class="col-12 col-md-6">
+            <%- partial('_partial/panel-card', {
+                  url: url_for(samplePost.path),
+                  title: samplePost.title,
+                  thumb: {src: samplePost.thumbnail, width: 200, height: 135},
+                  label: {icon: 'run-baton', text: '連載'},
+                  meta: '全9本・2026.08 更新',
+                  more: {url: '/series/', text: '連載一覧へ'},
+                }) %>
+          </div>
+          <div class="col-12 col-md-6">
+            <%- partial('_partial/panel-card', {
+                  url: 'https://atcoder.jp/',
+                  title: 'サムネイルの無いカード（別タブで開く）',
+                  meta: 'panel-thumb-empty で行頭を揃える',
+                  external: true,
+                }) %>
+          </div>
+        </div>
+      </div>
+      <div class="gallery-item">
         <p class="gallery-name"><code>_partial/post-panel-grid</code></p>
         <%- partial('_partial/post-panel-grid', {posts: samples.panelPosts}) %>
       </div>

--- a/themes/future/layout/httf.ejs
+++ b/themes/future/layout/httf.ejs
@@ -31,20 +31,18 @@
       <div class="series-panels row g-4">
         <% httfContests.forEach(function(c){ %>
         <div class="col-12 col-md-6 col-lg-4">
-          <div class="article-card series-panel h-100">
-            <%# ロゴは切り抜くと欠けるので contain 表示（panel-thumb-contain） %>
-            <a href="<%= c.url %>" title="<%= c.title %>" class="thumb-link panel-thumb panel-thumb-contain" tabindex="-1" aria-hidden="true" target="_blank" rel="noopener">
-              <img src="/httf_logo.png" alt="" width="640" height="280" loading="lazy">
-            </a>
-            <div class="panel-body">
-              <%# このページは読み物（歴代の記録）なので外部リンクの印は付けない (#2729)。
-                  行き先は冒頭の本文が「2018年から毎年 AtCoder…」と名乗っている %>
-              <a href="<%= c.url %>" class="panel-title" target="_blank" rel="noopener"><%= c.title %></a>
-              <div class="panel-meta">
-                <% if (c.final) { %><a href="<%= c.url %>" target="_blank" rel="noopener"><%= c.qualLabel %></a>・<a href="<%= c.final %>" target="_blank" rel="noopener">本選</a><% } else { %><%= c.meta %><% } %>
-              </div>
-            </div>
-          </div>
+          <%# ロゴは切り抜くと欠けるので contain 表示。
+              このページは読み物（歴代の記録）なので外部リンクの印は付けない (#2729)。
+              行き先は冒頭の本文が「2018年から毎年 AtCoder…」と名乗っている %>
+          <%- partial('_partial/panel-card', {
+                url: c.url,
+                title: c.title,
+                thumb: {src: '/httf_logo.png', width: 640, height: 280, contain: true},
+                meta: c.final
+                  ? `<a href="${c.url}" target="_blank" rel="noopener">${c.qualLabel}</a>・<a href="${c.final}" target="_blank" rel="noopener">本選</a>`
+                  : c.meta,
+                external: true,
+              }) %>
         </div>
         <% }) %>
       </div>

--- a/themes/future/layout/series.ejs
+++ b/themes/future/layout/series.ejs
@@ -61,22 +61,14 @@
       <div class="series-panels row g-4">
         <% list.forEach(function(s){ %>
         <div class="col-12 col-md-6 col-lg-4">
-          <div class="article-card series-panel h-100">
-            <% if (s.index.thumbnail) { %>
-            <a href="<%- url_for(s.index.path) %>" title="<%= s.name %>" class="thumb-link panel-thumb" tabindex="-1" aria-hidden="true">
-              <img src="<%= s.index.thumbnail %>" alt="" width="200" height="135" loading="lazy">
-            </a>
-            <% } else { %>
-            <%# サムネの無い連載は同じ大きさの空き枠で行頭を揃える（post_list.js と同じ流儀） %>
-            <span class="panel-thumb panel-thumb-empty"></span>
-            <% } %>
-            <div class="panel-body">
-              <a href="<%- url_for(s.index.path) %>" class="panel-title"><%= s.name %></a>
-              <%# 期間は連載の活動期間（初回〜最新）。単月で終わった連載は1つだけ名乗る %>
-              <% const first = date(s.first, 'YYYY.MM'); const latest = date(s.latest, 'YYYY.MM'); %>
-              <div class="panel-meta">全<%= s.total %>本・<%= first === latest ? first : first + ' 〜 ' + latest %></div>
-            </div>
-          </div>
+          <%# 期間は連載の活動期間（初回〜最新）。単月で終わった連載は1つだけ名乗る %>
+          <% const first = date(s.first, 'YYYY.MM'); const latest = date(s.latest, 'YYYY.MM'); %>
+          <%- partial('_partial/panel-card', {
+                url: url_for(s.index.path),
+                title: s.name,
+                thumb: s.index.thumbnail ? {src: s.index.thumbnail, width: 200, height: 135} : null,
+                meta: '全' + s.total + '本・' + (first === latest ? first : first + ' 〜 ' + latest),
+              }) %>
         </div>
         <% }) %>
       </div>


### PR DESCRIPTION
#2999（段階③）の**候補3・パネルカード**です。1 PR 1パターンなので、これだけを入れます。

## 何を集めたか

同じカードを4箇所で書いていました。

| 呼び出し元 | 中身 | 列 |
| --- | --- | --- |
| `_partial/archive.ejs` | ホームの「特集」 | 2列 |
| `_partial/post-panel-grid.ejs` | `/specials/` の記事パネル | 3列 |
| `series.ejs` | `/series/` の連載 | 3列 |
| `httf.ejs` | HTTF の歴代コンテスト | 3列 |

`_partial/panel-card.ejs` に集め、差分は**引数で吸収**します。

| 引数 | |
| --- | --- |
| `url` / `title` | 必須 |
| `thumb` | `{src, width, height, contain}` か `null`（`null` なら空き枠） |
| `label` | `{icon, text}` か `null`。種別の名札（#2892） |
| `meta` | 題の下の添え。**HTML を受け取る**（HTTF はリンクを含む） |
| `more` | `{url, text}` か `null`。カードごとの全件導線 |
| `external` | `true` なら別タブ |

**列は呼び出し側が持ちます。** 2列（特集）と3列（それ以外）で違い、グリッドの都合はカードの都合ではないためです。ここが描くのはカード1枚だけで、`post-panel-grid.ejs` はグリッドの partial として残ります。

## いちばんの動機

**サムネのリンクの `tabindex="-1" aria-hidden="true"` を4箇所すべてが手書きしていました。** 同じ行き先のリンクを1枚のカードに2つ置かない（#2845）ための指定で、**付け忘れてもエラーにならず、キーボードと支援技術で空振りが増えるだけ**の場所です。1箇所に集めました。

## 確かめたこと

**カード144枚の生成 HTML を前後比較しました**（`<div class="article-card series-panel h-100">…` を抜き出し、タグ間の空白を正規化）。

| ページ | 枚数 | |
| --- | ---: | --- |
| `/` | 2 | 一致 |
| `/series/` | 78 | 一致 |
| `/specials/httf/` | 24 | 一致（差はタグ間の空白のみ・下記） |
| `/specials/guidelines/` | 28 | 一致 |
| `/specials/advent-calendar/` | 10 | 一致 |
| `/specials/techcast/` | 2 | 一致 |

HTTF だけ1文字も同じにはなりません。もとの markup は `panel-meta` の中身を改行して書いていたので、そこだけ前後の空白が消えます。**構造・属性・テキストは同一**です。

```
before: <div class="panel-meta"> AtCoder Heuristic Contest 056 </div>
after : <div class="panel-meta">AtCoder Heuristic Contest 056</div>
```

`grep` で `article-card series-panel h-100` の定義が `_partial/panel-card.ejs` の1箇所だけになったことも確認しました。

## ギャラリー

「かたまり」の節に `_partial/panel-card` の見本を足しました（名札＋全件導線つきと、サムネ無し＋別タブの2枚）。**台帳は22件、警告0件**です。

## lint

- textlint（変更した6本の `.ejs`）0件
- markdownlint（`make fmt`）0件。`scripts/` は触っていないので prettier の対象に変化なし

## 残り（#2999）

候補2（傾向パネル・5画面）／4（タグチップの列・5画面）／5（echarts の読み込み・6重複）。

なお #3000 で見つけた **`category-without.ejs` だけシェアの内訳に `summary-sub` が付いていない**件は、まだ手を付けていません（見た目が変わるので別で判断）。
