### PR TITLE
関連タグの共起の群を「一緒に使われるタグで探す」にする (#3059)

### DIFF
--- a/themes/future/layout/_partial/related-tags.ejs
+++ b/themes/future/layout/_partial/related-tags.ejs
@@ -23,7 +23,7 @@
         軸が年の系列（インターン2022 / GoogleCloudNext2024）は「他の年」 %>
     <% const labels = {
          detail: 'もっと詳しいタグで探す',
-         adjacent: '隣接するタグを探す',
+         adjacent: '一緒に使われるタグで探す',
          broader: 'もっと広いタグで探す',
          versions: '他のバージョン',
          years: '他の年',


### PR DESCRIPTION
タグページの「関連タグ」で、共起の群のラベルを「隣接するタグを探す」から
**「一緒に使われるタグで探す」**に変えます。

Closes #3059

## なぜ

「隣接」はグラフ用語で、**何と何が隣なのかが読み取れない**。隣に並ぶ「もっと詳しい」
「もっと広い」は関係が言葉のとおりに読めるのに、ここだけ読者の語彙になっていなかった。

実際の関係は「同じ記事に一緒に付いている」で、**パネルの添え（`N本を共有`）は既に
それを言っている**。ラベルだけが別の言い方をしていた。

## 変えたもの

`themes/future/layout/_partial/related-tags.ejs` の表示文字列1行だけ。

```diff
-         adjacent: '隣接するタグを探す',
+         adjacent: '一緒に使われるタグで探す',
```

群の中身・並び・スコア（`scripts/related_tags.js`）は触っていません。

## 4つのラベルの並び

| 群 | ラベル | 添え |
| --- | --- | --- |
| `detail` | もっと詳しいタグで探す | `N本` |
| `adjacent` | **一緒に使われるタグで探す** | `N本を共有` |
| `broader` | もっと広いタグで探す | `N本` |
| `versions` / `years` | 他のバージョン / 他の年 | `N本` |

「詳しい ↔ 広い」が抽象度の軸、`adjacent` が共起の軸、`versions` / `years` が版の軸、
という3本立てになります。末尾を「〜で探す」に揃えているのもそのまま。

## 検証

`hexo server` の配信 HTML から `related-tag-groups` の節を切り出して、
`<h3 class="panels-label">` を全部拾いました。

| ページ | 出たラベル |
| --- | --- |
| `/tags/Terraform/` | もっと詳しいタグで探す / **一緒に使われるタグで探す** |
| `/tags/Go/` | もっと詳しいタグで探す / **一緒に使われるタグで探す** |
| `/tags/AWS/` | もっと詳しいタグで探す / **一緒に使われるタグで探す** |
| `/tags/インターン2024/` | もっと広いタグで探す / 他の年 |

3ページとも節の中に「隣接」の文字列は残っていません。版・年の群は従来どおり出ます。

- `node_modules/.bin/textlint themes/future/layout/_partial/related-tags.ejs` … 0件
- prettier の対象（`scripts/**/*.js` / `*.mjs`）は触っていません

## この PR の範囲外

- **`scripts/related_tags.js` のコメントの「隣接」はそのまま。** あちらは群の内部の
  呼び名（`adjacent` というキーの説明）で、読者には出ません。CLAUDE.md の
  「本文はフロントエンド一般の語で書く、内部の語彙はそのままでよい」(#2873) に沿って
  据え置きます
- #3057（「よく読まれている記事」のパネル）・#3061（hover）はこの節に触りません
