### PR TITLE
凡例を持たないチャートに凡例を生やさない

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -892,6 +892,11 @@ bootstrap-subset → theme-styles.styl の順で `/css/site.css` に連結する
   - **echarts の option では CSS 変数を参照できない。** `:root` から実効値を読んで
     option に流し込む（`_partial/chart-theme.ejs` が1箇所で持ち、各チャートは
     `themeChart(インスタンス)` を1回呼ぶ）。切り替えは `themechange` イベントで知らせる
+    - **持っていない部品を `setOption` で渡さない。** `legend: {…}` を無条件に重ねると、
+      **凡例を持たないチャートにそこで凡例が生える**（既定は `show: true` で系列名を
+      全部出す）。サイドバーのグラフは系列が1本なので凡例を出していない (#2911) のに、
+      #2746 でこれを踏んだ。`getOption()` を**最初に1度だけ**見て有無を覚える
+      （`apply` の後は自分が足した分が出るので、毎回見ると判定が変わる）
 - **暗い地の上には別の段を使う**（#2839）。`ink` / `rule` / `surface` は白地の上で
   決めた値で、ネイビー地では `ink-strong` が 1.63 しか出ず1つも使えない。
   暗地用の段は `_variables.styl` が持つ（`on-dark-strong` / `on-dark` / `on-dark-mute` /

--- a/themes/future/layout/_partial/chart-theme.ejs
+++ b/themes/future/layout/_partial/chart-theme.ejs
@@ -15,23 +15,36 @@
         line: s.getPropertyValue('--rule-base').trim(),
       };
     }
-    function apply(chart) {
+    // 元の option が凡例を持っているか。**持っていないチャートに legend を渡すと、
+    // echarts がそこで凡例を作ってしまう**（既定は show: true で系列名を全部出す）。
+    // サイドバーのグラフは系列が1本なので凡例を出していない (#2911)
+    function hasLegend(chart) {
+      var legend = (chart.getOption() || {}).legend;
+      return Array.isArray(legend) && legend.length > 0;
+    }
+    function apply(chart, legend) {
       var t = tokens();
       // 既存の option に重ねる。系列の色は触らない（カテゴリ色は #2170 で固定）
-      chart.setOption({
+      var option = {
         textStyle: { color: t.text },
-        legend: { textStyle: { color: t.text } },
         xAxis: { axisLabel: { color: t.text }, axisLine: { lineStyle: { color: t.line } } },
         yAxis: { axisLabel: { color: t.text }, splitLine: { lineStyle: { color: t.line } } },
-      });
+      };
+      if (legend) option.legend = { textStyle: { color: t.text } };
+      chart.setOption(option);
     }
     document.addEventListener('themechange', function () {
-      charts.forEach(apply);
+      charts.forEach(function (c) {
+        apply(c.chart, c.legend);
+      });
     });
     return function (chart) {
       if (!chart) return;
-      charts.push(chart);
-      apply(chart);
+      // 凡例の有無は最初に1度だけ見る。apply の後は自分が足した legend が
+      // getOption に出るので、毎回見ると判定が変わる
+      var entry = { chart: chart, legend: hasLegend(chart) };
+      charts.push(entry);
+      apply(entry.chart, entry.legend);
     };
   })();
 </script>


### PR DESCRIPTION
サイドバーのグラフに凡例が出ていました。**#2746（PR #3009）で私が入れた退行です。**

## 原因

`themeChart` が `legend` を**無条件に**重ねていました。

```js
chart.setOption({
  textStyle: { color: t.text },
  legend: { textStyle: { color: t.text } },   // ← これ
  xAxis: …, yAxis: …,
});
```

**`legend` を持たないチャートにこれを渡すと、echarts がそこで凡例を作ります**（既定は `show: true` で系列名を全部出す）。

サイドバーのグラフは #2911 で意図して凡例を外していました（カテゴリ別の積み上げは最長の `DataEngineering` だけで 117.9px あり、208px の列では横送りになって場所だけ取るため）。そこにカテゴリ名が1つだけ並んでいたことになります。

## 直し方

**元の option が凡例を持っているときだけ** `legend` を渡します。

```js
var entry = { chart: chart, legend: hasLegend(chart) };
```

**有無は最初に1度だけ見ます。** `apply` の後は自分が足した `legend` が `getOption()` に出るので、毎回見ると判定が変わります（`themechange` で呼び直すたびに結果が変わってしまう）。

## 影響するチャート

| ページ | 元の option の `legend` | 凡例 |
| --- | --- | --- |
| カテゴリ／タグ／著者の**サイドバー** | **なし** | **出なくなる**（本来の姿） |
| `/categories/` | あり | 出る（変わらず） |
| `/tags/` の2つ | あり | 出る（変わらず） |
| `/authors/` | あり | 出る（変わらず） |
| `/archives/` の週別 | あり | 出る（変わらず） |
| ホームの3つ | あり | 出る（変わらず） |

## 検証

- サイドバーの3種（`/categories/Programming/` `/tags/Go/` `/authors/真野隼記/`）の option に `legend` が無いこと
- `/tags/` の2つには `legend` があること
- `textlint` / `markdownlint` 通過

**テーマ追従（凡例の文字色を `--ink-mute` にする）は、凡例を持つチャートでは従来どおり効きます。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
