### PR TITLE
表の枠が消えていたのを直し、同じ形を機械で止める

### DIFF
--- a/.github/workflows/css.yml
+++ b/.github/workflows/css.yml
@@ -1,6 +1,9 @@
-# 文字サイズが段から外れていないかを PR で検出する (#2971)。
-# 26種類を7段に寄せた直後、別の PR が 1.4em と 12px を直接書いて段の外へ戻した。
-# CLAUDE.md に文章で書くだけでは守れなかったので機械で止める。
+# CSS の検査を PR で回す。
+# 1. 解決されなかった Stylus の識別子（#2746 で表の枠が全部消えた）
+# 2. 文字サイズが段から外れていないか (#2971)
+#
+# どちらも CLAUDE.md に文章で書くだけでは守れなかったもの。1つ目は表の枠が
+# 全ページで消え、2つ目は寄せ終えた直後に別の PR が段の外へ戻した。
 #
 # paths フィルタにより、CSS を触らない PR ではこのジョブ自体が走らない。
 name: css
@@ -9,14 +12,17 @@ on:
   pull_request:
     paths:
       - "themes/future/css-src/**"
+      - "css.mjs"
+      - "css_lint.mjs"
       - "font_size_lint.mjs"
+      - "scripts/lib/site_css.js"
       - ".github/workflows/css.yml"
 
 permissions:
   contents: read
 
 jobs:
-  font-size:
+  check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,6 +32,19 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: npm
+
+      # css.mjs は stylus を使うので依存が要る
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build CSS
+        run: node css.mjs
+
+      # Stylus は未定義の変数をエラーにせず名前をそのまま出力する。
+      # CSS 側では無効な値なので宣言ごと捨てられ、画面を見るまで気づけない
+      - name: Check for unresolved Stylus identifiers
+        run: node css_lint.mjs
 
       - name: Check font-size scale
         run: node font_size_lint.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1380,6 +1380,15 @@ bootstrap-subset → theme-styles.styl の順で `/css/site.css` に連結する
     `theme-styles.styl` と `highlight.styl` の両方に書く必要は残る（詳細度の都合）が、
     値を1箇所から引くので**揃っていることを説明するコメントが要らなくなった**。
     値の重複を消せば主張も消える、という形の例
+- **Stylus は未定義の変数をエラーにせず、名前をそのまま値として出力する。**
+  CSS 側では無効な値なので、その宣言が（一括指定なら丸ごと）捨てられる。
+  **画面を見るまで気づけない壊れ方**で、2回踏んでいる
+  - `:root { --table-border: table-border }` … 表の枠が全ページで消えた（#2746）
+  - `.footer-link { transition: hover-speed }` … #2753
+  - 原因はいつも同じで、**変数の定義が使う場所より後ろにある**こと。
+    `_variables.styl` は `theme-styles.styl` の先頭で読むので、そこに置けば起きない
+  - **再発は `css_lint.mjs` が止める**（`make lint-css`、PR では `css` ワークフロー）。
+    コンパイル後の CSS を見て、カスタムプロパティの値が裸の識別子になっていないかを検査する
 - **色は `_variables.styl` が値を持ち、`:root` が CSS 変数として配り、使う側は `var()` で引く**
   （#2746。ダークモードの前段）。3つの役を分ける
   - **値は Stylus 変数のまま置く。`:root` にだけ書かない。** CSS カスタムプロパティは

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ css:
 # 文字サイズが段（_variables.styl の text-*）から外れていないかを検査する (#2971)。
 # 寄せ終えた直後に別の PR が 1.4em を直接書いて戻した実績がある
 lint-css:
+	node css.mjs
+	node css_lint.mjs
 	node font_size_lint.mjs
 
 mermaid:

--- a/css_lint.mjs
+++ b/css_lint.mjs
@@ -1,0 +1,54 @@
+// コンパイル後の CSS に、解決されなかった Stylus の識別子が残っていないかを見る。
+//
+// Stylus は未定義の変数をエラーにせず、**名前をそのまま値として出力する**。
+// CSS 側では無効な値なので、その宣言（一括指定なら丸ごと）が捨てられる。
+// 画面を見るまで気づけない壊れ方で、実際に踏んだ:
+//
+//   :root { --table-border: table-border }   ← 解決されず、表の枠が全部消えた (#2746)
+//   .footer-link { transition: hover-speed }  ← 同じ形 (#2753)
+//
+// 原因はいつも同じで、**変数の定義が使う場所より後ろにある**こと。
+// _variables.styl は theme-styles.styl の先頭で読むので、そこに置けば起きない。
+import { readFileSync } from 'node:fs';
+
+const FILE = 'public/css/site.css';
+
+// 値として正当なキーワード。ここに無い裸の識別子は解決漏れとみなす
+const KEYWORDS = new Set([
+  'inherit',
+  'initial',
+  'unset',
+  'revert',
+  'none',
+  'auto',
+  'transparent',
+  'currentColor',
+  'solid',
+  'dashed',
+  'dotted',
+  'double',
+  'groove',
+  'ridge',
+  'inset',
+  'outset',
+  'hidden',
+]);
+
+const css = readFileSync(FILE, 'utf8');
+const errors = [];
+for (const m of css.matchAll(/(--[\w-]+):\s*([^;{}]+);/g)) {
+  const value = m[2].trim();
+  // 裸の識別子だけの値（#hex・数値・var()・関数・キーワードのどれでもない）
+  if (!/^[a-zA-Z][\w-]*$/.test(value)) continue;
+  if (KEYWORDS.has(value)) continue;
+  errors.push(`${m[1]}: ${value}`);
+}
+
+if (errors.length) {
+  console.error(`解決されなかった Stylus の識別子が ${errors.length} 件あります。\n`);
+  errors.forEach((e) => console.error(`  ${FILE}  ${e}`));
+  console.error('\n変数の定義が、使う場所より後ろにあります。');
+  console.error('_variables.styl へ移してください（theme-styles.styl の先頭で読まれます）。');
+  process.exit(1);
+}
+console.log('CSS に解決漏れの識別子はありません');

