### PR TITLE
aside に名前を付けて complementary ランドマークを区別できるようにする (#3065)

### DIFF
--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -163,7 +163,7 @@
       </div>
     </article>
   </main>
-  <aside class="col-md-3 blog-sidebar">
+  <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
     <%- partial('sidebar') %>
   </aside>
 </div>

--- a/themes/future/layout/_partial/related-categories.ejs
+++ b/themes/future/layout/_partial/related-categories.ejs
@@ -5,7 +5,7 @@
     つながったのかが隠れて、読者が関連の質を判断できない %>
 <% const rc = related_categories(page.category); %>
 <% if (rc.length) { %>
-<aside data-nosnippet>
+<aside data-nosnippet aria-label="関連カテゴリ">
   <section class="popular-articles margin-bottom-20">
     <% if (rc.length) { %>
     <%- partial('section-heading', {id: 'relatedcategories', text: '関連カテゴリ'}) %>

--- a/themes/future/layout/_partial/related-tags.ejs
+++ b/themes/future/layout/_partial/related-tags.ejs
@@ -3,7 +3,7 @@
     最終ページ = ページャーの下（読み尽くした読者への次の導線）(#2088 / #2213) %>
 <% const groups = related_tags(page.tag); %>
 <% if (groups.length) { %>
-<aside data-nosnippet>
+<aside data-nosnippet aria-label="関連タグ">
   <section class="popular-articles related-tag-groups margin-bottom-20">
     <%# 見出しは記事ページの「関連記事」に合わせる。あちらも内部ではスコアで
         並べているが強度は名乗っていない。「関連が強いタグ」とすると根拠を

--- a/themes/future/layout/advent-calendar.ejs
+++ b/themes/future/layout/advent-calendar.ejs
@@ -103,7 +103,7 @@
     </div>
   </div>
     </main>
-    <aside class="col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar', {specialsToc: [
         {id: 'calendars', text: '歴代のアドベントカレンダー'},
         {id: 'revival', text: 'ブログで読めるアドベントカレンダー記事'},

--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -151,7 +151,7 @@
     </nav>
     <% } %>
     </main>
-    <aside class="col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar-index-archive') %>
     </aside>
   </div>

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -91,7 +91,7 @@
         出すのはこのページ自身の統計だけ (#2911)。
         列そのものは中身が無くても残す。畳むと本文の幅がこのページだけ広くなり、
         一覧を行き来したときにカードの幅が揃わない (#2944) %>
-    <aside class="col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar', {showStats: true}) %>
     </aside>
   </div>

--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -79,7 +79,7 @@
 
     </div>
     </main>
-    <aside class="col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar-index-authors') %>
     </aside>
   </div>

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -51,7 +51,7 @@
     <% }) %>
 
     </main>
-    <aside class="col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar-index-categories') %>
     </aside>
   </div>

--- a/themes/future/layout/category-without.ejs
+++ b/themes/future/layout/category-without.ejs
@@ -42,7 +42,7 @@
     <%- partial('_partial/archive', {pagination: config.category, index: true, list_heading: page.current === 1 ? '新着記事' : '記事一覧', list_note: backLink}) %>
   </div>
     </main>
-    <aside class="col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%# _partial/sidebar はこのページでは何も描かない（軸の枠はカテゴリページで
           伏せている #3024）。統計だけを持つ専用の partial を呼ぶ %>
       <%- partial('_partial/sidebar-index-without') %>

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -72,7 +72,7 @@
 
   </div>
     </main>
-    <aside class="col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar', {showStats: true}) %>
     </aside>
   </div>

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -269,7 +269,7 @@
     </div>
   </div>
     </main>
-    <aside class="col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar', {specialsToc: SECTIONS}) %>
     </aside>
   </div>

--- a/themes/future/layout/gallery.ejs
+++ b/themes/future/layout/gallery.ejs
@@ -259,7 +259,7 @@
     </div>
   </div>
     </main>
-    <aside class="col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar', {specialsToc: [
         {id: 'elements', text: '要素'},
         {id: 'components', text: '部品'},

--- a/themes/future/layout/guidelines.ejs
+++ b/themes/future/layout/guidelines.ejs
@@ -66,7 +66,7 @@
     </div>
   </div>
     </main>
-    <aside class="col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar', {specialsToc: [
         {id: 'archguidelines', text: '設計ガイドライン'},
         {id: 'codingstandards', text: 'コーディング規約'},

--- a/themes/future/layout/httf.ejs
+++ b/themes/future/layout/httf.ejs
@@ -66,7 +66,7 @@
     </div>
   </div>
     </main>
-    <aside class="col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar', {specialsToc: [
         {id: 'why', text: 'フューチャーが HACK TO THE FUTURE を開催する理由'},
         {id: 'contests', text: '歴代のコンテスト'},

--- a/themes/future/layout/index.ejs
+++ b/themes/future/layout/index.ejs
@@ -31,7 +31,7 @@
     <%- partial('_partial/archive', {pagination: config.archive,
           list_total: page.current === 1 ? site.posts.length : null}) %>
       </main>
-      <aside class="col-md-3 blog-sidebar">
+      <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
         <%- partial('_partial/sidebar') %>
       </aside>
     </div>

--- a/themes/future/layout/page.ejs
+++ b/themes/future/layout/page.ejs
@@ -36,7 +36,7 @@
         別の軸への導線を並べると意図がぼやける（タグ・著者のページと同じ扱い）。
         以前は目次を持たない /specials/ だけカテゴリ一覧が出ていて、
         同じ /specials/ 配下で不揃いになっていた %>
-    <aside class="col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar', {tocHtml: tocHtml, tocOnly: true}) %>
     </aside>
   </div>

--- a/themes/future/layout/series.ejs
+++ b/themes/future/layout/series.ejs
@@ -50,7 +50,7 @@
     <% }) %>
 
     </main>
-    <aside class="col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar-index-series') %>
     </aside>
   </div>

--- a/themes/future/layout/tag.ejs
+++ b/themes/future/layout/tag.ejs
@@ -47,7 +47,7 @@
         出すのはこのページ自身の統計だけ (#2911)。
         列そのものは中身が無くても残す。畳むと本文の幅がこのページだけ広くなり、
         一覧を行き来したときにカードの幅が揃わない (#2944) %>
-    <aside class="col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar', {showStats: true}) %>
     </aside>
   </div>

--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -64,7 +64,7 @@
       </div>
 
     </main>
-    <aside class="col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar-index-tags') %>
     </aside>
   </div>

--- a/themes/future/layout/techcast.ejs
+++ b/themes/future/layout/techcast.ejs
@@ -69,7 +69,7 @@
     </div>
   </div>
     </main>
-    <aside class="col-md-3 blog-sidebar">
+    <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar', {specialsToc: [
         {id: 'listen', text: '番組を聴く'},
         {id: 'episodes', text: 'エピソード一覧'},


### PR DESCRIPTION
## やったこと

名前の無い `<aside>`（complementary ランドマーク）に `aria-label` を足した。`_partial/article-appendix.ejs` の `aria-label="関連情報"` と同じ形で、新しい仕組み・CSS・JS は足していない。

- `_partial/related-categories.ejs` → `aria-label="関連カテゴリ"`
- `_partial/related-tags.ejs` → `aria-label="関連タグ"`
- `aside.col-md-3.blog-sidebar` → `aria-label="サイドバー"`（18ファイル）

**20ファイル / 20行**。issue の列挙は `blog-sidebar` を17ファイルとしていたが、実際は `series.ejs` を含む**18ファイル**だった（`grep -rln 'blog-sidebar' themes/future/layout` で確認）。

サイドバーの名前を「サイドバー」にしたのは、中身がページ種で変わる（記事＝目次、カテゴリ／タグ／著者＝統計とグラフ、ホームと一覧＝人気の軸）ため。役で名付けようとすると3通りに割れるので、どのページでも成り立つ共通の名前を採った。

## 検証

`hexo generate`（10,360ファイル）した生成物で確認した。

代表ページの `<aside …>`:

| ページ | aside |
| --- | --- |
| `/categories/Programming/` | `関連カテゴリ` / `サイドバー` |
| `/tags/Go/` | `関連タグ` / `サイドバー` |
| `/articles/20260727a/` | `サイドバー` / `関連情報` |
| `/` | `サイドバー` |
| `/authors/admin/` | `サイドバー` |
| `/series/` | `サイドバー` |

さらに `public` 配下を全走査した。**`<aside>` を持つ 2,844ページで、名前の無い aside 0件・同一ページ内で名前が重複するページ 0件。**

axe（`site-audit`、カテゴリ個別・タグ個別 × 幅 375 / 768 / 1280 の6画面）:

- before: 6画面すべてで `landmark-unique`（moderate）
- after: **`landmark-unique` は0件。エラー0**

残る警告は「本文まで19〜23回タブ停止する」の2件で、ヘッダーのナビとタグ一覧に由来する既存のもの。この変更とは無関係で、新しい所見は出ていない。

textlint（変更した20ファイル）は通っている。

Closes #3065

🤖 Generated with [Claude Code](https://claude.com/claude-code)
