### PR TITLE
タグチップの列を partial にする (#2999)

### DIFF
--- a/themes/future/layout/_partial/tag-chips.ejs
+++ b/themes/future/layout/_partial/tag-chips.ejs
@@ -1,0 +1,16 @@
+<%# タグチップの列 (#2999)。サイドバーの「人気のタグ」・/categories/ と
+    「◯◯以外の記事」の代表タグ・/tags/ の新着タグ・ガイドラインの関連タグが
+    同じ形を持つ。
+
+    引数:
+      items [{name, path, label, title, count}]
+        label 省略時は name。count を渡すと右肩に総数を出す (#2129)
+        title 省略時は属性ごと出さない
+
+    **記事のタグ（_partial/post/tag）とは別物なので統合しない。** あちらは
+    ul を持たず、1記事だけのタグを非リンクの .tag-list-text で描く %>
+<ul class="tag-list">
+  <% items.forEach(function(t){ %>
+  <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag"<%- t.title ? ` title="${t.title}"` : '' %>><%= t.label || t.name %><% if (t.count) { %><span class="tag-list-count"><%= t.count %></span><% } %></a></li>
+  <% }) %>
+</ul>

--- a/themes/future/layout/_widget/tag.ejs
+++ b/themes/future/layout/_widget/tag.ejs
@@ -5,11 +5,11 @@
 <% const tags = recent_popular_tags(typeof limit !== 'undefined' ? limit : theme.tag_display_max_count); %>
 <% if (tags.length){ %>
 <div class="widget">
-  <ul class="tag-list">
-    <% tags.forEach(function(t){ %>
-    <%# Go はタグ名だけだと言語と分からないため表示だけ変える（旧実装から踏襲） %>
-    <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.name %> の記事 <%= t.count %>本（直近1年 <%= t.recent %>本・<%= t.pv.toLocaleString() %> View）"><%= t.name === 'Go' ? 'Go言語' : t.name %><span class="tag-list-count"><%= t.count %></span></a></li>
-    <% }) %>
-  </ul>
+  <%# Go はタグ名だけだと言語と分からないため表示だけ変える（旧実装から踏襲） %>
+  <%- partial('../_partial/tag-chips', {items: tags.map(function(t){
+        return {name: t.name, path: t.path, count: t.count,
+                label: t.name === 'Go' ? 'Go言語' : t.name,
+                title: `${t.name} の記事 ${t.count}本（直近1年 ${t.recent}本・${t.pv.toLocaleString()} View）`};
+      })}) %>
 </div>
 <% } %>

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -112,11 +112,10 @@
             のはカテゴリ内の本数で意味が違うため出さない（title には残す）。
             本数付きの一覧はカテゴリ個別ページの「よく使われるタグ」が持つ %>
         <div class="blog-tags">
-          <ul class="tag-list">
-            <% c.topTags.forEach(function(t){ %>
-            <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= c.name %> カテゴリの <%= t.name %> の記事 <%= t.count %>本"><%= t.name %></a></li>
-            <% }) %>
-          </ul>
+          <%- partial('_partial/tag-chips', {items: c.topTags.map(function(t){
+                return {name: t.name, path: t.path,
+                        title: `${c.name} カテゴリの ${t.name} の記事 ${t.count}本`};
+              })}) %>
         </div>
       </li>
       <% }) %>

--- a/themes/future/layout/category-without.ejs
+++ b/themes/future/layout/category-without.ejs
@@ -39,11 +39,10 @@
     <% if (stats.topTags.length) { %>
     <%- partial('_partial/section-heading', {id: 'toptags', text: 'よく使われるタグ'}) %>
     <div class="blog-tags">
-      <ul class="tag-list">
-        <% stats.topTags.forEach(function(t){ %>
-        <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= page.category %> カテゴリの <%= t.name %> の記事 <%= t.count %>本"><%= t.name %><span class="tag-list-count"><%= t.count %></span></a></li>
-        <% }) %>
-      </ul>
+      <%- partial('_partial/tag-chips', {items: stats.topTags.map(function(t){
+            return {name: t.name, path: t.path, count: t.count,
+                    title: `${page.category} カテゴリの ${t.name} の記事 ${t.count}本`};
+          })}) %>
     </div>
     <% } %>
     <% } %>

--- a/themes/future/layout/gallery.ejs
+++ b/themes/future/layout/gallery.ejs
@@ -156,6 +156,19 @@
         <% } %>
       </div>
       <div class="gallery-item">
+        <p class="gallery-name"><code>_partial/tag-chips</code></p>
+        <%# 右肩の件数（count）は「タグ総数」の意味だけに使う (#2129)。
+            渡さなければ名前だけのチップになる %>
+        <div class="blog-tags">
+          <%- partial('_partial/tag-chips', {items: recent_popular_tags(6).map(function(t){
+                return {name: t.name, path: t.path, count: t.count, title: `${t.name} の記事 ${t.count}本`};
+              })}) %>
+          <%- partial('_partial/tag-chips', {items: recent_popular_tags(3).map(function(t){
+                return {name: t.name, path: t.path};
+              })}) %>
+        </div>
+      </div>
+      <div class="gallery-item">
         <p class="gallery-name"><code>_partial/tendency-panels</code></p>
         <%# カテゴリはチップにせずテキストリンク＋アイコン、タグはチップ。
             この見分けが2つの枝の理由そのもの %>

