### PR TITLE
helper が partial を呼んでよい場面を CLAUDE.md に書く (#3036)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,15 @@ URL は読者向け、コード配置は保守者向けの分類なので、鏡�
     持っている予約語で、`partial(name, {layout: 'row'})` と渡しても**届かない**。
     エラーにはならず既定の枝で描かれるので、**生成 HTML を見るまで気づけない**。
     見た目の違いを渡す引数は `variant` にする
+  - **`scripts/` の中で部品の markup を組み立てない**（#3029 / #3031）。
+    `themes/` だけを掃除しても JS の中は残るので、同じ形の直しが2箇所に散る
+    （#2845 の `aria-hidden` と #2999 の partial 化は、どちらもここが漏れた）
+    - **原則は「helper はデータだけ返し、EJS が描く」**（#2729 の `techcast_items`）
+    - **呼び出し元が多くて描画が重複するときは、helper から
+      `this.partial('_partial/…', {…})` を呼んでよい**（#3031 の `popular_posts_in`）。
+      helper の `this` はテンプレートのローカルなので、`url_for` と同じように使える。
+      呼び出し元が7つあり、データ返しにするとグリッドの繰り返しが7回に増える場面で採った
+    - どちらの形でも、**部品そのものの markup は partial が1箇所で持つ**
 
 **ページの骨格は `container > breadcrumb > row > main#main.col-md-9.blog-posts >
 aside.col-md-3.blog-sidebar`**（#2995）。サイドバーを持たないページは


### PR DESCRIPTION
CLAUDE.md に1項目足すだけです。**実装は変えていません。**

## 背景

CLAUDE.md には「**helper はデータだけ返し、EJS が描く**」とだけ書いてありました（#2729。Tech Cast の `techcast_items`）。

一方 #3031 の `popular_posts_in` は、その形にすると**呼び出し元が7つ**あるためグリッドの繰り返しが7回に増えます。そこで **helper から `this.partial('_partial/panel-card', {…})` を呼ぶ**形を採りました。`this.partial` が helper の中で使えることは #3031 で確認済みです（helper の `this` はテンプレートのローカルなので `url_for` と同じように呼べる）。

**この使い分けがどこにも書かれていませんでした。** 次に同じ場面が来たとき、原則だけを見て7箇所に描画を散らすか、逆に理由なく helper に markup を戻すかのどちらかになります。

## 足したこと

「部品を作るかどうかの基準」（#2985）の下に4行。

- **`scripts/` の中で部品の markup を組み立てない。** `themes/` だけを掃除しても JS の中は残るので、同じ形の直しが2箇所に散る（**#2845 の `aria-hidden` と #2999 の partial 化は、どちらもここが漏れた**）
- **原則は「helper はデータだけ返し、EJS が描く」**（#2729）
- **呼び出し元が多くて描画が重複するときは、helper から `this.partial()` を呼んでよい**（#3031。呼び出し元7つ）
- どちらの形でも、**部品そのものの markup は partial が1箇所で持つ**

## lint

- markdownlint（`make fmt`）0件。テンプレート・`scripts/`・CSS は触っていない

Closes #3036
