### PR TITLE
ranking_tags を tag-chips で描く (#3029)

### DIFF
--- a/scripts/tags.js
+++ b/scripts/tags.js
@@ -160,13 +160,15 @@ hexo.extend.helper.register('ranking_tags', function () {
     .sort(compareFunc)
     .slice(0, 30);
 
-  // マークアップは関連タグ・「今年使われ始めたタグ」と同じチップに揃える。
-  // 以前は素のテキストリンクで、同じページ内でタグの見た目が割れていた (#2052)
-  let result = '';
-  rankings.map((tp) => {
-    result += `<li class="tag-list-item"><a class="tag-list-link" href="${this.url_for(tp.tag.path)}" rel="tag" title="${tp.tag.name} の記事 ${tp.count}本（総シェア ${tp.shareCount}）">${tp.tag.name}<span class="tag-list-count">${tp.count}</span></a></li>`;
-  });
-  return `<div class="blog-tags"><div class="widget"><ul class="tag-list">${result}</ul></div></div>`;
+  // ここはデータだけ返し、描くのは呼び出し側 (#3029)。チップの形は
+  // _partial/tag-chips.ejs が1箇所で持つ。JS の中で HTML を作ると、
+  // 同じ形の直しが themes/ の外にも散る（#3008 のときここだけ漏れた）
+  return rankings.map((tp) => ({
+    name: tp.tag.name,
+    path: tp.tag.path,
+    count: tp.count,
+    shareCount: tp.shareCount,
+  }));
 });
 
 const totalCount = (posts) => {

--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -103,7 +103,14 @@
         <div class="col-12 col-md-6">
           <section class="summary-panel tag-pool-panel h-100">
             <span class="summary-panel-label">累計</span>
-            <%- ranking_tags() %>
+            <div class="blog-tags">
+              <div class="widget">
+                <%- partial('_partial/tag-chips', {items: ranking_tags().map(function(t){
+                      return {name: t.name, path: t.path, count: t.count,
+                              title: `${t.name} の記事 ${t.count}本（総シェア ${t.shareCount}）`};
+                    })}) %>
+              </div>
+            </div>
           </section>
         </div>
       </div>


### PR DESCRIPTION
「他のセッションの作業で、既存 partial を使ったほうがよい箇所が出ていないか」の再チェックで見つかった1件目です。

## 何が起きていたか

`scripts/tags.js` の `ranking_tags`（`/tags/` の「人気のタグ」の**累計**側）が、タグチップの markup を**文字列で組み立てていました。**

```js
result += `<li class="tag-list-item"><a class="tag-list-link" href="…" rel="tag" title="…">${name}<span class="tag-list-count">${count}</span></a></li>`;
return `<div class="blog-tags"><div class="widget"><ul class="tag-list">${result}</ul></div></div>`;
```

`_partial/tag-chips.ejs`（#3008）と同じ形です。段階③で5画面を集めたとき、**ここだけ `themes/` の外にあったので漏れました**（「JS の中の HTML は洗い漏れる」という既知の罠で、#2845 が `ga4_pv.js` で漏れたのと同じ場所）。

**すぐ隣が既に partial を使っています。** 同じページの「新着タグ」は `partial('_partial/tag-chips', …)` で描いていて、**同じ画面の中で同じ部品が2つの作りに割れていました。**

## やったこと

**helper はデータだけ返し、描くのは呼び出し側**にしました（#2729 で Tech Cast に採ったのと同じ形）。

- `ranking_tags` → `[{name, path, count, shareCount}]` を返す
- `tags.ejs` が `_partial/tag-chips` を呼ぶ。**隣の「新着タグ」と同じ書き方**になります

**新しい partial は作っていません。** 既にあるものを使うだけです。

## 確かめたこと

**変更前の版にいったん戻してサーバを起動し直し、同じ抽出で取り直して比較しました。**

```
tagsA.txt（変更前）  チップ 30 個
tagsB.txt（変更後）  チップ 30 個
diff → 差分なし
```

`href` / `rel` / `title` / タグ名 / 右肩の件数、外側の `<div class="blog-tags"><div class="widget">` まで**30個すべて完全一致**です。

## 再チェックの結果（この PR の範囲外）

`themes/future/layout/**` の全 `.ejs` を、既存 partial が担う9つの形（統計タイル・傾向パネル・タグチップ・パネルカード・echarts・節見出し・アイコン・パンくず・目次）で走査しました。**テンプレート側の再実装は0件**です。

残っているのは `scripts/` の中の HTML で、**もう1件あります。**

- **`scripts/ga4_pv.js` の `popular_posts_in` → `panel-card` と同じ形**（7画面の「よく読まれている記事」）
- CSS も `.series-panels .article-card, .post-panel { … }` と**1つのルールが2つの名前**を持っている
- **サムネが無いときの空き枠（`panel-thumb-empty`）が抜けている**ため、サムネを持たない記事（1,481本中118本 = 8.0%）がランキングに入るとそのカードだけ本文が左に寄ります

呼び出し元が7つあるので別の issue で扱います。

## lint

- `npx prettier --check "scripts/**/*.js" "*.mjs"` 通過
- textlint（`themes/future/layout/tags.ejs`）0件

Closes #3029
