### PR TITLE
echarts の読み込みを partial にする (#2999)

### DIFF
--- a/scripts/ui_gallery.js
+++ b/scripts/ui_gallery.js
@@ -32,6 +32,7 @@ const NOT_SHOWN = {
   'breadcrumb-page': 'Markdown のページ用にパンくずの項目を組むだけの包み。見た目はパンくずが持つ',
   'chart-xaxis-year-labels': 'echarts に渡す設定値を返す断片。見た目を持たない',
   'chart-yaxis-count': '同上',
+  'echarts-script': 'グラフのライブラリを読み込む <script>。見た目を持たない',
   'featured-post': '呼び出し元が無い',
   'footer-columns': 'フッターの中身。実物がこのページの下端に出ている',
   footer: '同上',

--- a/themes/future/layout/_partial/echarts-script.ejs
+++ b/themes/future/layout/_partial/echarts-script.ejs
@@ -1,0 +1,8 @@
+<%# echarts の読み込み (#2999)。年月ページ・/authors/ ・/categories/ ・/tags/ ・
+    投稿数の推移・サイドバーの統計の6箇所が、integrity ハッシュまで同じ
+    <script> タグを複製していた。版を上げるときに5箇所直し漏れる形だったので集める。
+
+    **option はここに置かない。** グラフの中身はページごとに全く違う
+    （面 / 棒 / 積み上げ、tooltip の formatter、legend の有無）ので、共通部分が無い。
+    色と線の太さは scripts/chart_style.js が1箇所で持つ (#2768) %>
+<script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>

--- a/themes/future/layout/_partial/posts-chart.ejs
+++ b/themes/future/layout/_partial/posts-chart.ejs
@@ -28,7 +28,7 @@
   </div>
   <% } %>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
+<%- partial('echarts-script') %>
 <script type="text/javascript">
 <% if (year) { %>
   const periodData = <%- posts_stack_series(year) %>;

--- a/themes/future/layout/_partial/sidebar-stats.ejs
+++ b/themes/future/layout/_partial/sidebar-stats.ejs
@@ -95,7 +95,7 @@
       117.9px あり、208px の列では横送りになって場所だけ取る。
       どの色が何かはツールチップ（trigger: axis）が名乗る %>
   <div id="chart" class="sidebar-stats-chart"></div>
-  <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
+  <%- partial('echarts-script') %>
   <script type="text/javascript">
     const chartData = <%- stats.chart %>;
     const catColors = <%- category_colors() %>;

--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -39,7 +39,7 @@
         月の中はデータ量が少ないのでタブは設けず1枚にする (#2227) %>
     <%- partial('_partial/section-heading', {id: 'trend', text: '投稿数の推移'}) %>
     <div id="chart-week" style="width:100%;min-height:250px"></div>
-    <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
+    <%- partial('_partial/echarts-script') %>
     <script type="text/javascript">
       const weekData = <%- get_weekly_category_data(page.year, page.month) %>;
       const catColors = <%- category_colors() %>;

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -20,7 +20,7 @@
       <%# 種別の定義。凡例のホバーでも出すが、タッチ端末はホバーが無いので
           注記でも読めるようにする %>
       ※継続=前年にも投稿 ／ 再開=2年以上あいての投稿 ／ 新規=初投稿 ／ 常連=2年連続で年2本以上
-      <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
+      <%- partial('_partial/echarts-script') %>
       <script type="text/javascript">
         <%# 継続・新規・再開の3種別 (#2145)。定義はヘルパー（yearly_author_types）側 %>
         const chartData = <%- yearly_author_types() %>;

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -19,7 +19,7 @@
     ※各月末時点の累計投稿数を表示
     <div id="category-chart" style="width: 100%; height: 400px;"></div>
 
-    <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
+    <%- partial('_partial/echarts-script') %>
 
     <script type="text/javascript">
       const chartData = <%- get_monthly_category_data() %>;

--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -38,7 +38,7 @@
           <div id="chart-tag-retention" style="width:100%;min-height:250px"></div>
         </div>
       </div>
-      <script src="https://cdn.jsdelivr.net/npm/echarts@5.1.2/dist/echarts.min.js" integrity="sha384-QqZssazD9IzPiEJz2lyFewTMgYObqDWxBfCX5k5E4n4fH7ygMIqp6A6Ek8HIrRyQ" crossorigin="anonymous"></script>
+      <%- partial('_partial/echarts-script') %>
       <script type="text/javascript">
         const chartData = <%- new_tags_by_year() %>;
         const catColors = <%- category_colors() %>;


### PR DESCRIPTION
#2999（段階③）の**候補5・echarts の読み込み**です。これで段階③の候補が全部片付きます。

## 何を集めたか

**integrity ハッシュまで完全に同じ `<script>` タグが6箇所に複製**されていました。版を上げるときに5箇所直し漏れる形です。

| 呼び出し元 | |
| --- | --- |
| `archive.ejs` | 年月ページの推移 |
| `authors.ejs` | 年別 著者数の推移 |
| `categories.ejs` | カテゴリ別 累計投稿数の推移 |
| `tags.ejs` | 年別 新規タグ数の推移 |
| `_partial/posts-chart.ejs` | 投稿数の推移（タブ） |
| `_partial/sidebar-stats.ejs` | サイドバーの月別グラフ |

`_partial/echarts-script.ejs` に集めました。**引数はありません。**

**option はここに置きません。** グラフの中身はページごとに全く違い（面 / 棒 / 積み上げ、`tooltip` の formatter、legend の有無）、共通部分がないためです。色と線の太さは `scripts/chart_style.js` が1箇所で持ちます（#2768）。

## 確かめたこと

置き換えは**文字列として1対1**（各出現を、その文字列だけを出す partial の呼び出しに置換）なので、ページごとのタグ数は原理的に変わりません。実際に配信中の HTML を数えて確かめました。

| ページ | script | `echarts.init` |
| --- | ---: | ---: |
| `/articles/2026/08/` | 1 | 1 |
| `/articles/2026/` | 1 | 2 |
| `/articles/` | 1 | 2 |
| `/authors/` | 1 | 1 |
| `/categories/` | 1 | 1 |
| `/tags/` | 1 | 2 |
| `/categories/Programming/` | 1 | 1 |
| `/tags/Go/` | 1 | 1 |
| `/authors/真野隼記/` | 1 | 1 |
| `/specials/gallery/` | 0 | 0 |

グラフを出すページはすべて**ちょうど1本**読み込み、グラフの数も変わっていません。`grep` で CDN を直書きしているファイルが `_partial/echarts-script.ejs` の1本だけになったことも確認しました。

## ギャラリー

**見た目を持たない部品なので見本は出しません。** `scripts/ui_gallery.js` の `NOT_SHOWN` に理由つきで登録したので、「見本も理由も無い」警告は出ません。**台帳は24件のまま、警告0件**です。

## lint

- textlint（変更した7本の `.ejs`）0件
- `npx prettier --check "scripts/**/*.js" "*.mjs"` 通過
- markdownlint（`make fmt`）0件

## 段階③はこれで完了

| # | パターン | PR |
| --- | --- | --- |
| 1 | 統計タイル | #3000 |
| 2 | 傾向パネル | #3003 |
| 3 | パネルカード | #3002 |
| 4 | タグチップの列 | #3008 |
| 5 | echarts の読み込み | この PR |

保留にした2つ（チャートのタブ帯・連載ナビ）と、しないと決めた3つ（ページの骨格・ユーティリティ・記事のタグとの統合）は #2999 に理由を書いてあります。

## 持ち越している小さな不整合

この段階の作業中に見つけたもので、**見た目が変わる**ので手を付けていません。

- **`category-without.ejs` だけシェアの内訳に `summary-sub` が付いていない**（他4画面は付いている・#3000 で発見）
- **`Go` → `Go言語` の表示替えが2箇所にある**（`_widget/tag.ejs` と `_partial/post/tag.ejs`・#3008 で発見）