--- a/themes/future/css-src/_variables.styl
+++ b/themes/future/css-src/_variables.styl
@@ -30,7 +30,12 @@ rule-strong = #ccc    // focus / hover でひとつ強める
 // ダークでも白のまま
 surface-base = #fff
 surface-tint = #f5f5f5 // 静止した面。チップ・タブ帯・表のヘッダ
-surface-mute = #eee    // hover / focus の面と、空・無効の面・インラインコードの地
+surface-mute = #eee
+// 表のセルの罫線。行を目で追う役をこの線が担っているので、枠（rule-base）より
+// 一段強い段を使う。**ここに置くのは :root がこれを配るため**（#2746）。
+// theme-styles.styl の後半に置くと、先頭の :root からは見えず、
+// Stylus が識別子のまま出力して枠が消える
+table-border = rule-strong    // hover / focus の面と、空・無効の面・インラインコードの地
 
 // リンクの色は4値・3状態（通常 / 訪問済み / 濃い地の上）。
 // 地が濃くなるぶん暗い側へ振った値を持つ。link-blue は白地で AA を満たすが、

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2482,9 +2482,6 @@ button.share-btn {
   記事中のテーブル789個を数えると中央値4行・73%が6行以下で、
   縞が効く長さの表はそもそも少ない。
 */
-// 表のセルの罫線。行を目で追う役をこの線が担っているので、枠（rule-base）より
-// 一段強い段を使う
-table-border = rule-strong
 
 table {
   table-layout: auto;


### PR DESCRIPTION
明るいテーマで**記事中の表の枠線が全ページで消えていました**。#2746 で私が入れた退行です。

## 原因

```css
:root {
  --table-border: table-border;   /* ← Stylus 変数名がそのまま出ている */
}
th, td {
  border: solid 1px var(--table-border);
}
```

`table-border = rule-strong` の定義が `theme-styles.styl` の**後半（2487行目）**にあり、**先頭の `:root` からは見えていませんでした。**

**Stylus は未定義の変数をエラーにせず、名前をそのまま値として出力します。** CSS 側では無効な値なので、`border` の**一括指定ごと**捨てられ、枠が消えます。

暗いテーマは `--table-border: dark-rule-strong`（`_variables.styl` にある）なので解決されていて、**明るいテーマだけが壊れていました。**

## 直し方

定義を `_variables.styl` へ移します。あちらは `theme-styles.styl` の先頭で読まれるので、`:root` から見えます。

| | before | after |
| --- | --- | --- |
| 明 | `table-border`（無効） | **`#ccc`**（`rule-strong`） |
| 暗 | `#4d4d59` | `#4d4d59`（変わらず） |

## 同じ形を機械で止めます

**この壊れ方は画面を見るまで気づけません。** Stylus がエラーを出さず、CSS も黙って宣言を捨てるためです。**#2753 でも踏んでいます**（`transition: hover-speed` が文字列のまま出た）。

`css_lint.mjs` を足しました。コンパイル後の CSS を見て、**カスタムプロパティの値が裸の識別子になっていないか**を検査します。

```text
解決されなかった Stylus の識別子が 1 件あります。

  public/css/site.css  --table-border: table-border

変数の定義が、使う場所より後ろにあります。
_variables.styl へ移してください（theme-styles.styl の先頭で読まれます）。
```

**実際にこの回帰を検出することを確認しました**（直した CSS の1文字を戻すと exit 1）。

`make lint-css` に組み込み、PR では `css` ワークフローが走ります。`css.mjs` が stylus を使うのでワークフローに `npm ci` を足し、`paths` に `css.mjs` / `css_lint.mjs` / `scripts/lib/site_css.js` を加えました。

## 検証

- 配信中の CSS で `--table-border` が `#ccc` に解決されること
- **コンパイル後の CSS 全体に解決漏れの識別子が他に無い**こと（この1件だけでした）
- 壊した CSS で検査が exit 1 になること
- `make lint-css` / `prettier --check` / `markdownlint` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
