### PR TITLE
一覧の共有ボタンの読み上げ名に記事名を足す (#3066)

### DIFF
--- a/themes/future/layout/_partial/social-button.ejs
+++ b/themes/future/layout/_partial/social-button.ejs
@@ -99,7 +99,10 @@
           数字は枠の外に置くのでリンクの外だが、読み上げでは名前に含める %>
       <a class="share-btn" href="<%- s.href %>" rel="nofollow" title="<%= s.label %>">
         <svg class="share-btn-icon" viewBox="<%= svg.viewBox %>" fill="currentColor" aria-hidden="true"><% if (svg.transform) { %><g transform="<%= svg.transform %>"><% } %><% svg.paths.forEach(function(d){ %><path d="<%= d %>"/><% }) %><% if (svg.transform) { %></g><% } %></svg>
-        <span class="sr-only"><%= s.label %><%= s.count ? `（${s.count}${s.unit}）` : '' %></span>
+        <%# 一覧では25枚が同じ名前で行き先だけ違うので記事名を足す (#3066)。
+            記事ページは1組しか無く、直上の h1 が記事を名乗るので足さない %>
+        <% const srName = is_post() ? s.label : `${s.label}：${title}`; %>
+        <span class="sr-only"><%= srName %><%= s.count ? `（${s.count}${s.unit}）` : '' %></span>
       </a>
       <% if (s.count) { %><span class="share-count" aria-hidden="true"><%= s.count %></span><% } %>
     </li>


### PR DESCRIPTION
Closes #3066

## やったこと

`_partial/social-button.ejs` の `sr-only` を、一覧（`!is_post()`）では
「Xでポストする：<記事名>（N ポスト）」の形にした。記事ページは1組しか無く、直上の h1 が記事を名乗るので今のまま。`title` 属性（マウス向け）も変えていない。

## 判断

- **場面の判定は `post` の有無ではなく `is_post()`。** issue は「`post` が渡っているとき（一覧）」としていたが、記事ページも `post.ejs` → `_partial/article` が `post: page` を渡していて、partial のローカルは親から継がれるので `typeof post !== 'undefined'` は両方で真になる（現に記事ページの X の本文は `title = post.title` で組めている）。一覧と記事を分けられるのは `is_post()` だけ
- 区切りは全角コロン。件数は既存の `（N ポスト）` の形のまま末尾に付く
- `/specials/gallery/` の見本は `is_post()` が偽なので一覧の形で出る

## 確認（port 4003 の hexo server で配信 HTML を解析）

| ページ | 共有リンク | 一意な名前 |
| --- | --- | --- |
| `/`（before） | 75 | 3 |
| `/`（after） | 75 | **75** |
| `/categories/Programming/`（after） | 75 | **75** |
| `/articles/20260828a/`（after） | 3 | 3（「Xでポストする」等、変更なし） |

- `node .claude/skills/site-audit/audit.mjs / --base http://localhost:4003` → 「同じ文字で行き先が違うリンク」が出なくなった（エラー 0 / 警告 2 は既存のタブ停止数の件）
- textlint（`.ejs` プラグイン）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)