--- a/themes/future/layout/guidelines.ejs
+++ b/themes/future/layout/guidelines.ejs
@@ -58,10 +58,10 @@
 
       <%- partial('_partial/section-heading', {id: 'relatedtags', text: '関連タグ'}) %>
       <div class="blog-tags">
-        <ul class="tag-list">
-          <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for('/tags/ガイドライン/') %>" rel="tag">ガイドライン</a></li>
-          <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for('/tags/コーディング規約/') %>" rel="tag">コーディング規約</a></li>
-        </ul>
+        <%- partial('_partial/tag-chips', {items: [
+              {name: 'ガイドライン', path: '/tags/ガイドライン/'},
+              {name: 'コーディング規約', path: '/tags/コーディング規約/'},
+            ]}) %>
       </div>
     </div>
   </div>

--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -109,11 +109,10 @@
           同じ見た目の要素が別の作りだとスタイルの調整が二重になる %>
       <div class="blog-tags">
         <div class="widget">
-          <ul class="tag-list">
-            <% recent_new_tags().forEach(function(t){ %>
-            <li class="tag-list-item"><a class="tag-list-link" href="<%- url_for(t.path) %>" rel="tag" title="<%= t.name %> の記事 <%= t.count %>本（初出 <%= t.first.format('YYYY.MM') %>）"><%= t.name %><span class="tag-list-count"><%= t.count %></span></a></li>
-            <% }) %>
-          </ul>
+          <%- partial('_partial/tag-chips', {items: recent_new_tags().map(function(t){
+                return {name: t.name, path: t.path, count: t.count,
+                        title: `${t.name} の記事 ${t.count}本（初出 ${t.first.format('YYYY.MM')}）`};
+              })}) %>
         </div>
       </div>
 


### PR DESCRIPTION
#2999（段階③）の**候補4・タグチップの列**です。1 PR 1パターンなので、これだけを入れます。

## 何を集めたか

同じ形を**5画面**で書いていました。

| 呼び出し元 | 節 | 件数 | title |
| --- | --- | --- | --- |
| `_widget/tag.ejs` | サイドバーの「人気のタグ」 | あり | 直近1年とPV |
| `categories.ejs` | 各カテゴリの代表タグ | なし | カテゴリ内の本数 |
| `category-without.ejs` | 「◯◯以外の記事」の代表タグ | あり | 同上 |
| `tags.ejs` | 新着タグ | あり | 初出の年月 |
| `guidelines.ejs` | 関連タグ（手書き2件） | なし | なし |

`_partial/tag-chips.ejs` に集め、差分は **`items` の要素の持ち方**で吸収します。

| キー | |
| --- | --- |
| `name` / `path` | 必須 |
| `label` | 省略時は `name`（`Go` → `Go言語` の表示替えだけがこれを使う） |
| `count` | 渡すと右肩に総数を出す。**「タグ総数」の意味だけに使う**（#2129） |
| `title` | 省略時は属性ごと出さない（ガイドラインの2件） |

**記事のタグ（`_partial/post/tag`）とは統合しません。** あちらは `ul` を持たず、1記事だけのタグを非リンクの `.tag-list-text` で描く別物です（#2999 の起票時にそう決めています）。

## 確かめたこと

**5ページ29ブロック252個のチップの生成 HTML を前後比較しました**（`<ul class="tag-list">…</ul>` を抜き出し、タグ間の空白を正規化）。

| ページ | ブロック | チップ |
| --- | ---: | ---: |
| `/` | 2 | 20 |
| `/categories/` | 19 | 100 |
| `/categories/Programming/without-go/` | 2 | 15 |
| `/specials/guidelines/` | 2 | 12 |
| `/tags/` | 4 | 85 |

**差分は0**です（`diff -r` で1件も出ません）。件数の有無・`title` の有無・`Go` → `Go言語` の表示替えが、すべて元のまま出ていることがこの一致で担保されています。

`grep` で `<ul class="tag-list">` の定義が partial の1箇所だけになったことも確認しました。

## ギャラリー

「部品」の節に `_partial/tag-chips` の見本を足しました（件数つきと名前だけの2列）。**台帳は24件、警告0件**です。

## 見つけたが直していないこと

**`Go` → `Go言語` の表示替えが2箇所にあります**（`_widget/tag.ejs` と `_partial/post/tag.ejs`）。同じ表示規則が2つの部品に散っていますが、**両者は統合しない部品**なので、この PR では呼び出し側に置いたままにしました。まとめるなら「タグ名の表示名」を1箇所で持つ別の変更になります。

## lint

- textlint（変更した6本の `.ejs`）0件
- markdownlint（`make fmt`）0件。`scripts/` は触っていないので prettier の対象に変化なし

## 残り（#2999）

候補5（echarts の読み込み・integrity ごと6重複）だけになります。

`category-without.ejs` の `summary-sub` の件（#3000 で見つけたもの）はまだ持ち越しています。
