### PR TITLE
関連記事の title から内部スコアを外す (#3076)

### DIFF
--- a/scripts/related_posts.js
+++ b/scripts/related_posts.js
@@ -119,12 +119,9 @@ function generateRelatedPostsHtml(posts, series) {
     return `<p class="related-posts-none">No related post.</p>`;
   }
 
-  // マークアップは lib/post_list.js に集約している
-  const item = (related) => {
-    const scoreText = related.score ? `スコア: ${related.score.toFixed(4)}` : '';
-    const titleAttr = `${related.lede} ${scoreText}`.trim();
-    return postListItem(related, 'related-posts-item', { titleAttr, withThumb: true });
-  };
+  // マークアップは lib/post_list.js に集約している。title は lede だけ
+  // （postListItem の既定）。score は並び順を決める内部の重みで読者には出さない (#3076)
+  const item = (related) => postListItem(related, 'related-posts-item', { withThumb: true });
 
   // 語彙と作りはランキング・参照記事の畳みに揃える (#2249)
   const moreHtml = more.length


### PR DESCRIPTION
Closes #3076

## やったこと

記事末「関連記事」の各行の `title` 属性に付いていた内部スコア（`スコア: 4.0262`）を外した。`scripts/related_posts.js` の `item()` が lede の後ろに `related.score` を連結していたもので、`postListItem` の既定（lede だけ）に任せる形にした。`score` は並び順（`b.score - a.score`）にだけ使う。

```diff
-    const scoreText = related.score ? `スコア: ${related.score.toFixed(4)}` : '';
-    const titleAttr = `${related.lede} ${scoreText}`.trim();
-    return postListItem(related, 'related-posts-item', { titleAttr, withThumb: true });
+  const item = (related) => postListItem(related, 'related-posts-item', { withThumb: true });
```

## 検証

`list_related_posts` ヘルパーを全記事に対して直接呼び、出力の `title` を数えた（`hexo.init()` + `hexo.load()`。生成は回していない）。

| | 値 |
| --- | --- |
| 記事 | 1,481 |
| 関連記事の行（title の数） | 11,650 |
| title に「スコア: 」を含む記事 | **0**（変更前の生成物では 1,480 記事） |

`npx prettier --check scripts/related_posts.js` 通過。

## 範囲外

issue に書いた「確認が要るなら `/doctor/` に節を立てる」は入れていない。スコアの検算が要る場面が今のところ無く、要るときに立てればよい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
