### PR TITLE
グラフのツールチップから0を落とし、期間ページの内訳を大カテゴリにそろえる

### DIFF
--- a/themes/future/layout/_partial/chart-tooltip-count.ejs
+++ b/themes/future/layout/_partial/chart-tooltip-count.ejs
@@ -10,13 +10,21 @@
     言っていることは同じで、場所だけ取る。
 
     軸の規則（chart-yaxis-count / chart-xaxis-year-labels）と同じく、
-    1箇所でしか決めないための共有部品 %>
+    1箇所でしか決めないための共有部品。
+
+    shadow: true で軸の帯（axisPointer）を出す。年別の棒グラフはこの形。
+    emptyText: 数えているものが投稿でないグラフ（/tags/ の新規タグ数）は
+    空の言い方が変わるので呼び出し側が渡す %>
+<% const tipShadow = typeof shadow !== 'undefined' && shadow; %>
+<% const tipEmpty = typeof emptyText === 'undefined' ? '投稿なし' : emptyText; %>
 {
   trigger: 'axis',
+<% if (tipShadow) { %>  axisPointer: { type: 'shadow' },
+<% } %>
   formatter: (params) => {
     const label = params.length ? params[0].axisValueLabel : '';
     const rows = params.filter((p) => p.value);
-    if (!rows.length) return `${label}<br>投稿なし`;
+    if (!rows.length) return `${label}<br><%= tipEmpty %>`;
     <%# 値を右端へ寄せるのは echarts の既定のツールチップと同じ組み方。
         ここだけ左寄せにすると、他のグラフと見え方が割れる %>
     return [

--- a/themes/future/layout/_partial/chart-tooltip-count.ejs
+++ b/themes/future/layout/_partial/chart-tooltip-count.ejs
@@ -1,0 +1,30 @@
+<%# 投稿数チャートのツールチップ。echarts の option 内で
+    tooltip: <この部品>, として使う。
+
+    **値が0の系列は出さない** (#2989)。タグ・著者ページの積み上げはサイトの
+    全カテゴリ（18件）を系列に持つので、その月に1本しか無くても既定の
+    ツールチップは18行を並べる。実測で 150×324px あり、高さ120pxのグラフから
+    上へ206px はみ出して、サイドバーの統計を覆っていた。
+
+    投稿が1本も無い月は「投稿なし」の1行にする。0の行を18本並べても
+    言っていることは同じで、場所だけ取る。
+
+    軸の規則（chart-yaxis-count / chart-xaxis-year-labels）と同じく、
+    1箇所でしか決めないための共有部品 %>
+{
+  trigger: 'axis',
+  formatter: (params) => {
+    const label = params.length ? params[0].axisValueLabel : '';
+    const rows = params.filter((p) => p.value);
+    if (!rows.length) return `${label}<br>投稿なし`;
+    <%# 値を右端へ寄せるのは echarts の既定のツールチップと同じ組み方。
+        ここだけ左寄せにすると、他のグラフと見え方が割れる %>
+    return [
+      label,
+      ...rows.map(
+        (p) =>
+          `${p.marker}${p.seriesName}<span style="float:right;margin-left:16px;font-weight:700">${p.value}</span>`,
+      ),
+    ].join('<br>');
+  },
+}

--- a/themes/future/layout/_partial/sidebar-index-archive.ejs
+++ b/themes/future/layout/_partial/sidebar-index-archive.ejs
@@ -15,7 +15,7 @@
       {value: s.pocket, label: 'Pocket', sub: true},
     ];
     // 月の中はデータ量が少ないので内訳は週別の1枚だけ (#2227)
-    archiveCharts = [{id: 'sidebar-chart-week', label: '投稿数（週別）'}];
+    archiveCharts = [{id: 'sidebar-chart-week', label: '投稿数（大カテゴリ別）'}];
   } else {
     const s = is_year() ? summary_yearly_term(page.year) : summary_all_term();
     archiveItems = [
@@ -31,12 +31,12 @@
     // 割っても、週は月の区切りでしかなく読み取るべき問いが無い。
     // 全期間は年を重ねた月を足す（#2757）。
     //
-    // **全期間のカテゴリ別は大カテゴリ（群）で積む。** 127ヶ月 × 18系列を
-    // 285px の列に積むと、1系列あたりの帯が細くなりすぎて色が読めない。
+    // **内訳は3つとも大カテゴリ（群）で積む** (#3044)。18系列だと1系列あたりの
+    // 帯が 285px の列では細くなりすぎて色が読めず、ツールチップも18行になる。
     // 群なら5本で、どの分野が伸びたかが帯の厚みで分かる。
-    // 年ページは12ヶ月なので18系列のままでよい
+    // 月・年・全期間で内訳の単位が変わると、年を押したとたんに読み方が変わる
     archiveCharts = is_year()
-      ? [{id: 'sidebar-chart-category', label: '投稿数（カテゴリ別）'}]
+      ? [{id: 'sidebar-chart-groups', label: '投稿数（大カテゴリ別）'}]
       : [
           {id: 'sidebar-chart-groups', label: '投稿数（大カテゴリ別）'},
           {id: 'sidebar-chart-years', label: '投稿数（年別）'},
@@ -45,21 +45,33 @@
 %>
 <%- partial('sidebar-stats-index', {items: archiveItems, charts: archiveCharts}) %>
 <script type="text/javascript">
-  const archiveCatColors = <%- category_colors() %>;
+  <%# 群の所属は category_groups() が1箇所で持つ（source/_data/category_groups.yml）。
+      ここで束ね直すと、ヘッダーのドロップダウンや /categories/ と割れる %>
+  const archiveGroupDefs = <%- JSON.stringify(category_groups().map(function(g){
+        return {name: g.name, categories: g.categories.map(function(c){ return c.name; })};
+      })) %>;
+  <%# カテゴリ別の系列を群に畳む。3枚のグラフが同じ畳み方を使う %>
+  const archiveGroupSeries = (labels, series, stack) =>
+    archiveGroupDefs.map((g) => ({
+      name: g.name,
+      type: 'bar',
+      stack: stack,
+      data: labels.map((_, i) =>
+        series.reduce((n, s) => n + (g.categories.indexOf(s.name) >= 0 ? s.data[i] || 0 : 0), 0),
+      ),
+    }));
+  <%# 群は対等なので濃淡ではなく色相で分ける。色は scripts/chart_style.js が
+      1箇所で持ち、順は category_groups.yml のキーの順に当たる %>
+  const archiveGroupColors = <%- chart_series_colors('category_groups') %>;
 <% if (is_month()) { %>
   const weekData = <%- get_weekly_category_data(page.year, page.month) %>;
   sidebarChart('sidebar-chart-week', {
-    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    tooltip: <%- partial('chart-tooltip-count', {shadow: true}).trim() %>,
     xAxis: { type: 'category', data: weekData.weeks, axisTick: { show: false } },
+    <%# 縦軸は畳む前の系列で決めてよい。積み上げの合計は畳んでも変わらない %>
     yAxis: <%- partial('chart-yaxis-count', {series: 'weekData.series'}).trim() %>,
-    <%# 色はカテゴリ名で固定 (#2170) %>
-    series: weekData.series.map((s) => ({
-      name: s.name,
-      type: 'bar',
-      stack: 'categories',
-      itemStyle: { color: archiveCatColors[s.name] },
-      data: s.data,
-    })),
+    color: archiveGroupColors,
+    series: archiveGroupSeries(weekData.weeks, weekData.series, 'groups'),
   });
 <% } else { %>
   <%# 粒度は年の指定に関わらず月 (#2432)。読み手が知りたいのは
@@ -68,33 +80,8 @@
   <%# **月ページでも is_year() は真になる**（hexo は page.year があれば真を返す）。
       冒頭の if / else と同じ1本の連鎖にしないと、月ページで存在しない div に
       echarts.init が走る %>
-<% if (is_year()) { %>
-  sidebarChart('sidebar-chart-category', {
-    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
-    xAxis: {
-      type: 'category',
-      data: archiveCatData.months,
-      axisTick: { show: false },
-      axisLabel: <%- partial('chart-xaxis-year-labels', {months: 'archiveCatData.months', el: 'sidebar-chart-category'}).trim() %>
-    },
-    yAxis: { type: 'value', min: 0 },
-    <%# 色はカテゴリ名で固定 (#2170) %>
-    series: archiveCatData.series.map((s) => ({
-      name: s.name,
-      type: 'bar',
-      stack: 'categories',
-      itemStyle: { color: archiveCatColors[s.name] },
-      data: s.data,
-    })),
-  });
-<% } else { %>
-  <%# 群の所属は category_groups() が1箇所で持つ（source/_data/category_groups.yml）。
-      ここで束ね直すと、ヘッダーのドロップダウンや /categories/ と割れる %>
-  const archiveGroupDefs = <%- JSON.stringify(category_groups().map(function(g){
-        return {name: g.name, categories: g.categories.map(function(c){ return c.name; })};
-      })) %>;
   sidebarChart('sidebar-chart-groups', {
-    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    tooltip: <%- partial('chart-tooltip-count', {shadow: true}).trim() %>,
     xAxis: {
       type: 'category',
       data: archiveCatData.months,
@@ -102,22 +89,10 @@
       axisLabel: <%- partial('chart-xaxis-year-labels', {months: 'archiveCatData.months', el: 'sidebar-chart-groups'}).trim() %>
     },
     yAxis: { type: 'value', min: 0 },
-    <%# 群は対等なので濃淡ではなく色相で分ける。色は scripts/chart_style.js が
-        1箇所で持ち、順は category_groups.yml のキーの順に当たる %>
-    color: <%- chart_series_colors('category_groups') %>,
-    series: archiveGroupDefs.map((g) => ({
-      name: g.name,
-      type: 'bar',
-      stack: 'groups',
-      data: archiveCatData.months.map((_, i) =>
-        archiveCatData.series.reduce(
-          (n, s) => n + (g.categories.indexOf(s.name) >= 0 ? s.data[i] || 0 : 0),
-          0,
-        ),
-      ),
-    })),
+    color: archiveGroupColors,
+    series: archiveGroupSeries(archiveCatData.months, archiveCatData.series, 'groups'),
   });
-
+<% if (!is_year()) { %>
   const yearData = <%- posts_year_overlay_series() %>;
   <%# 凡例が無いので selected（初期表示は直近3年）が効かない。そのままだと
       直近5年ぶんの線が全部出る。平坦な古い年が読み取りの邪魔になるのは

--- a/themes/future/layout/_partial/sidebar-index-categories.ejs
+++ b/themes/future/layout/_partial/sidebar-index-categories.ejs
@@ -4,16 +4,32 @@
         {value: site.categories.length, label: 'カテゴリ数'},
         {value: count_articles(), label: '投稿'},
       ],
-      charts: [{id: 'sidebar-chart-categories', label: '累計投稿数（カテゴリ別）'}],
+      charts: [{id: 'sidebar-chart-categories', label: '累計投稿数（大カテゴリ別）'}],
     }) %>
 <script type="text/javascript">
   <%# 月ごとの実数を足し上げて累計にする。ヘルパーは実数のまま返し、
       表示側で累計にする（軸の作り方をヘルパー1箇所に保つ）(#2432) %>
   const categoriesData = <%- get_monthly_category_data() %>;
-  const categoriesColors = <%- category_colors() %>;
-  const categoriesCumulative = categoriesData.series.map((s) => {
+  <%# **内訳は大カテゴリ（群）で積む** (#3044)。18系列を 285px の列に積むと
+      1系列あたりの帯が細くなりすぎて色が読めず、ツールチップも17行になる。
+      群なら5本で、どの分野が伸びたかが帯の厚みで分かる。
+      期間ページ（月・年・全期間）と同じ単位にそろえる。
+      群の所属は category_groups() が1箇所で持つ %>
+  const categoriesGroupDefs = <%- JSON.stringify(category_groups().map(function(g){
+        return {name: g.name, categories: g.categories.map(function(c){ return c.name; })};
+      })) %>;
+  const categoriesCumulative = categoriesGroupDefs.map((g) => {
     let sum = 0;
-    return { name: s.name, data: s.data.map((n) => (sum += n)) };
+    return {
+      name: g.name,
+      data: categoriesData.months.map(
+        (_, i) =>
+          (sum += categoriesData.series.reduce(
+            (n, s) => n + (g.categories.indexOf(s.name) >= 0 ? s.data[i] || 0 : 0),
+            0,
+          )),
+      ),
+    };
   });
   sidebarChart('sidebar-chart-categories', {
     xAxis: {
@@ -28,16 +44,18 @@
       axisLabel: <%- partial('chart-xaxis-year-labels', {months: 'categoriesData.months', el: 'sidebar-chart-categories'}).trim() %>
     },
     yAxis: { type: 'value' },
+    <%# 群は対等なので濃淡ではなく色相で分ける。色は scripts/chart_style.js が
+        1箇所で持ち、順は category_groups.yml のキーの順に当たる %>
+    color: <%- chart_series_colors('category_groups') %>,
     <%# 累計は単調増加で、127点だと棒の差が縞にしか見えない。積み上げ面にすると
-        帯の厚みがそのカテゴリの蓄積量、上端が総数になる。色は名前で固定 (#2170) %>
+        帯の厚みがその群の蓄積量、上端が総数になる %>
     series: categoriesCumulative.map((s) => ({
       name: s.name,
       type: 'line',
       stack: 'categories',
       symbol: 'none',
       lineStyle: { width: 0 },
-      areaStyle: { color: categoriesColors[s.name] },
-      itemStyle: { color: categoriesColors[s.name] },
+      areaStyle: {},
       data: s.data,
     })),
   });

--- a/themes/future/layout/_partial/sidebar-index-tags.ejs
+++ b/themes/future/layout/_partial/sidebar-index-tags.ejs
@@ -22,7 +22,7 @@
   const tagYearData = <%- new_tags_by_year() %>;
   const tagCatColors = <%- category_colors() %>;
   sidebarChart('sidebar-chart-tag-category', {
-    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    tooltip: <%- partial('chart-tooltip-count', {shadow: true, emptyText: '新しいタグなし'}).trim() %>,
     xAxis: { type: 'category', data: tagYearData.years, axisTick: { show: false } },
     yAxis: { type: 'value', min: 0, minInterval: 1 },
     <%# 色はカテゴリ名で固定 (#2170) %>
@@ -37,7 +37,7 @@
 
   const tagRetentionData = <%- new_tags_retention() %>;
   sidebarChart('sidebar-chart-tag-retention', {
-    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    tooltip: <%- partial('chart-tooltip-count', {shadow: true, emptyText: '新しいタグなし'}).trim() %>,
     xAxis: { type: 'category', data: tagRetentionData.years, axisTick: { show: false } },
     yAxis: { type: 'value', min: 0, minInterval: 1 },
     <%# 土台が定着、上が定着せず。週別の積み上げと同じ段を共有する %>

--- a/themes/future/layout/_partial/sidebar-stats-index.ejs
+++ b/themes/future/layout/_partial/sidebar-stats-index.ejs
@@ -47,7 +47,7 @@
         {
           // タイトルは直上のラベルが担うので、チャートの中では重ねない
           title: {},
-          tooltip: { trigger: 'axis' },
+          tooltip: <%- partial('chart-tooltip-count').trim() %>,
           <%# right に余白を置くのは、containLabel が**端のカテゴリラベルの
               はみ出しを見ない**ため。軸の最後の目盛は grid の右端にあり、
               「2026」の半分（約13px）が外へ出て切れる。

--- a/themes/future/layout/_partial/sidebar-stats.ejs
+++ b/themes/future/layout/_partial/sidebar-stats.ejs
@@ -88,7 +88,7 @@
     sidebarChart.setOption({
       <%# タイトルは直上の h2 が担うので、チャート内では重ねない %>
       title: {},
-      tooltip: { trigger: 'axis' },
+      tooltip: <%- partial('chart-tooltip-count').trim() %>,
       <%# 既定の grid.left 10% で右へズレて見える。軸ラベル込みで左端に寄せる。
           right に余白を置くのは、containLabel が**端のカテゴリラベルのはみ出しを
           見ない**ため。軸の最後が1月に当たると「2026年」の半分が外へ出て切れる %>


### PR DESCRIPTION
## やったこと

サイドバーの投稿数グラフのツールチップから、**値が0の系列を落とします**（#2989）。

| | before | after |
| --- | --- | --- |
| `/tags/Go/` の 2020/12 | **150 × 324px**・25行（うち0が11行） | **144 × 64px**・1行（`Programming 2`） |
| 投稿の無い月 | 全18カテゴリが `0` で並ぶ | **「投稿なし」の1行**（78 × 64px） |
| 位置 | 高さ120pxのグラフから**上へ206px はみ出す**（統計の枠を覆う） | はみ出さない |

タグ・著者ページの積み上げは**サイトの全カテゴリ（18件）を系列に持つ**ので、その月に1本しか無くても18行が並んでいました。

## グラフ自体は変えていません

#2989 の案（刻みを丸める / 軸に窓を切る / 本数の閾値を上げる）は**どれも採りません**。

- 棒が細くても**ホバーは効きます**（`trigger: 'axis'` なので棒を狙う必要がない。実測で幅の30%→`2020/12`、55%→`2023/03`、80%→`2025/06`）
- 月単位の傾向は 253px でもシルエットとして読めます
- **月刻みを崩すと「いつ書かれたか」の解像度が落ちます。**そちらの方が損です

issue の「棒が細くて形を読めない」という前提の方を、実測に合わせて訂正します。実際に壊れていたのはツールチップでした。

## 年別のグラフにも同じ形を（レビューでの指摘）

`/articles/` と `/tags/` のグラフは**自前の `tooltip` を持っていて共有部品を通っていません**でした。5箇所とも寄せています。

- 軸の帯（`axisPointer: shadow`）は引数で受け取る（年別の棒グラフはこの形）
- **投稿を数えていないグラフ**（`/tags/` の新規タグ数）は空のときの言い方が変わるので、`emptyText` を呼び出し側が渡す（「新しいタグなし」）

実測: `/tags/` の2016年は18系列中**12行だけ**表示（before は18行）。

## 期間ページの内訳を大カテゴリ（群）にそろえる（レビューでの指摘）

| ページ | before | after |
| --- | --- | --- |
| `/articles/`（全期間） | 大カテゴリ別（5系列） | 変えていない |
| **`/articles/2025/`（年）** | **カテゴリ別（18系列）** | **大カテゴリ別（5系列）** |
| **`/articles/2025/06/`（月・週別）** | **カテゴリ別（18系列）** | **大カテゴリ別（5系列）** |
| **`/categories/`（累計の積み上げ面）** | **カテゴリ別（18系列）** | **大カテゴリ別（5系列）** |

285px の列で18系列を積むと、**1系列あたりの帯が細くなりすぎて色が読めません**。ツールチップも18行になります。群なら5本で、どの分野が伸びたかが帯の厚みで分かります。

全期間だけが群だったので、**年を押したとたんに内訳の単位が変わっていた**のも揃います。

実測のツールチップ: 年ページ `5月 開発8 基盤9 AI7 セキュリティ1`、月ページ `第2週 開発1 基盤1`、カテゴリ一覧 `2020/10 開発129 基盤92 AI32 セキュリティ7 ビジネス51`（**164×400px → 144×148px**）。

畳む処理は3枚で共有し、群の所属は `category_groups()`、色は `chart_series_colors('category_groups')` が1箇所で持ちます。

## 作り

軸の規則（`chart-yaxis-count` / `chart-xaxis-year-labels`）と同じく**共有部品**（`_partial/chart-tooltip-count.ejs`）にして、個別ページ（`sidebar-stats`）と一覧ページ（`sidebar-stats-index`）の2箇所から呼びます。

## 確認

`/tags/Go/` `/categories/Programming/` `/authors/…` `/tags/` `/categories/` `/authors/` `/articles/` `/articles/2025/` `/articles/2025/06/` の9ページで、コンソールエラーなし・グラフが描かれることを確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
