### PR TITLE
部品の台帳を /doctor/ へ移す (#3045)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -3354,14 +3354,6 @@ ul.tag-list {
 }
 /* /specials/gallery/ の部品ギャラリー (#2985)。運営用のページなので、
    /doctor/ と同じく素の一覧と枠だけで組む。新しい段は作らない */
-.gallery-ledger {
-  padding-left: 0;
-  list-style: none;
-}
-.gallery-ledger > li {
-  padding: 6px 0;
-  border-bottom: 1px solid var(--rule-weak);
-}
 .gallery-note {
   display: block;
   color: ink-mute;
@@ -3372,13 +3364,6 @@ ul.tag-list {
   margin: 0 0 12px;
   color: ink-mute;
   font-size: text-meta;
-}
-/* 見本を持たない部品が分類から漏れたときの注意。差し色にするのは、
-   台帳に並ぶ行と違って**直す先がある**ため */
-.gallery-alert {
-  margin: 16px 0 0;
-  color: brand-crimson;
-  font-size: text-body;
 }
 /* 見本を1つずつ枠で囲む。地は白のまま——中の部品が白地の上で決めた値を持つ (#2874) */
 .gallery-item {
@@ -3402,6 +3387,13 @@ ul.tag-list {
 /* サイドバーの枠はその列の内寸で描かないと実物と違って見える (#2943 の 208〜298px) */
 .gallery-sidebar-scale {
   max-width: 253px;
+}
+/* 分類から漏れた部品の注意 (#3045)。差し色にするのは、台帳に並ぶ行と違って
+   **直す先がある**ため */
+.doctor-alert {
+  margin: 16px 0 0;
+  color: brand-crimson;
+  font-size: text-body;
 }
 /* /doctor/ の検査結果リスト */
 .doctor-list {

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -11,6 +11,11 @@
     const textSuggest = doctor_text_suggestions();
     const dormant = doctor_dormant_authors();
     const thisYear = new Date().getFullYear();
+    // 共通部品の台帳 (#3045)。見本は /specials/gallery/ が持ち、ここは
+    // 「どこから呼ばれているか」と「分類の漏れ」だけを持つ。
+    // パスと呼び出し元はリポジトリの中の話なので、読者向けのページには置かない
+    // （#2864 / #2895 と同じ線引き）
+    const uiParts = ui_partial_index();
     const SECTIONS = [
       {id: 'duplicates', text: 'ほぼ重なるタグ（統合候補）', label: '統合候補のタグ', count: checks.nearDuplicates.length},
       {id: 'single-use', text: '1記事にしか使われていないタグ', label: '1記事タグ', count: checks.singleUse.length},
@@ -18,6 +23,7 @@
       {id: 'ontology', text: 'タグの親子関係（オントロジー）', label: 'オントロジー登録', count: onto.nodeCount},
       {id: 'text-suggestions', text: '本文に何度も出てくるのにタグが付いていない記事', label: 'タグ付け漏れ候補', count: textSuggest.posts.length},
       {id: 'dormant', text: '投稿が途切れている著者', label: '投稿が途切れた著者', count: dormant.recent.length},
+      {id: 'ui-partials', text: '共通部品の台帳', label: '共通部品', count: uiParts.rows.length},
     ];
     const heading = (id) => partial('_partial/section-heading', SECTIONS.find(s => s.id === id));
   %>
@@ -240,6 +246,26 @@
       <% } else { %>
       <p>該当なし</p>
       <% } %>
+      <div class="doctor-single">
+        <section>
+          <%- heading('ui-partials') %>
+          ※テンプレートで共通化されている部品と、それを使っている画面です。見本は <a href="/specials/gallery/">部品ギャラリー</a> にあります
+          <ul class="doctor-list">
+            <% uiParts.rows.forEach(function(r){ %>
+            <li>
+              <code><%= r.name %></code>
+              <span class="doctor-note"><%= r.callers.length %>画面<% if (r.callers.length) { %>: <%= r.callers.join('、') %><% } %><% if (!r.shown && r.reason) { %>／見本なし: <%= r.reason %><% } %></span>
+            </li>
+            <% }) %>
+          </ul>
+          <% if (uiParts.unclassified.length) { %>
+          <p class="doctor-alert">見本も「見本を出さない理由」も無い部品が <%= uiParts.unclassified.length %>件あります: <% uiParts.unclassified.forEach(function(r, i){ %><code><%= r.name %></code><%= i < uiParts.unclassified.length - 1 ? '、' : '' %><% }) %>。ギャラリーに見本を出すか、<code>scripts/ui_gallery.js</code> に理由を書いてください</p>
+          <% } %>
+          <% if (uiParts.orphan.length) { %>
+          <p class="doctor-alert">呼び出し元が無い部品が <%= uiParts.orphan.length %>件あります: <% uiParts.orphan.forEach(function(r, i){ %><code><%= r.name %></code><%= i < uiParts.orphan.length - 1 ? '、' : '' %><% }) %></p>
+          <% } %>
+        </section>
+      </div>
     </div>
   </div>
     </main>

--- a/themes/future/layout/gallery.ejs
+++ b/themes/future/layout/gallery.ejs
@@ -12,7 +12,7 @@
     （ページの骨格や head のような見た目を持たないものまで並ぶと、
     「共通の部品はどれか」が読み取れなくなる）。見本を持たない部品は
     scripts/ui_gallery.js の NOT_SHOWN が理由ごと引き受け、
-    **どちらでもないものだけ**が台帳の下の警告に出る。
+    **どちらでもないものだけ**が /doctor/ の「共通部品の台帳」に警告として出る (#3045)。
 
     **ここで新しい部品は作らない。** いま共通化されているものだけを展示する。
     どれを部品にするかは #2985 の候補一覧で別に決める %>
@@ -23,7 +23,6 @@
   // 条件を満たす記事でないと見本が空になる
   const authorPost = site.posts.sort('date', -1).toArray()
     .find(function(p){ const pr = get_profile_data(p.author); return pr && pr.about; });
-  const index = ui_partial_index();
 %>
 <div class="container">
   <%- partial('_partial/breadcrumb', {items: [
@@ -35,24 +34,7 @@
   <div class="margin-top-30">
     <div class="footer-gap">
       <h1 class="list-page margin-bottom-20">部品ギャラリー</h1>
-      <p class="specials-text">テンプレートで共通化されている部品を、実物を呼んで並べたページです。運営向けで、見た目の決まりそのものは <a href="/specials/styleguide/">スタイルガイド</a> が持ちます。</p>
-
-      <%- partial('_partial/section-heading', {id: 'ledger', text: '台帳', meta: '全' + index.shown.length + '件'}) %>
-      <p class="specials-text">下に見本を並べている部品と、それを使っている画面です。画面数にこのページは含めません。</p>
-      <ul class="gallery-ledger">
-        <% index.shown.forEach(function(r){ %>
-        <li>
-          <code><%= r.name %></code>
-          <span class="gallery-note"><%= r.callers.length %>画面<% if (r.callers.length) { %>: <%= r.callers.join('、') %><% } %></span>
-        </li>
-        <% }) %>
-      </ul>
-      <% if (index.unclassified.length) { %>
-      <p class="gallery-alert">見本も「見本を出さない理由」も無い部品が <%= index.unclassified.length %>件あります: <% index.unclassified.forEach(function(r, i){ %><code><%= r.name %></code><%= i < index.unclassified.length - 1 ? '、' : '' %><% }) %>。見本を出すか、<code>scripts/ui_gallery.js</code> に理由を書いてください。</p>
-      <% } %>
-      <% if (index.orphan.length) { %>
-      <p class="gallery-alert">呼び出し元が無い部品が <%= index.orphan.length %>件あります: <% index.orphan.forEach(function(r, i){ %><code><%= r.name %></code><%= i < index.orphan.length - 1 ? '、' : '' %><% }) %></p>
-      <% } %>
+      <p class="specials-text">テンプレートで共通化されている部品を、実物を呼んで並べたページです。見た目の決まりそのものは <a href="/specials/styleguide/">スタイルガイド</a>、保守用の台帳（呼び出し元と分類の漏れ）は <a href="/doctor/">記事ドクター</a> が持ちます。</p>
 
       <%- partial('_partial/section-heading', {id: 'elements', text: '要素'}) %>
       <p class="specials-text">それ以上分けられない最小の部品です。絵柄の辞書は <code>_partial/svg-icon.ejs</code> が1箇所で持ち、カテゴリ名との対応は <code>_partial/category-icon.ejs</code> の側にあります。</p>
@@ -257,7 +239,6 @@
     </main>
     <aside class="col-md-3 blog-sidebar">
       <%- partial('_partial/sidebar', {specialsToc: [
-        {id: 'ledger', text: '台帳'},
         {id: 'elements', text: '要素'},
         {id: 'components', text: '部品'},
         {id: 'patterns', text: 'かたまり'},


### PR DESCRIPTION
> **この PR のマージ先は `main` ではなく #3043 のブランチ（`gallery-ledger-catchup`）です。** 同じファイルを触るので積んでいます。**#3043 をマージすると、この PR のベースは自動的に `main` に切り替わります。**

ギャラリーを公開のコンポーネント集にする**段階A**です。

## 面の分け方（今回決めたこと）

| ページ | 持つもの |
| --- | --- |
| スタイルガイド | 色・文字・行間・間隔・形・状態の**決まり**。記事の中の見た目（note・表） |
| **ギャラリー** | **部品のカタログ**。実物と使いどころ |
| `/doctor/` | 保守用の**台帳**（パス・呼び出し元・分類の漏れ） |

Foundations / Components で切る、業界の通例に合わせた形です。

## なぜ台帳を動かすか

いまのギャラリーは**保守コンソール**として作ってあり、**読者に見せられない情報**を持っています。

```
_partial/svg-icon                            ← リポジトリのファイルパス
20画面: _partial/archive.ejs、author.ejs、…   ← 呼び出し元のファイル名
「scripts/ui_gallery.js に理由を書いてください」  ← 保守作業の指示
```

これは CLAUDE.md が公開ページに書かないと決めているものです（#2864「リポジトリのファイルパスへのリンクは読者にとって行き止まりになる」、#2895「ソースの出現回数（『呼び出し元 19』）」）。

**「ギャラリーだから非公開」ではなく「いまのギャラリーは保守コンソールだから公開面に出せない」**が正確なところでした。台帳を分ければ公開できます。

## やったこと

- `/doctor/` に**「共通部品の台帳」の節**を足す。既存の検査と同じ `doctor-list` の形で、行は `部品名 ／ N画面: 使っている画面 ／ 見本なし: 理由`
- 分類の漏れ・呼び出し元ゼロの**警告もそちらへ**
- ギャラリーの冒頭に行き先を書く（決まりは[スタイルガイド]、台帳は[記事ドクター]）
- `.gallery-ledger` を落とし、`.gallery-alert` を `.doctor-alert` に移す

**この段階では公開しません**（noindex のまま）。

## 確かめたこと

```
/doctor/           台帳 51行 / 警告 0件 / 冒頭の統計タイルに「共通部品」が並ぶ
/specials/gallery/ 台帳 0 / 警告 0 / 見本の枠 19 / 記事ドクターへの導線あり
```

## 途中で踏んだ罠

**`<% … %>` の JS ブロックの中に `<%# … %>` を書いて、ページが丸ごと落ちました**（`Could not find matching close tag for "<%"`）。`/doctor/` が0バイトになり、`WARN No layout` が出ます。JS のコメント（`//`）に直しました。生成物を見ていなければ気づけない壊れ方です。

## 次の段階

- **B**: ギャラリーを読者の言葉に書き換えて公開（noindex 解除・`/specials/` に掲載・アイコン / カード / 節見出し / パンくず / 統計 / タブの6つを追加・使いどころを1〜2文）
- **C**: スタイルガイドの「チップ」をギャラリーへ送り、導線を1本置く

## lint

- textlint（`doctor.ejs` / `gallery.ejs`）0件
- `scripts/` は触っていないので prettier の対象に変化なし

Closes #3045
