### PR TITLE
/series/ の年の束ねを summary-panel の枠ではなく h3 にする (#3081)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -3555,7 +3555,7 @@ ul.tag-list {
   color: var(--ink-strong);
 }
 .group-heading-meta {
-  margin-left: 12px;
+  margin-left: 8px;
   color: var(--ink-mute);
   font-size: text-meta;
   font-weight: 400;

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -3546,12 +3546,24 @@ ul.tag-list {
 .category-list-link {
   padding: 0 6px 0 0;
 }
-/* /categories/ の群の見出し (#2908)。節見出し（.bottom-content-header）の下の段 */
-.category-group-heading {
+/* 群の見出し。節見出し（.bottom-content-header）の下の段で、/categories/ の群 (#2908) と
+   /series/ の年 (#3081) が使う。年の内訳のような添えは太らせず一段薄くする */
+.group-heading {
   margin: 32px 0 0;
   font-size: text-lead;
   font-weight: 700;
   color: var(--ink-strong);
+}
+.group-heading-meta {
+  margin-left: 12px;
+  color: var(--ink-mute);
+  font-size: text-meta;
+  font-weight: 400;
+}
+/* row(g-4) の負のトップマージンが見出しに食い込むので外す。
+   見出しとカードの間隔がカード同士の間隔（24px）と同じになる */
+.group-heading + .series-panels {
+  margin-top: 0;
 }
 /* /categories/ の一覧。1件は 名前＋統計 / 説明 / タグ の3段構成。
    17件を縦に積むと長いので、幅があるときは2列にする。
@@ -5313,23 +5325,6 @@ p.more-link {
 /* 既定の 2px はタイル数値用の詰め。チップ相手だとラベルが貼り付いて見える */
 .tag-pool-panel .summary-panel-label {
   margin-bottom: 10px;
-}
-
-/* /series/ の年ごとの枠。ラベルと枠線は summary-panel を継ぎ、
-   カードが収まるよう下側の padding だけ広げる */
-.series-year {
-  padding-bottom: 16px;
-  margin-bottom: 24px;
-}
-/* row(g-4) の負のトップマージンが年ラベルに食い込むため枠内では無効化する。
-   ラベルとカードの間隔がカード同士の間隔（24px）と同じになる */
-.series-year .series-panels {
-  margin-top: 0;
-}
-/* 年ラベル横のその年の内訳 (#2572)。年が先に読めるよう間を空ける。
-   色・大きさは親（summary-panel-label）のまま継ぐ */
-.series-year-meta {
-  margin-left: 12px;
 }
 
 /* サムネの無い連載の空き枠。.panel-thumb img と同じ寸法 */

--- a/themes/future/layout/_partial/toc-list.ejs
+++ b/themes/future/layout/_partial/toc-list.ejs
@@ -1,7 +1,9 @@
-<%# 手で組む目次の一覧。items（[{id, text}]）を渡す。
+<%# 手で組む目次の一覧。items（[{id, text, children?}]）を渡す。
+    形は hexo の toc() と同じ（toc-level-2 の下に toc-child の toc-level-3）。
+    children は1段だけ。特設ページの見出しは h2 と h3 までしか無い (#3081)。
     サイドバーと本文前の折りたたみ（.toc-mobile）が同じ形を共有する %>
 <ol class="toc">
   <% items.forEach(function(item){ %>
-  <li class="toc-item toc-level-2"><a class="toc-link" href="#<%= item.id %>"><span class="toc-text"><%= item.text %></span></a></li>
+  <li class="toc-item toc-level-2"><a class="toc-link" href="#<%= item.id %>"><span class="toc-text"><%= item.text %></span></a><% if (item.children && item.children.length) { %><ol class="toc-child"><% item.children.forEach(function(c){ %><li class="toc-item toc-level-3"><a class="toc-link" href="#<%= c.id %>"><span class="toc-text"><%= c.text %></span></a></li><% }) %></ol><% } %></li>
   <% }) %>
 </ol>

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -19,7 +19,7 @@
     <%# 群で区切る (#2908)。群と並びは category_group_index() が1箇所で持ち、
         ヘッダーのドロップダウン・サイドバーと同じ群・同じ並びになる %>
     <% category_group_index().forEach(function(g, gi, groups){ %>
-    <h3 class="category-group-heading"><%= g.name %></h3>
+    <h3 class="group-heading"><%= g.name %></h3>
     <ul class="category-index<%= gi === groups.length - 1 ? ' footer-gap' : '' %>">
       <% g.categories.forEach(function(c){ %>
       <li class="category-index-item">

--- a/themes/future/layout/series.ejs
+++ b/themes/future/layout/series.ejs
@@ -28,7 +28,8 @@
           著者は連載をまたいで重なるため、名前で寄せてから数える (#2572) %>
       <% const list = byYear.get(year); %>
       <% const yearAuthors = new Set(list.flatMap((s) => s.authors)); %>
-      <h3 class="group-heading"><%= year %>年<span class="group-heading-meta"><%= list.length %>連載・全<%= list.reduce((sum, s) => sum + s.total, 0) %>本・著者<%= yearAuthors.size %>名</span></h3>
+      <%# 年と内訳の間の空白は読み上げのための区切り。「2026年7連載」と続けて読まれない %>
+      <h3 class="group-heading"><%= year %>年 <span class="group-heading-meta"><%= list.length %>連載・全<%= list.reduce((sum, s) => sum + s.total, 0) %>本・著者<%= yearAuthors.size %>名</span></h3>
       <%# .series-panels がパネルの横並びレイアウトを持つ（トップの「連載から探す」と同じ部品） %>
       <div class="series-panels row g-4<%= yi === years.length - 1 ? ' footer-gap' : '' %>">
         <% list.forEach(function(s){ %>

--- a/themes/future/layout/series.ejs
+++ b/themes/future/layout/series.ejs
@@ -12,9 +12,8 @@
 
     <%# h1「連載一覧」と重ならない語にする（categories.ejs の流儀） %>
     <%- partial('_partial/section-heading', {id: 'series', text: 'すべての連載'}) %>
-    <%# 最終更新の年ごとに枠で束ねる。枠と小ラベルは詳細ページの
-        「累計/直近1年」パネル（summary-panel）と同じ見た目に揃える。
-        並べ方の注記は置かない。年は枠のラベルが、順序と期間は各カードの
+    <%# 最終更新の年ごとに h3 で束ねる (#3081)。/categories/ の群と同じ見出し。
+        並べ方の注記は置かない。年は見出しが、順序と期間は各カードの
         「全9本・2026.02 〜 2026.08」が名乗っている（categories.ejs と同じ流儀） %>
     <% const byYear = new Map(); %>
     <% series.forEach(function(s){
@@ -24,15 +23,14 @@
        }); %>
     <% const years = [...byYear.keys()]; %>
     <% years.forEach(function(year, yi){ %>
-    <section class="summary-panel series-year <%= yi === years.length - 1 ? 'footer-gap' : '' %>">
-      <%# 年ラベルの横にその年の内訳。本数は連載の全本数なので「全」を付ける
-          （枠の並びは最終更新の年で、年をまたぐ連載も本数はまとめて数える）。
+      <%# 年の横にその年の内訳。本数は連載の全本数なので「全」を付ける
+          （束ねは最終更新の年で、年をまたぐ連載も本数はまとめて数える）。
           著者は連載をまたいで重なるため、名前で寄せてから数える (#2572) %>
       <% const list = byYear.get(year); %>
       <% const yearAuthors = new Set(list.flatMap((s) => s.authors)); %>
-      <span class="summary-panel-label"><%= year %>年<span class="series-year-meta"><%= list.length %>連載・全<%= list.reduce((sum, s) => sum + s.total, 0) %>本・著者<%= yearAuthors.size %>名</span></span>
+      <h3 class="group-heading"><%= year %>年<span class="group-heading-meta"><%= list.length %>連載・全<%= list.reduce((sum, s) => sum + s.total, 0) %>本・著者<%= yearAuthors.size %>名</span></h3>
       <%# .series-panels がパネルの横並びレイアウトを持つ（トップの「連載から探す」と同じ部品） %>
-      <div class="series-panels row g-4">
+      <div class="series-panels row g-4<%= yi === years.length - 1 ? ' footer-gap' : '' %>">
         <% list.forEach(function(s){ %>
         <div class="col-12 col-md-6 col-lg-4">
           <%# 期間は連載の活動期間（初回〜最新）。単月で終わった連載は1つだけ名乗る %>
@@ -46,7 +44,6 @@
         </div>
         <% }) %>
       </div>
-    </section>
     <% }) %>
 
     </main>

--- a/themes/future/layout/series.ejs
+++ b/themes/future/layout/series.ejs
@@ -29,7 +29,7 @@
       <% const list = byYear.get(year); %>
       <% const yearAuthors = new Set(list.flatMap((s) => s.authors)); %>
       <%# 年と内訳の間の空白は読み上げのための区切り。「2026年7連載」と続けて読まれない %>
-      <h3 class="group-heading"><%= year %>年 <span class="group-heading-meta"><%= list.length %>連載・全<%= list.reduce((sum, s) => sum + s.total, 0) %>本・著者<%= yearAuthors.size %>名</span></h3>
+      <h3 id="series-<%= year %>" class="group-heading"><%= year %>年 <span class="group-heading-meta"><%= list.length %>連載・全<%= list.reduce((sum, s) => sum + s.total, 0) %>本・著者<%= yearAuthors.size %>名</span></h3>
       <%# .series-panels がパネルの横並びレイアウトを持つ（トップの「連載から探す」と同じ部品） %>
       <div class="series-panels row g-4<%= yi === years.length - 1 ? ' footer-gap' : '' %>">
         <% list.forEach(function(s){ %>
@@ -50,6 +50,9 @@
     </main>
     <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar-index-series') %>
+      <%# 年の見出しへの目次。8つの年を縦に送る距離が長いので、特設ページと同じ
+          specialsToc の形で持つ。統計はページ自身の数字なので目次より上 (#2911) %>
+      <%- partial('_partial/sidebar', {specialsToc: years.map(function(y){ return {id: 'series-' + y, text: y + '年'}; })}) %>
     </aside>
   </div>
 </div>

--- a/themes/future/layout/series.ejs
+++ b/themes/future/layout/series.ejs
@@ -50,9 +50,12 @@
     </main>
     <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar-index-series') %>
-      <%# 年の見出しへの目次。8つの年を縦に送る距離が長いので、特設ページと同じ
-          specialsToc の形で持つ。統計はページ自身の数字なので目次より上 (#2911) %>
-      <%- partial('_partial/sidebar', {specialsToc: years.map(function(y){ return {id: 'series-' + y, text: y + '年'}; })}) %>
+      <%# 目次は記事と同じ h2 → h3 の入れ子。h2「すべての連載」の下に年を並べる。
+          特設ページと同じ specialsToc の形で持つ。統計はページ自身の数字なので目次より上 (#2911) %>
+      <%- partial('_partial/sidebar', {specialsToc: [{
+            id: 'series', text: 'すべての連載',
+            children: years.map(function(y){ return {id: 'series-' + y, text: y + '年'}; }),
+          }]}) %>
     </aside>
   </div>
 </div>


### PR DESCRIPTION
Closes #3081

## やったこと

- `/series/`「すべての連載」の年ごとの `summary-panel`（統計の枠）を、**`/categories/` の群と同じ h3** にした。年の内訳「7連載・全46本・著者24名」は見出しの後ろの添え（`ink-mute` × `text-meta`・太さ 400）として残す
- 群の見出しのルールは **`.group-heading` の1つ**にし、`/categories/` の `.category-group-heading` もこれに寄せた（値は同じ `text-lead` 18px・700・上 32px）。`.series-year` の3ルールは消した
- カードの行（`.series-panels.row.g-4`）は `.group-heading + .series-panels { margin-top: 0 }` で負のトップマージンを外し、見出しとカードの間がカード同士の間隔（24px）と同じになる

## 判断

- **18px（`/categories/` の群）にし、`/articles/` の年（15.6px）にしなかった。** 下に並ぶ `panel-card` の題が 15.6px 太字なので、15.6px だと同着になる
- 年と内訳の間に空白を1つ置く。読み上げで「2026年7連載」と続かないように

## 実測（playwright、375 / 1280px）

| | `/series/` | `/categories/` |
| --- | --- | --- |
| h3 | 18px・700・8本 | 18px・700・5本 |
| 直上との間 | 32px（h2 と最初の h3 も 32） | 32px |
| 直下との間 | 24px（カードの間隔と同じ） | 12px（`.category-index` の既存値） |
| 左端 | h1 と同じ 82px（375px では 12px） | 同じ |

- `summary-panel.series-year` は0件。内訳の添えは 12px・400・`ink-mute`
- `make lint-css`・textlint（`.ejs`）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)