### PR TITLE
「◯◯以外の記事」のシェア内訳を sub に揃える (#2999)

### DIFF
--- a/themes/future/layout/category-without.ejs
+++ b/themes/future/layout/category-without.ejs
@@ -16,16 +16,16 @@
     <% if (page.current === 1) { %>
     <% const summary = summary_posts(page.withoutPosts); %>
     <% const stats = stats_of_posts(page.category, page.withoutPath, page.withoutPosts); %>
-    <%# 内訳に summary-sub を付けていないのは他のページと揃っていないが、
-        見た目を変えない改修なのでここでは直さない (#2999) %>
+    <%# サービスごとの数は総シェア数の内訳なので sub で一段下げる (#2096)。
+        年月ページ・サイドバーの統計と同じ扱い %>
     <%- partial('_partial/summary-tiles', {items: [
           {value: page.withoutPosts.length, label: '投稿'},
           {value: summary.authors, label: '著者数'},
           {value: summary.total, label: '総シェア数'},
-          {value: summary.twitter, label: 'X'},
-          {value: summary.facebook, label: 'Facebook'},
-          {value: summary.hatebu, label: 'はてブ'},
-          {value: summary.pocket, label: 'Pocket'},
+          {value: summary.twitter, label: 'X', sub: true},
+          {value: summary.facebook, label: 'Facebook', sub: true},
+          {value: summary.hatebu, label: 'はてブ', sub: true},
+          {value: summary.pocket, label: 'Pocket', sub: true},
         ]}) %>
     <%- partial('_partial/summary-tiles', {items: [
           {value: stats.recent, label: '直近1年の投稿'},


### PR DESCRIPTION
`/categories/◯◯/without-◯◯/`（「◯◯以外の記事」）の統計タイルだけ、シェアの内訳に `summary-sub` が付いていませんでした。**サービスごとの数は総シェア数の内訳なので一段下げます**（#2096）。

#3000（統計タイルの partial 化）で見つけましたが、あちらは見た目を変えない改修だったので分けてあります。

## 変更前後

| | 投稿 | 著者数 | 総シェア数 | X | Facebook | はてブ | Pocket |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 変更前 | 主要 | 主要 | 主要 | **主要** | **主要** | **主要** | **主要** |
| 変更後 | 主要 | 主要 | 主要 | **内訳** | **内訳** | **内訳** | **内訳** |

これで年月ページ・サイドバーの統計と同じ扱いになります。

```
/articles/2026/                     main 投稿 / main 平均投稿/月 / main 総シェア数 / sub X / sub Facebook / sub はてブ / sub Pocket
/categories/Programming/without-go/ main 投稿 / main 著者数     / main 総シェア数 / sub X / sub Facebook / sub はてブ / sub Pocket
```

## 確かめたこと

配信中の HTML をパースして、7項目の `summary-sub` の有無が年月ページと同じ形になったことを確認しました（主要3・内訳4）。

対象は「◯◯以外の記事」のページだけで、**同じ `_partial/summary-tiles` を使う他の画面は引数を変えていない**ので影響しません。

## lint

- textlint（`category-without.ejs`）0件
- `scripts/` は触っていないので prettier の対象に変化なし
