### PR TITLE
傾向パネルを partial にする (#2999)

### DIFF
--- a/themes/future/layout/_partial/author-tendencies.ejs
+++ b/themes/future/layout/_partial/author-tendencies.ejs
@@ -8,24 +8,13 @@
 <% const as = author_stats(page.author); %>
 <% if (as.topCategories.length) { %>
 <%- partial('section-heading', {id: 'topcategories', text: 'よく使うカテゴリ'}) %>
-<ul class="tendency-panels">
-  <% as.topCategories.forEach(function(c){ %>
-  <li class="tendency-panel">
-    <%# カテゴリはタグと誤認しないようチップにせず、記事メタデータと同じテキストリンク %>
-    <a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事へ"><%- partial('category-icon', {name: c.name}) %><%= c.name %></a>
-    <span class="tendency-panel-count"><%= c.count %>本投稿</span>
-  </li>
-  <% }) %>
-</ul>
+<%- partial('tendency-panels', {kind: 'category', items: as.topCategories.map(function(c){
+      return {name: c.name, path: c.path, title: `${c.name} カテゴリの記事へ`, note: `${c.count}本投稿`};
+    })}) %>
 <% } %>
 <% if (as.topTags.length) { %>
 <%- partial('section-heading', {id: 'toptags', text: 'よく使うタグ'}) %>
-<ul class="tendency-panels">
-  <% as.topTags.forEach(function(t){ %>
-  <li class="tendency-panel">
-    <a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.name %> タグの記事へ"><%= t.name %></a>
-    <span class="tendency-panel-count"><%= t.count %>本投稿</span>
-  </li>
-  <% }) %>
-</ul>
+<%- partial('tendency-panels', {kind: 'tag', items: as.topTags.map(function(t){
+      return {name: t.name, path: t.path, title: `${t.name} タグの記事へ`, note: `${t.count}本投稿`};
+    })}) %>
 <% } %>

--- a/themes/future/layout/_partial/related-categories.ejs
+++ b/themes/future/layout/_partial/related-categories.ejs
@@ -10,14 +10,9 @@
   <section class="popular-articles margin-bottom-20">
     <% if (rc.length) { %>
     <%- partial('section-heading', {id: 'relatedcategories', text: '関連カテゴリ'}) %>
-    <ul class="tendency-panels">
-      <% rc.forEach(function(c){ %>
-      <li class="tendency-panel">
-        <a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事へ"><%- partial('category-icon', {name: c.name}) %><%= c.name %></a>
-        <span class="tendency-panel-count"><%= c.tags.join('・') %>を共有</span>
-      </li>
-      <% }) %>
-    </ul>
+    <%- partial('tendency-panels', {kind: 'category', items: rc.map(function(c){
+          return {name: c.name, path: c.path, title: `${c.name} カテゴリの記事へ`, note: `${c.tags.join('・')}を共有`};
+        })}) %>
     <% } %>
     <%# 1つのタグがカテゴリの過半数を占めると、それ以外の記事に辿り着けない。
         絞り込む側はタグページが担うので、除いた側だけ導線を出す (#2038)。

--- a/themes/future/layout/_partial/related-tags.ejs
+++ b/themes/future/layout/_partial/related-tags.ejs
@@ -40,16 +40,12 @@
                : `${t.name} の記事 ${t.posts}本（うち ${page.tag} と共通 ${t.co}本）`; %>
     <% groups.forEach(function(g){ %>
     <h3 class="panels-label"><%= labels[g.kind] %></h3>
-    <ul class="tendency-panels">
-      <% g.tags.forEach(function(t){ %>
-      <li class="tendency-panel">
-        <a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= note(g.kind, t) %>"><%= t.name %></a>
-        <%# 隣接だけは共通本数が関係の強さそのもの。他の2群は移動先の本数
-            （＝押した先の一覧の長さ）を出す %>
-        <span class="tendency-panel-count"><%= g.kind === 'adjacent' ? `${t.co}本を共有` : `${t.posts}本` %></span>
-      </li>
-      <% }) %>
-    </ul>
+    <%# 隣接だけは共通本数が関係の強さそのもの。他の2群は移動先の本数
+        （＝押した先の一覧の長さ）を出す %>
+    <%- partial('tendency-panels', {kind: 'tag', items: g.tags.map(function(t){
+          return {name: t.name, path: t.path, title: note(g.kind, t),
+                  note: g.kind === 'adjacent' ? `${t.co}本を共有` : `${t.posts}本`};
+        })}) %>
     <% }) %>
   </section>
 </aside>

--- a/themes/future/layout/_partial/tendency-panels.ejs
+++ b/themes/future/layout/_partial/tendency-panels.ejs
@@ -1,0 +1,26 @@
+<%# 傾向パネル (#2999)。著者の「よく使うカテゴリ／タグ」・カテゴリの
+    「よく使われるタグ」「関連カテゴリ」・タグの「よく使われるカテゴリ」「関連タグ」が
+    同じ形を持つ。
+
+    引数:
+      kind  'category' か 'tag'
+      items [{name, path, title, note}]
+
+    **カテゴリはチップにしない。** タグと誤認されるので、記事のメタ行と同じ
+    テキストリンク＋アイコンで描く。この見分けが2つの枝の理由そのもの。
+
+    **note（右の添え）は呼び出し側が文にする。** 「n本投稿」「n本で使用」
+    「n本が所属」「◯◯を共有」と場所ごとに意味が違い、数字だけにすると
+    何を数えたのかが読めなくなる (#2129) %>
+<ul class="tendency-panels">
+  <% items.forEach(function(i){ %>
+  <li class="tendency-panel">
+    <% if (kind === 'category') { %>
+    <a class="article-category-link" href="<%- url_for(i.path) %>" title="<%= i.title %>"><%- partial('category-icon', {name: i.name}) %><%= i.name %></a>
+    <% } else { %>
+    <a class="tag-list-link" href="<%- url_for(i.path) %>" rel="tag" title="<%= i.title %>"><%= i.name %></a>
+    <% } %>
+    <span class="tendency-panel-count"><%= i.note %></span>
+  </li>
+  <% }) %>
+</ul>

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -46,14 +46,9 @@
         tendency-panel の作りに揃える。チップは通常のタグ表現のまま、
         カテゴリ内の本数はパネル側が「n本で使用」と名乗る (#2129) %>
     <%- partial('_partial/section-heading', {id: 'toptags', text: 'よく使われるタグ'}) %>
-    <ul class="tendency-panels">
-      <% cs.topTags.forEach(function(t){ %>
-      <li class="tendency-panel">
-        <a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.name %> タグの記事へ"><%= t.name %></a>
-        <span class="tendency-panel-count"><%= t.count %>本で使用</span>
-      </li>
-      <% }) %>
-    </ul>
+    <%- partial('_partial/tendency-panels', {kind: 'tag', items: cs.topTags.map(function(t){
+          return {name: t.name, path: t.path, title: `${t.name} タグの記事へ`, note: `${t.count}本で使用`};
+        })}) %>
     <% } %>
     <%- partial('_partial/related-categories') %>
     <% } %>

--- a/themes/future/layout/gallery.ejs
+++ b/themes/future/layout/gallery.ejs
@@ -156,6 +156,17 @@
         <% } %>
       </div>
       <div class="gallery-item">
+        <p class="gallery-name"><code>_partial/tendency-panels</code></p>
+        <%# カテゴリはチップにせずテキストリンク＋アイコン、タグはチップ。
+            この見分けが2つの枝の理由そのもの %>
+        <%- partial('_partial/tendency-panels', {kind: 'category', items: category_groups()[0].categories.slice(0, 3).map(function(c){
+              return {name: c.name, path: c.path, title: `${c.name} カテゴリの記事へ`, note: `${c.count}本が所属`};
+            })}) %>
+        <%- partial('_partial/tendency-panels', {kind: 'tag', items: recent_popular_tags(3).map(function(t){
+              return {name: t.name, path: t.path, title: `${t.name} タグの記事へ`, note: `${t.count}本で使用`};
+            })}) %>
+      </div>
+      <div class="gallery-item">
         <p class="gallery-name"><code>_partial/social-button</code></p>
         <%- partial('_partial/social-button', {post: samplePost, actions: true}) %>
       </div>

--- a/themes/future/layout/tag.ejs
+++ b/themes/future/layout/tag.ejs
@@ -31,14 +31,9 @@
     <% const tc = tag_stats(page.tag); %>
     <% if (tc && tc.topCategories.length) { %>
     <%- partial('_partial/section-heading', {id: 'topcategories', text: 'よく使われるカテゴリ'}) %>
-    <ul class="tendency-panels">
-      <% tc.topCategories.forEach(function(c){ %>
-      <li class="tendency-panel">
-        <a class="article-category-link" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事へ"><%- partial('_partial/category-icon', {name: c.name}) %><%= c.name %></a>
-        <span class="tendency-panel-count"><%= c.count %>本が所属</span>
-      </li>
-      <% }) %>
-    </ul>
+    <%- partial('_partial/tendency-panels', {kind: 'category', items: tc.topCategories.map(function(c){
+          return {name: c.name, path: c.path, title: `${c.name} カテゴリの記事へ`, note: `${c.count}本が所属`};
+        })}) %>
     <% } %>
     <% } else { %>
     <%- partial('_partial/pagination-info', {total: count_tag(page.tag)}) %>


### PR DESCRIPTION
#2999（段階③）の**候補2・傾向パネル**です。1 PR 1パターンなので、これだけを入れます。

## 何を集めたか

同じ形を**5画面6箇所**で書いていました。

| 呼び出し元 | 節 | 種別 |
| --- | --- | --- |
| `_partial/author-tendencies.ejs` | よく使うカテゴリ | カテゴリ |
| 〃 | よく使うタグ | タグ |
| `_partial/related-categories.ejs` | 関連カテゴリ | カテゴリ |
| `_partial/related-tags.ejs` | 関連タグ（3群） | タグ |
| `category.ejs` | よく使われるタグ | タグ |
| `tag.ejs` | よく使われるカテゴリ | カテゴリ |

`_partial/tendency-panels.ejs` に集め、差分は**引数2つ**で吸収します。

| 引数 | |
| --- | --- |
| `kind` | `'category'` か `'tag'` |
| `items` | `[{name, path, title, note}]` |

**カテゴリはチップにせずテキストリンク＋アイコンで描きます。** タグと誤認されないための区別で、**これが2つの枝の理由そのもの**です。

**`note`（右の添え）は呼び出し側が文にします。** 「n本投稿」「n本で使用」「n本が所属」「◯◯を共有」と場所ごとに意味が違い、数字だけにすると何を数えたのかが読めなくなるためです（#2129）。

## 確かめたこと

**6ページ14ブロック99項目の生成 HTML を前後比較しました**（`<ul class="tendency-panels">…</ul>` を抜き出し、タグ間の空白を正規化）。

| ページ | ブロック | 項目 |
| --- | ---: | ---: |
| `/authors/真野隼記/` | 2 | 13 |
| `/authors/澁川喜規/` | 2 | 13 |
| `/categories/Programming/` | 2 | 10 |
| `/categories/DevOps/` | 2 | 9 |
| `/tags/Go/` | 3 | 33 |
| `/tags/AWS/` | 3 | 21 |

**差分は0**です（`diff -r` で1件も出ません）。関連タグの3群（隣接・版・年）で `note` が出し分けられていることも、この一致で担保されています。

`grep` で `<ul class="tendency-panels">` の定義が partial の1箇所だけになったことも確認しました。

## ギャラリー

「部品」の節に `_partial/tendency-panels` の見本を足しました（カテゴリ版とタグ版を並べて、チップかテキストリンクかの違いが見えるように）。**台帳は23件、警告0件**です。

## lint

- textlint（変更した7本の `.ejs`）0件
- markdownlint（`make fmt`）0件。`scripts/` は触っていないので prettier の対象に変化なし

## 残り（#2999）

候補4（タグチップの列・5画面）／5（echarts の読み込み・6重複）。

`category-without.ejs` の `summary-sub` の件（#3000 で見つけたもの）はまだ持ち越しています。
