### PR TITLE
/tags/ のパネルのラベルを 直近 / 累計 に戻す

### DIFF
--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -12,17 +12,20 @@
           「〜から記事を探す」を繰り返さない体言止めにする（ホーム側は
           文脈が混在するため説明的な「人気のタグから記事を探す」のまま） %>
       <%- partial('_partial/section-heading', {id: 'populartags', text: '人気のタグ'}) %>
-      <%# 「いま読まれている」（PV を経過年ペナルティで割った順 #3028）と
-          「累計のシェア」（全期間のシェア効率）を2列で並べて両方見せる (#2358)。
+      <%# 「直近」（PV を経過年ペナルティで割った順 #3028）と
+          「累計」（全期間のシェア効率）を2列で並べて両方見せる (#2358)。
           タブ切り替えは上のグラフのタブと見た目が重複するためやめた。
           枠と小ラベルは詳細ページの統計パネル（#2276）と同じ部品。
           並びは鮮度が主目的のセクションなので「いま」を左にする。
-          **ラベルは物差しを名乗る。** 以前は「直近1年」だったが、#3028 で
-          左の列が窓を持たなくなったので、そのままでは嘘になる %>
+          **ラベルは時間の向きだけを名乗る。** 左は #3028 で窓を持たなくなったので
+          「直近1年」とは書けないが、経過年で割るぶん新しい記事が効くという向きは
+          変わらないので「直近」。物差しそのもの（PV / シェア効率）は
+          チップの title が持つ。ここは「人気のタグ」の節なので、
+          ラベルに「シェア」と書くとタグ自体がシェアされたように読める %>
       <div class="row g-4 tag-pool-panels">
         <div class="col-12 col-md-6">
           <section class="summary-panel tag-pool-panel h-100">
-            <span class="summary-panel-label">いま読まれている</span>
+            <span class="summary-panel-label">直近</span>
             <div class="blog-tags">
               <%- partial('_widget/tag.ejs', {limit: 30}) %>
             </div>
@@ -30,7 +33,7 @@
         </div>
         <div class="col-12 col-md-6">
           <section class="summary-panel tag-pool-panel h-100">
-            <span class="summary-panel-label">累計のシェア</span>
+            <span class="summary-panel-label">累計</span>
             <div class="blog-tags">
               <div class="widget">
                 <%- partial('_partial/tag-chips', {items: ranking_tags().map(function(t){


### PR DESCRIPTION
## 直すもの

#3033 で付けたラベルを **「直近」「累計」** に戻します。

| | before（#3033） | after |
| --- | --- | --- |
| 左 | いま読まれている | **直近** |
| 右 | 累計のシェア | **累計** |

**ここは「人気のタグ」の節なので、ラベルに「シェア」と書くとタグ自体がシェアされたように読めます**（レビューでの指摘）。

## ラベルの役

**時間の向きだけを名乗ります。** 左は #3028 で窓を持たなくなったので「直近1年」とは書けませんが、**経過年で割るぶん新しい記事が効く**という向きは変わらないので「直近」です。

物差しそのものはチップの `title` が持ちます。

- 左: `Go の記事 265本・累計 841,900 View`
- 右: `HTML の記事 7本（総シェア 17,186）`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
