### PR TITLE
引き出しの「連載の一覧を見る」の仕切り線を項目にそろえる

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -688,6 +688,18 @@ Header and header elements
   .header-dropdown-label {
     padding: 0 (space-step * 3);
   }
+  /* 全件への導線の仕切り線を、項目の文字と同じ位置で始めて終える。
+     引き出しではパネルが横の余白を持たない（上の padding: 0 0 …）ので、
+     線だけが画面の端から端まで伸びていた。項目とラベルは自分の padding で
+     12px 内側にいるため、線1本だけが外へ出ている状態だった。
+     .header-nav で絞るのは、同じクラスを使う検索窓のヒントパネルが
+     別の器（自分の余白を持つ）にいるため */
+  .header-nav .header-dropdown-more {
+    margin-left: (space-step * 3);
+    margin-right: (space-step * 3);
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 /* breadcrumb */
 .breadcrumb {

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -688,17 +688,16 @@ Header and header elements
   .header-dropdown-label {
     padding: 0 (space-step * 3);
   }
-  /* 全件への導線の仕切り線を、項目の文字と同じ位置で始めて終える。
-     引き出しではパネルが横の余白を持たない（上の padding: 0 0 …）ので、
-     線だけが画面の端から端まで伸びていた。項目とラベルは自分の padding で
-     12px 内側にいるため、線1本だけが外へ出ている状態だった。
+  /* 全件への導線の仕切り線は引き出しでは引かない。線はドロップダウン
+     （幅288px の浮いたパネル）の中で「下に付いている1行」を示すためのもので、
+     画面いっぱいの引き出しでは幅351pxの罫線になり、節の区切りに見えてしまう。
+     引き出しでは次の組の見出し（「リソース」）が区切りを持っているので、
+     ここは間隔だけで足りる（まとまりは間隔の差が作る #2747）。
      .header-nav で絞るのは、同じクラスを使う検索窓のヒントパネルが
-     別の器（自分の余白を持つ）にいるため */
+     別の器（浮いたパネル）にいるため */
   .header-nav .header-dropdown-more {
-    margin-left: (space-step * 3);
-    margin-right: (space-step * 3);
-    padding-left: 0;
-    padding-right: 0;
+    margin-top: (space-step * 2);
+    border-top: 0;
   }
 }
 /* breadcrumb */


### PR DESCRIPTION
## やったこと

ハンバーガーメニュー（1024px 以下の引き出し）の「連載の一覧を見る」の**仕切り線を引かないようにしました**。間隔（8px）だけで分けます。

| | before | 中間 | after |
| --- | --- | --- | --- |
| 線（幅375px） | 0〜375px | 12〜363px | **引かない** |
| 上の空き | 4px | 4px | **8px** |

**最初は「線を項目の文字にそろえる」だけにしましたが（12〜363px）、幅375pxでは12pxの余白は目立たず「端まで」のままに見えました。** レビューでの指摘を受けて線そのものをやめています。

## 原因

引き出しでは `.header-dropdown` の横の余白を 0 にしています（`padding: 0 0 (space-step * 3)`）。項目とラベルは**自分の padding で 12px 内側**にいるので文字はそろっていましたが、`.header-dropdown-more` の `border-top` は要素の幅いっぱいに引かれるため、**線だけが外へ出ていました**。

## なぜ線をやめるのか

線の役は**ドロップダウン（幅288pxの浮いたパネル）の中で「下に付いている1行」を示すこと**です。画面いっぱいの引き出しでは同じ線が幅351pxの罫線になり、**節の区切りに見えます**。

引き出しでは次の組の見出し（「リソース」）が区切りを持っているので、ここは間隔だけで足ります（まとまりは間隔の差が作る、#2747）。

**`.header-nav` で絞っています。** 同じ `.header-dropdown-more` クラスを検索窓のヒントパネル（「すべてのタグを見る」）も使っていますが、あちらは浮いたパネルなので線はそのままです（実測 1px のまま）。デスクトップのドロップダウンの線も変わりません（実測 1px `rule-weak`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
