### PR TITLE
選択中のタブの飛び出しを戻し、人気の連載の子を字下げする

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -597,6 +597,15 @@ Header and header elements
 .header-dropdown-more:hover {
   background: var(--surface-mute);
 }
+/* ラベルを持つパネル（人気の連載）の行は、ラベルの文字に頭をそろえる。
+   ラベルはアイコンを持つぶん文字が 16px 右から始まるので、そろえないと
+   子の行が親の文字より左から始まって、まとまりとして読めない。
+   面（hover の的）は動かさず、文字だけ寄せる。
+   **全件導線（.header-dropdown-more）は寄せない。** あれは「人気の連載」の
+   子ではなくパネル自身の行き先で、仕切りの線もそう名乗っている */
+.header-dropdown-label ~ .header-dropdown-item {
+  padding-left: (space-step * 3) + (space-step * 4);
+}
 /* パネルの中の仕切り。見出しではなく面の中のラベルなので h2 は使わない
    （検索のヒントパネルと同じ扱い） */
 .header-dropdown-label {
@@ -3326,30 +3335,6 @@ ul.tag-list {
    年ごとの ID ルールを毎年 CSS に足さずに済むよう、input+label+content を
    隣接させて flex の order で並べ替える。ラベルだけ order:1 で帯に並び、
    選択された組のコンテンツが order:2 + 全幅で下段に出る */
-/* 期間ページのグラフ切り替えタブ (#2171)。year-tabs と同じ input+label+content
-   方式だが、非表示側を display:none にすると ECharts が幅0のまま初期化されて
-   描画が壊れるため、高さ0で畳んで幅は保つ */
-.tabs.chart-tabs {
-  display: flex;
-  flex-wrap: wrap;
-}
-.chart-tabs .tab_item {
-  float: none;
-  order: 1;
-}
-.chart-tabs .tab_content {
-  order: 2;
-  width: 100%;
-  display: block;
-  height: 0;
-  padding: 0 22px;
-  overflow: hidden;
-}
-.chart-tabs input:checked + .tab_item + .tab_content {
-  height: auto;
-  padding: 18px 22px;
-  overflow: visible;
-}
 .tabs.year-tabs {
   /* 後方の .tabs { display: flow-root } と同詳細度だと記述順で負けて
      flex が効かず、ラベルがインライン扱いで選択コンテンツの後ろに
@@ -4742,13 +4727,19 @@ a.award-badge:focus {
   float: left;
   /* 真下に出す .tab-hint の基準 (#2852) */
   position: relative;
-  /* 上辺のアクセントは箱の内側に置く。以前は負のマージン（-8px）でカードの外へ
-     出していたが、枠線を持つと線がタブを横切るので内側に収めた (#2747)。
-     文字の位置は変わらない（border 3 + padding 10 = 13。未選択も選択も同じ）。
+  /* 上辺のアクセントをカードの外に出す。負のマージンで持ち上げた分を
+     padding-top で戻すので、文字の位置と下辺は動かない
+     （margin -8 + border 3 + padding 18 = 13。未選択も選択も同じ）。
 
-     未選択時の枠は透明なので、何も起きていないように見える */
-  padding: 10px 22px 10px;
-  margin: 0 4px 0 0;
+     **全タブに掛けるのが要点。** 選択やホバーのときだけ持ち上げると、
+     マウスを乗せるたびにタブが跳ねてしまう。
+     未選択タブは地も枠も透明なので、飛び出して見えるのは選択中の1つだけ。
+
+     #2747 でカードが枠線を持ったとき「線がタブを横切る」として内側へ収めたが、
+     実際には起きない。選択中のタブは白い地がカードの上辺線を覆い、
+     未選択タブは透明なので線がカードの上端としてそのまま見えるだけ */
+  padding: 18px 22px 10px;
+  margin: -8px 4px 0 0;
   font-size: text-row;
   line-height: leading-row;
   letter-spacing: 0.02em;
@@ -4853,14 +4844,12 @@ a.award-badge:focus {
     opacity: 1;
   }
 }
-.chart-tabs input:checked + .tab_item + .tab_content,
 .year-tabs input:checked + .tab_item + .tab_content {
   animation: tab-fade-in tab-speed ease;
 }
 /* 動きを減らす設定では切り替えを瞬時に戻す。0.05秒の色や面の送りは
    動きではないので止めない（#2686 と同じ線引き） */
 @media (prefers-reduced-motion: reduce) {
-  .chart-tabs input:checked + .tab_item + .tab_content,
   .year-tabs input:checked + .tab_item + .tab_content {
     animation: none;
   }


### PR DESCRIPTION
## 1. 選択中のタブの飛び出しを戻す

「戻っている」というご指摘でしたが、**戻ったのではなく #2747 で意図的に外されていました。**

```
3c547a3a  選択中のタブのアクセントをカードの外に出す      ← 導入
c7c27fb8  タブのアクセントの飛び出し量を 8px にする        ← 調整
74c2cd07  カードの影をやめ、一覧は輪郭を持たせない (#2747) ← 撤去
```

#2747 でカードが影をやめて `border: 1px solid rule-base` を持ったため、「枠線を持つと線がタブを横切る」という理由で内側に収められています。

**その問題は実際には起きませんでした。** 選択中のタブは白い地がカードの上辺線を覆い、未選択タブは透明なので線がカードの上端としてそのまま見えるだけです。

負のマージンは**全タブに掛けます**。選択やホバーのときだけ持ち上げるとマウスを乗せるたびにタブが跳ねるためです。未選択タブは地も枠も透明なので、飛び出して見えるのは選択中の1つだけになります。

実測（タブを使う3箇所すべて）:

```
ランキング / 著者の年別 / ギャラリー
  飛び出し 7px（カードが1px枠を持つぶん、枠外への出方は7px）
  下辺一致 true    文字位置一致 true    ← 跳ねが起きない
```

## 2. 人気の連載の子を字下げ

ラベル「人気の連載」はアイコンを持つぶん**文字が 16px 右から始まる**のに、子の行はアイコンの位置にそろっていました。親の文字より左から始まるので、まとまりとして読めていません。

```
変更前   ⚑ 人気の連載
        秋のブログ週間2025      ← ラベルの文字より左

変更後   ⚑ 人気の連載
            秋のブログ週間2025  ← ラベルの文字にそろう
```

- ずらす量は `space-step` 4つ分（16px）。ラベルの文字の開始位置を実測して決めました
- **面（hover の的）は動かさず、文字だけ寄せます**
- **全件導線（連載の一覧を見る）は寄せません。** あれは「人気の連載」の子ではなくパネル自身の行き先で、仕切りの線もそう名乗っています
- ラベルを持つパネルは連載だけなので、**カテゴリ18件・リソース・アクティビティの行は動きません**（4パネルすべての padding を実測して確認）

## 3. 掃除

`.chart-tabs` の CSS が孤立していたので落としました。本文のグラフをサイドバーへ移した #3025 以降、参照はコメントだけになっていました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
