### PR TITLE
部品ギャラリーのアイコン一覧を辞書から生成する (#3054)

### DIFF
--- a/scripts/ui_gallery.js
+++ b/scripts/ui_gallery.js
@@ -132,6 +132,19 @@ function buildIndex() {
 hexo.extend.helper.register('ui_partial_index', buildIndex);
 
 /**
+ * アイコンの一覧は辞書から出す (#3054)。手で並べていたときは、
+ * 辞書に無い名前が5件混ざり、svg-icon.ejs が何も出さないまま
+ * ラベルだけが並んでいた。辞書は svg-icon.ejs の JS ブロックの中にあって
+ * require できないので、キーだけを読み出す
+ */
+hexo.extend.helper.register('ui_icon_names', function () {
+  const src = fs.readFileSync(path.join(LAYOUT_DIR, '_partial', 'svg-icon.ejs'), 'utf8');
+  const from = src.indexOf('const SVG_ICON_PATHS = {');
+  const dict = src.slice(from, src.indexOf('\n};', from));
+  return [...dict.matchAll(/^ {2}'([^']+)':/gm)].map((m) => m[1]);
+});
+
+/**
  * 見本に使う実データ。作り物のダミーは置かない——実物を出せば、
  * 部品が本番で何を渡されているかがそのまま見える
  */

--- a/themes/future/layout/gallery.ejs
+++ b/themes/future/layout/gallery.ejs
@@ -39,7 +39,9 @@
         <p class="gallery-name">アイコン</p>
         <p class="specials-text">線画で統一し、文字の色を継ぎます。見出し・ナビ・チップ・ボタンの中に置きます。</p>
         <ul class="gallery-icons">
-          <% ['code','cloud','server','infinity','browser','mountain','brain','database','device-mobile','file-code','device-watch','building-store','chart-dots','users-group','robot','shield-lock','key','augmented-reality','tag','tags','category','users','user','calendar-stats','run-baton','book','speakerphone','crown','rss','external-link','chevron-right','chevron-down','search'].forEach(function(name){ %>
+          <%# 一覧は辞書から出す (#3054)。手で並べると辞書に無い名前が混ざり、
+              絵の出ないラベルだけが並ぶ %>
+          <% ui_icon_names().forEach(function(name){ %>
           <li><%- partial('_partial/svg-icon', {icon: name}) %><span class="gallery-note"><%= name %></span></li>
           <% }) %>
         </ul>


### PR DESCRIPTION
Closes #3054

部品ギャラリーの「アイコン」の節だけが辞書と連動しない手書きの配列だったので、**辞書から生成**します。

## 直った不具合

**辞書に無い名前が5件並んでいて、絵が出ていませんでした。** `_partial/svg-icon.ejs` は未知の名前では何も出さないので、**ラベルだけが出て絵が空**の項目が公開ページに並んでいました。

```
device-watch / building-store / chart-dots / robot / augmented-reality
```

| | before | after |
| --- | --- | --- |
| 見本の件数 | 33 | **46**（辞書の全件） |
| **絵が出ていないもの** | **5** | **0** |
| 辞書にあるのに載っていないもの | 18 | 0 |

配信中の `/specials/gallery/` を parse して数えました。after は46件すべてが `<svg>` を持ちます。

## やったこと

`scripts/ui_gallery.js` に `ui_icon_names()` を足しました。辞書は `svg-icon.ejs` の JS ブロックの中にあって `require` できないので、**台帳（`ui_partial_index`）と同じくファイルからキーを読み出します**。

並びは辞書の順のままです。辞書はカテゴリ系 → UI → ブランド → その他と並んでいて、そこに意味があります。

## 範囲外

**辞書にあるがどこでも使われていない3件**（`brand-youtube` / `brand-connpass` / `award`）は消していません。カタログとしては「サイトが持っているもの」を出すのが正しく、辞書から消すかは別の判断です。**生成に変えたことで、この3件はページ上に見えるようになりました。**

`speakerphone` と `book` は一度「未使用」と数えましたが、`_partial/archive.ejs` が `labelIcon:` という別のキーで渡していただけで使われています。`facebook` / `hatebu` / `pocket` は `social-button.ejs` が塗りの SVG を自前で持つもので、`svg-icon` の線画とは別系統です。

## CI

- prettier: `npx prettier --check "scripts/**/*.js" "*.mjs"` → 通過
- 記事は触っていないので textlint の対象なし
