### PR TITLE
popular_posts_in を panel-card で描く (#3031)

### DIFF
--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -134,22 +134,25 @@ hexo.extend.helper.register('popular_posts_in', function (posts, limit, decay) {
 
   if (ranked.length === 0) return '';
 
-  // マークアップはホームの「連載から探す」と同じカード。2列で並べる
+  // カードは _partial/panel-card.ejs が1箇所で持つ (#3031)。ここで手書きすると、
+  // 同じ形の直しが themes/ の外にも散る（#2845 の aria-hidden はここが漏れた）。
+  // 列だけは呼び出し側の都合なので JS が持つ。2列で並べる
   const cards = ranked
-    .map(({ post }) => {
-      // サムネはタイトルと同じ行き先なので、タブ順と読み上げから外す (#2845 / #2936)
-      const thumb = post.thumbnail
-        ? `<a href="/${post.path}" title="${post.title}" class="thumb-link panel-thumb" tabindex="-1" aria-hidden="true"><img src="${post.thumbnail}" alt="" width="200" height="135" loading="lazy"></a>`
-        : '';
-      return (
-        `<div class="col-12 col-md-6"><div class="article-card post-panel h-100">${thumb}` +
-        `<div class="panel-body"><a href="/${post.path}" class="panel-title">${post.title}</a>` +
-        // 推薦カードの日付は鮮度の目安なので年月まで (#2404)
-        `<div class="panel-meta">${post.date.format('YYYY.MM')}${snsLabel(post.permalink)}</div>` +
-        `</div></div></div>`
-      );
-    })
+    .map(
+      ({ post }) =>
+        '<div class="col-12 col-md-6">' +
+        this.partial('_partial/panel-card', {
+          url: '/' + post.path,
+          title: post.title,
+          thumb: post.thumbnail ? { src: post.thumbnail, width: 200, height: 135 } : null,
+          // 推薦カードの日付は鮮度の目安なので年月まで (#2404)
+          meta: post.date.format('YYYY.MM') + snsLabel(post.permalink),
+        }) +
+        '</div>',
+    )
     .join('');
 
-  return `<div class="row g-4">${cards}</div>`;
+  // 囲みは .series-panels .article-card が持つ。以前は .post-panel という別名で
+  // 同じルールを引いていたが、名前が2つある理由が無かった
+  return `<div class="series-panels row g-4">${cards}</div>`;
 });

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2081,8 +2081,7 @@ body {
 
 /* ホームの「連載から探す」と、カテゴリ・タグの「よく読まれている記事」で共用する
    カード。We're hiring と同じ横並びの作り */
-.series-panels .article-card,
-.post-panel {
+.series-panels .article-card {
   display: flex;
   /* 「特集」のパネルは本文が4行（ラベル・タイトル・メタ・導線）で 91px あり、
      88×59 のサムネの 1.5 倍の高さになる。12px では文字の塊がサムネに寄って見える


### PR DESCRIPTION
再チェックで見つかった2件目です（1件目は #3030）。**これで `scripts/` の中の HTML から、既存 partial の再実装が無くなります。**

## 何が起きていたか

`scripts/ga4_pv.js` の `popular_posts_in`（**7画面**の「よく読まれている記事」＝カテゴリ・タグ・著者・年月／年／全期間・「◯◯以外の記事」）が、パネルカードを文字列で組み立てていました。

段階③で4画面を集めたとき、**ここだけ `themes/` の外にあったので漏れました**（#2845 の `aria-hidden` もここが漏れています）。

## 実害があります：サムネ無しの空き枠が抜けていた

```js
const thumb = post.thumbnail ? `<a … class="thumb-link panel-thumb" …>` : '';   // ← 空文字
```

`panel-card` は `<span class="panel-thumb panel-thumb-empty">` を出して行頭を揃えます（CLAUDE.md「サムネの無いものは同じ大きさの空き枠で行頭を揃える」）。こちらは空文字だったので、**そのカードだけ本文が左に寄っていました。**

サムネを持たない記事は **1,481本中118本（8.0%）**。実際に `/articles/2020/` のランキング6枚のうち1枚が該当します。

```html
<!-- 変更後 -->
<div class="article-card series-panel h-100">
  <span class="panel-thumb panel-thumb-empty"></span>
  <div class="panel-body">
    <a href="/articles/20200116/" class="panel-title">実践Drawio</a>
    <div class="panel-meta">2020.01<span class="snscount">♡527</span></div>
  </div>
</div>
```

## やったこと

- カードを `this.partial('_partial/panel-card', {…})` で描く。**新しい partial は作っていません**
- 囲みを `.series-panels .article-card` に寄せる（ラッパを `<div class="series-panels row g-4">` に）
- **使い手の居なくなった `.post-panel` を CSS から落とす**

CSS は `.series-panels .article-card, .post-panel { … }` と**1つのルールが2つの名前**を持っていて、`.post-panel` を使うのはこの helper だけでした。これで名前が1つになります（`site.css` の `post-panel` は0件）。

**列（`col-12 col-md-6`）だけは JS が持ちます。** 2列か3列かは呼び出し側の都合で、カードの都合ではないためです（#2999 でそう決めています）。

## 確かめたこと

配信中の HTML で確認しました。

```
/categories/Programming/  カード 6 枚 / series-panel 6 / post-panel 0 / series-panels ラッパ あり
/articles/2020/           カード 6 枚 / 空き枠 1 枚  ← 直ったところ
/articles/2021/           カード 6 枚 / 空き枠 0 枚
/articles/                カード 6 枚 / 空き枠 0 枚
/categories/Frontend/     カード 6 枚 / 空き枠 0 枚
```

サムネのあるカードは、`href` / `title` / `tabindex="-1"` / `aria-hidden="true"` / `width` / `height` / `loading` と `panel-title`・`panel-meta`（日付＋♡）まで元のままです。

`this.partial` が helper の中から呼べることも確認しました（`this` がテンプレートのローカルなので、`url_for` と同じように使えます）。

## lint

- `npx prettier --check "scripts/**/*.js" "*.mjs"` 通過
- テンプレートは触っていないので textlint の対象に変化なし

Closes #3031
