### PR TITLE
部品ギャラリーの目次を部品ごとにし、統計の枠・記事のメタ・タグのチップの見本を直す (#3088)

### DIFF
--- a/scripts/ui_gallery.js
+++ b/scripts/ui_gallery.js
@@ -46,6 +46,10 @@ const NOT_SHOWN = {
   'sidebar-index-tags': '同上（/tags/）',
   'sidebar-stats-index':
     '一覧ページのサイドバーの中身。渡された統計とグラフを並べるだけで、単体では形を持たない',
+  'post/title':
+    '記事の題。一覧のカード（archive-post）の見本の中に実物が出ている。メタ情報の見本には入れない',
+  'post/category':
+    '同上。カテゴリはパンくずが名乗るので、記事のメタ情報の並びには出てこない (#2837)',
   'related-categories': 'カテゴリページの本体の一部。page.category に依存する',
   'related-tags': 'タグページの本体の一部。page.tag に依存する',
   scripts: 'ページ末のスクリプト。見た目を持たない',

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -4230,91 +4230,6 @@ a.series-nav-item:hover .series-nav-item-title {
 .sidebar-stats {
   margin-top: 30px;
 }
-.sidebar-stats .summary-panels {
-  /* 列の内寸は 208〜298px。累計の7タイルを横に並べると 480px 要るので縦に積む */
-  flex-direction: column;
-  margin-bottom: 0;
-}
-/* タイルではなく行。ラベルを左、数値を右に置いて桁の位置をそろえる */
-/* タイル（数値の下にラベル）を行（数値の右にラベル）に組み替える。
-   208〜298px の列にタイルを7つ並べると 480px 要る。クラスと大きさの段は
-   本文の統計と共有するので、ここで持つのは並べ方だけ */
-.sidebar-stats .summary {
-  flex-direction: column;
-  align-items: stretch;
-  gap: (space-step) 0;
-  padding-bottom: 0;
-}
-.sidebar-stats .summary li {
-  display: flex;
-  align-items: baseline;
-  /* 数値とラベルは1つのまとまりなので、行の中では詰める */
-  gap: 6px;
-}
-/* 数字は幅をそろえて右寄せにする。桁数が違うとラベルの開始位置がずれ、
-   縦に読めなくなる（実測で最大31px）。幅は EJS が桁数から配る
-   （--summary-count-width）。tabular-nums は数字1文字の幅をそろえる指定で、
-   ch（「0」の幅）で数えた値と実際の幅を一致させる */
-.sidebar-stats .summary-count {
-  display: inline-block;
-  width: var(--summary-count-width, 3ch);
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-}
-/* シェアの内訳は総シェア数の内訳で、読者の行動を変える数字ではない。
-   本文のタイルが .summary-sub で数値を一段小さくしていた区別はそのまま効く (#2096)。
-   縦に並ぶぶん大きさだけでは従属が読み取りにくいので字下げを足し、
-   文字も一段薄い ink-faint に落とす（白地で 4.5 を満たす最も薄い段。これより薄くしない）。
-
-   **字下げない。数値は右端、ラベルは左端で主要行とそろえる。**
-   内訳の数値だけが右へずれると 4989 + 253 + 10009 + 6528 = 21779 という
-   足し合わせの関係が切れ、「弱い項目が4つ並んでいる」ようにしか見えない。
-   従属は大きさ（text-body → text-meta）と色と線が示す。帳簿の内訳と同じ形。
-
-   **さらに左の縦線で「1つの塊」を示す。** 引用と同じ考え方（塊の左に1本、
-   #2457）で、塊を囲う役なので段は rule-base（区切りの rule-weak ではない）。
-   行の間の空き（4px）を上下2pxずつまたいで1本につなぐ。
-   最初の行の上と最後の行の下は伸ばさない */
-.sidebar-stats .summary li.summary-sub {
-  position: relative;
-}
-.sidebar-stats .summary li.summary-sub::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: -(space-step / 2);
-  bottom: -(space-step / 2);
-  border-left: 1px solid var(--rule-base);
-}
-.sidebar-stats .summary li.summary-sub:first-of-type::before {
-  top: 0;
-}
-.sidebar-stats .summary li.summary-sub:last-child::before {
-  bottom: 0;
-}
-/* ch は自分の font-size を見るので、数値を一段小さくした内訳では
-   同じ桁数でも箱が狭くなり、右端が総シェア数とそろわない
-   （ずれ方は桁数で変わるので固定値では戻せない）。段の比で戻すと、
-   ラベルの左端も自動的にそろう（数値の箱の右に 6px で置いているだけなので） */
-.sidebar-stats .summary li.summary-sub .summary-count {
-  /* Stylus は px 同士の割り算に px を残すので unit() で無次元に戻す。
-     付いたままだと calc が「長さ×長さ」になって無効になり、width が
-     auto に落ちて桁ごとに幅が変わる（一度踏んだ） */
-  width: s('calc(var(--summary-count-width, 3ch) * %s)', unit(text-body / text-meta, ''));
-}
-.sidebar-stats .summary-sub .summary-count,
-.sidebar-stats .summary-sub .summary-label {
-  color: var(--ink-faint);
-}
-
-/* 2組目（「直近1年」）の前は刻み6つぶん空ける。組の中（ラベルの下 8px・
-   行の間 4px）より広くして、1つの枠の中でも2組に読めるようにする (#2747)。
-   枠を2つ並べていたときの間は 22px（下の余白2 + 罫線1 + 間隔12 + 罫線1 +
-   上の余白6）で、線が無くなったぶん切れ目はそれより狭くしない */
-.sidebar-stats .summary + .summary-panel-label {
-  margin-top: (space-step * 6);
-}
-
 /* 高さは本文にあった 250px から下げる。細い列で縦に長いと棒より余白が目立つ。
    軸ラベルに約20px 取られるので、棒が立つのは 100px ぶん。
    上の空きは数字の枠と地続きに見えない量を取る（枠の中の行間隔より広く） */
@@ -4397,6 +4312,86 @@ a.series-nav-item:hover .series-nav-item-title {
 .summary-panel .award-name a:focus {
   color: var(--ink-strong);
   text-decoration: underline;
+}
+/* 枠の中はタイル（数値の下にラベル）ではなく行（数値の右にラベル）。
+   サイドバーの内寸 208〜298px にタイルを7つ並べると 480px 要る。
+   クラスと大きさの段は本文の統計と共有するので、ここで持つのは並べ方だけ。
+   **並べ方は置き場所ではなく部品が持つ** (#3088)。置き場所（.sidebar-stats）の側に
+   束ねると、枠を単体で置いたときに数値とラベルが詰まる */
+.summary-panel .summary {
+  flex-direction: column;
+  align-items: stretch;
+  gap: (space-step) 0;
+  padding-bottom: 0;
+}
+.summary-panel .summary li {
+  display: flex;
+  align-items: baseline;
+  /* 数値とラベルは1つのまとまりなので、行の中では詰める */
+  gap: 6px;
+}
+/* 数字は幅をそろえて右寄せにする。桁数が違うとラベルの開始位置がずれ、
+   縦に読めなくなる（実測で最大31px）。幅は EJS が桁数から配る
+   （--summary-count-width）。tabular-nums は数字1文字の幅をそろえる指定で、
+   ch（「0」の幅）で数えた値と実際の幅を一致させる */
+.summary-panel .summary-count {
+  display: inline-block;
+  width: var(--summary-count-width, 3ch);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+/* シェアの内訳は総シェア数の内訳で、読者の行動を変える数字ではない。
+   本文のタイルが .summary-sub で数値を一段小さくしていた区別はそのまま効く (#2096)。
+   縦に並ぶぶん大きさだけでは従属が読み取りにくいので字下げを足し、
+   文字も一段薄い ink-faint に落とす（白地で 4.5 を満たす最も薄い段。これより薄くしない）。
+
+   **字下げない。数値は右端、ラベルは左端で主要行とそろえる。**
+   内訳の数値だけが右へずれると 4989 + 253 + 10009 + 6528 = 21779 という
+   足し合わせの関係が切れ、「弱い項目が4つ並んでいる」ようにしか見えない。
+   従属は大きさ（text-body → text-meta）と色と線が示す。帳簿の内訳と同じ形。
+
+   **さらに左の縦線で「1つの塊」を示す。** 引用と同じ考え方（塊の左に1本、
+   #2457）で、塊を囲う役なので段は rule-base（区切りの rule-weak ではない）。
+   行の間の空き（4px）を上下2pxずつまたいで1本につなぐ。
+   最初の行の上と最後の行の下は伸ばさない */
+.summary-panel .summary li.summary-sub {
+  position: relative;
+}
+.summary-panel .summary li.summary-sub::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: -(space-step / 2);
+  bottom: -(space-step / 2);
+  border-left: 1px solid var(--rule-base);
+}
+.summary-panel .summary li.summary-sub:first-of-type::before {
+  top: 0;
+}
+.summary-panel .summary li.summary-sub:last-child::before {
+  bottom: 0;
+}
+/* ch は自分の font-size を見るので、数値を一段小さくした内訳では
+   同じ桁数でも箱が狭くなり、右端が総シェア数とそろわない
+   （ずれ方は桁数で変わるので固定値では戻せない）。段の比で戻すと、
+   ラベルの左端も自動的にそろう（数値の箱の右に 6px で置いているだけなので） */
+.summary-panel .summary li.summary-sub .summary-count {
+  /* Stylus は px 同士の割り算に px を残すので unit() で無次元に戻す。
+     付いたままだと calc が「長さ×長さ」になって無効になり、width が
+     auto に落ちて桁ごとに幅が変わる（一度踏んだ） */
+  width: s('calc(var(--summary-count-width, 3ch) * %s)', unit(text-body / text-meta, ''));
+}
+.summary-panel .summary-sub .summary-count,
+.summary-panel .summary-sub .summary-label {
+  color: var(--ink-faint);
+}
+
+/* 2組目（「直近1年」）の前は刻み6つぶん空ける。組の中（ラベルの下 8px・
+   行の間 4px）より広くして、1つの枠の中でも2組に読めるようにする (#2747)。
+   枠を2つ並べていたときの間は 22px（下の余白2 + 罫線1 + 間隔12 + 罫線1 +
+   上の余白6）で、線が無くなったぶん切れ目はそれより狭くしない */
+.summary-panel .summary + .summary-panel-label {
+  margin-top: (space-step * 6);
 }
 .award-badges {
   display: flex;

--- a/themes/future/layout/_partial/sidebar-summary-panel.ejs
+++ b/themes/future/layout/_partial/sidebar-summary-panel.ejs
@@ -37,20 +37,21 @@
     枠を2つ置くと1つめの下辺と2つめの上辺で線が2本並ぶ。組の切れ目は間隔が作る (#2747)。
 
     **組が1つのページではラベルを置かない。** 対になる相手が無いので
-    「累計」と名乗っても何とも対比されない %>
-<div class="summary-panels" style="--summary-count-width: <%= panelWidth %>ch">
-  <section class="summary-panel">
-    <% if (panelRecent) { %>
-    <span class="summary-panel-label">累計</span>
-    <% } %>
-    <%- partial('summary-tiles', {items: panelTotal, variant: 'row'}) %>
-    <% if (panelRecent) { %>
-    <span class="summary-panel-label">直近1年</span>
-    <% if (panelRecentRows.length) { %>
-    <%- partial('summary-tiles', {items: panelRecentRows, variant: 'row'}) %>
-    <% } else { %>
-    <p class="summary-note">投稿はありません</p>
-    <% } %>
-    <% } %>
-  </section>
-</div>
+    「累計」と名乗っても何とも対比されない。
+
+    枠は1つなので .summary-panels の包みは持たない。行の並び・桁そろえ・
+    内訳の線は .summary-panel が自分で持つので、どこに置いても同じ形で出る %>
+<section class="summary-panel" style="--summary-count-width: <%= panelWidth %>ch">
+  <% if (panelRecent) { %>
+  <span class="summary-panel-label">累計</span>
+  <% } %>
+  <%- partial('summary-tiles', {items: panelTotal, variant: 'row'}) %>
+  <% if (panelRecent) { %>
+  <span class="summary-panel-label">直近1年</span>
+  <% if (panelRecentRows.length) { %>
+  <%- partial('summary-tiles', {items: panelRecentRows, variant: 'row'}) %>
+  <% } else { %>
+  <p class="summary-note">投稿はありません</p>
+  <% } %>
+  <% } %>
+</section>

--- a/themes/future/layout/gallery.ejs
+++ b/themes/future/layout/gallery.ejs
@@ -20,6 +20,13 @@
   // 条件を満たす記事でないと見本が空になる
   const authorPost = site.posts.sort('date', -1).toArray()
     .find(function(p){ const pr = get_profile_data(p.author); return pr && pr.about; });
+  // 見本の題は h3。id を持たせてサイドバーの目次から飛べるようにする。
+  // 題と目次の項目を1回で両方に出す——別々に書くと、片方だけ足したときにずれる
+  const galleryToc = {elements: [], components: [], patterns: []};
+  const galleryName = function (group, id, text) {
+    galleryToc[group].push({id: id, text: text});
+    return '<h3 id="' + id + '" class="gallery-name">' + text + '</h3>';
+  };
 %>
 <div class="container">
   <%- partial('_partial/breadcrumb', {items: [
@@ -31,12 +38,12 @@
   <div class="margin-top-30">
     <div class="footer-gap">
       <h1 class="list-page margin-bottom-20">部品ギャラリー</h1>
-      <p class="specials-text">このブログを組み立てている部品を、実物のまま並べたページです。どれもサイトで実際に動いているものを呼び出しているので、ここで見た形がそのまま各ページに出ます。色・文字・間隔といった土台の決まりは <a href="/specials/styleguide/">スタイルガイド</a> が持ちます。</p>
+      <p class="specials-text">このブログを組み立てている部品を、実物のまま並べたページです。色・文字・間隔といった土台の決まりは <a href="/specials/styleguide/">スタイルガイド</a> が持ちます。</p>
 
       <%- partial('_partial/section-heading', {id: 'elements', text: '要素'}) %>
       <p class="specials-text">それ以上分けられない最小の部品です。</p>
       <div class="gallery-item">
-        <p class="gallery-name">アイコン</p>
+        <%- galleryName('elements', 'sample-icons', 'アイコン') %>
         <p class="specials-text">線画で統一し、文字の色を継ぎます。見出し・ナビ・チップ・ボタンの中に置きます。</p>
         <ul class="gallery-icons">
           <%# 一覧は辞書から出す (#3054)。手で並べると辞書に無い名前が混ざり、
@@ -47,7 +54,7 @@
         </ul>
       </div>
       <div class="gallery-item">
-        <p class="gallery-name">カテゴリのアイコン</p>
+        <%- galleryName('elements', 'sample-category-icons', 'カテゴリのアイコン') %>
         <p class="specials-text">カテゴリごとに絵柄が決まっています。パンくず・サイドバー・ヘッダーのどこで見ても同じ絵が出ます。</p>
         <ul class="gallery-icons">
           <% category_groups().forEach(function(g){ g.categories.forEach(function(c){ %>
@@ -56,7 +63,7 @@
         </ul>
       </div>
       <div class="gallery-item">
-        <p class="gallery-name">表彰のメダル</p>
+        <%- galleryName('elements', 'sample-award-medal', '表彰のメダル') %>
         <p class="specials-text">受賞の回数で色が変わります（灰 → 銅 → 金）。回数はメダルの中の数字が持ちます。記事に添えるときは、数字が何を指すか読み取れないので色だけにします。</p>
         <ul class="gallery-icons">
           <li><%- partial('_partial/award-medal', {nth: 1}) %><span class="gallery-note">1回</span></li>
@@ -70,13 +77,13 @@
       <%- partial('_partial/section-heading', {id: 'components', text: '部品'}) %>
       <p class="specials-text">要素を組んだ、1つの役を持つまとまりです。記事にまつわる見本は <a href="<%- url_for(samplePost.path) %>"><%= samplePost.title %></a> の実データで描いています。</p>
       <div class="gallery-item">
-        <p class="gallery-name">節見出し</p>
+        <%- galleryName('components', 'sample-section-heading', '節見出し') %>
         <p class="specials-text">節の始まりを示します。罫線は記事本文の見出しだけが持ち、ここは前の空きで区切ります。行の右端に「全N本」のような添えを置けます。</p>
         <%- partial('_partial/section-heading', {id: 'sample-heading', text: '節見出し'}) %>
         <%- partial('_partial/section-heading', {id: 'sample-heading-meta', text: '添えつき', meta: '全327本'}) %>
       </div>
       <div class="gallery-item">
-        <p class="gallery-name">パンくず</p>
+        <%- galleryName('components', 'sample-breadcrumb', 'パンくず') %>
         <p class="specials-text">上の階層への道筋だけを出します。現在地は真下の見出しが名乗るので出しません（ページを繰っているときだけ「Nページ目」が現在地として残ります）。1項目しか無いときはパンくず自体を出しません。</p>
         <%- partial('_partial/breadcrumb', {items: [
               {label: 'ホーム', url: '/'},
@@ -89,7 +96,7 @@
             ]}) %>
       </div>
       <div class="gallery-item">
-        <p class="gallery-name">タブ</p>
+        <%- galleryName('components', 'sample-tabs', 'タブ') %>
         <p class="specials-text">クリックでも矢印キーでも切り替えられます。矢印キーが使えることは、選んでいるタブの真下に出ます（キーボードで操作しているときだけ）。</p>
         <div class="nav tabs" role="radiogroup" aria-label="見本のタブ">
           <input id="gallery-tab-a" type="radio" name="gallery_tab" checked>
@@ -101,7 +108,7 @@
         </div>
       </div>
       <div class="gallery-item">
-        <p class="gallery-name">統計</p>
+        <%- galleryName('components', 'sample-summary', '統計') %>
         <p class="specials-text">数値が主役で、ラベルは小さく添えます。内訳（総シェア数に対する X・はてブなど）は一段下げます。数値の下にラベルを置く形と、右に並べる形があります。</p>
         <%- partial('_partial/summary-tiles', {items: [
               {value: 1481, label: '投稿'},
@@ -118,7 +125,7 @@
         </div>
       </div>
       <div class="gallery-item">
-        <p class="gallery-name">統計の枠</p>
+        <%- galleryName('components', 'sample-summary-panel', '統計の枠') %>
         <p class="specials-text">サイドバーで使う形です。累計と直近1年を1つの枠に積み、数字の桁をそろえてラベルの開始位置を合わせます。</p>
         <div class="gallery-sidebar-scale">
           <%- partial('_partial/sidebar-summary-panel', {
@@ -132,12 +139,12 @@
         </div>
       </div>
       <div class="gallery-item">
-        <p class="gallery-name">ページの位置</p>
+        <%- galleryName('components', 'sample-pagination-info', 'ページの位置') %>
         <p class="specials-text">一覧の2ページ目から出ます。いま何本目を見ているかを示します。</p>
         <%- partial('_partial/pagination-info', {total: 327, page: {current: 2}}) %>
       </div>
       <div class="gallery-item">
-        <p class="gallery-name">目次</p>
+        <%- galleryName('components', 'sample-toc', '目次') %>
         <p class="specials-text">記事と特設ページのサイドバーに出ます。読んでいる節の行に面が付きます。</p>
         <%# **器ごと置く。** 見た目は .toc-section の中でしか効かないので、裸で呼ぶと
             連番と土台のリンク色（青）で出る。実物と同じくサイドバーの列幅で描く %>
@@ -148,39 +155,37 @@
         </div>
       </div>
       <div class="gallery-item">
-        <p class="gallery-name">記事のメタ情報</p>
+        <%- galleryName('components', 'sample-post-meta', '記事のメタ情報') %>
         <p class="specials-text">日付・著者・文字数・閲覧数を1行に並べ、タグはその下の行に置きます。カテゴリはパンくずが名乗るので、この行には入りません。</p>
         <ul class="blog-info">
           <li class="blog-info-item"><%- partial('_partial/post/date', {post: samplePost, class_name: 'archive-article-date', date_format: 'YYYY.MM.DD'}) %></li>
           <%- post_author_link(samplePost) %>
         </ul>
         <div class="article-header-tags"><%- partial('_partial/post/tag', {post: samplePost}) %></div>
-        <%- partial('_partial/post/title', {post: samplePost, class_name: 'archive-post-title'}) %>
-        <% if (samplePost.categories && samplePost.categories.length) { %>
-        <p><%- partial('_partial/post/category', {cat: samplePost.categories.first()}) %></p>
-        <% } %>
       </div>
       <div class="gallery-item">
-        <p class="gallery-name">タグのチップ</p>
+        <%- galleryName('components', 'sample-tag-chips', 'タグのチップ') %>
         <p class="specials-text">タグは丸い枠のチップで表します。右肩の数字はそのタグの記事の総数で、数を出さずに名前だけにすることもできます。</p>
         <div class="blog-tags">
+          <span class="gallery-note">件数あり</span>
           <%- partial('_partial/tag-chips', {items: recent_popular_tags(6).map(function(t){
                 return {name: t.name, path: t.path, count: t.count, title: `${t.name} の記事 ${t.count}本`};
               })}) %>
+          <span class="gallery-note">名前だけ</span>
           <%- partial('_partial/tag-chips', {items: recent_popular_tags(3).map(function(t){
                 return {name: t.name, path: t.path};
               })}) %>
         </div>
       </div>
       <div class="gallery-item">
-        <p class="gallery-name">ラベル付きの行</p>
+        <%- galleryName('components', 'sample-label-rows', 'ラベル付きの行') %>
         <p class="specials-text">左のラベルが群を名乗り、右にその群のチップを並べます。群の範囲は行の上下の罫線が示します。著者一覧の受賞年と、タグ一覧の頭文字の索引が同じ形です。</p>
         <%- partial('_partial/label-rows', {variant: 'tag', rows: tag_index().slice(1, 3).map(function(g){
               return {label: g.label, items: g.items.slice(0, 4)};
             })}) %>
       </div>
       <div class="gallery-item">
-        <p class="gallery-name">関連の一覧</p>
+        <%- galleryName('components', 'sample-tendency-panels', '関連の一覧') %>
         <p class="specials-text">関連するカテゴリ・タグを、右に本数を添えて並べます。何を数えた本数かは節の見出しが名乗ります。カテゴリはチップにせずテキストのリンクにして、タグと見分けが付くようにします。</p>
         <%- partial('_partial/tendency-panels', {kind: 'category', items: category_groups()[0].categories.slice(0, 3).map(function(c){
               return {name: c.name, path: c.path, title: `${c.name} カテゴリの記事へ`, note: `${c.count}本`};
@@ -190,7 +195,7 @@
             })}) %>
       </div>
       <div class="gallery-item">
-        <p class="gallery-name">共有ボタン</p>
+        <%- galleryName('components', 'sample-social-button', '共有ボタン') %>
         <p class="specials-text">アイコンだけで、サービス名は書きません。数はボタンの下に小さく出し、0のときは出しません。</p>
         <%- partial('_partial/social-button', {post: samplePost, actions: true}) %>
       </div>
@@ -198,12 +203,12 @@
       <%- partial('_partial/section-heading', {id: 'patterns', text: 'かたまり'}) %>
       <p class="specials-text">部品を組んで、そのまま画面の一区画になるものです。</p>
       <div class="gallery-item">
-        <p class="gallery-name">一覧のカード</p>
+        <%- galleryName('patterns', 'sample-archive-post', '一覧のカード') %>
         <p class="specials-text">記事一覧の1件です。サムネイル・題・概要・カテゴリ・共有の数を持ちます。画像と題は同じ行き先なので、キーボードで止まるのは題の1回だけです。</p>
         <%- partial('_partial/archive-post', {post: samplePost, index: false}) %>
       </div>
       <div class="gallery-item">
-        <p class="gallery-name">パネル</p>
+        <%- galleryName('patterns', 'sample-panel-card', 'パネル') %>
         <p class="specials-text">連載や特設ページへの入口です。サムネイルが無いときは同じ大きさの空き枠を置いて、題の頭をそろえます。種別の名札と、全件への行き先を添えられます。</p>
         <div class="series-panels row g-4">
           <div class="col-12 col-md-6">
@@ -227,13 +232,13 @@
         </div>
       </div>
       <div class="gallery-item">
-        <p class="gallery-name">パネルの並び</p>
+        <%- galleryName('patterns', 'sample-post-panel-grid', 'パネルの並び') %>
         <p class="specials-text">特設ページで、記事へのパネルを3列で並べます。</p>
         <%- partial('_partial/post-panel-grid', {posts: samples.panelPosts}) %>
       </div>
       <% if (authorPost) { %>
       <div class="gallery-item">
-        <p class="gallery-name">著者紹介</p>
+        <%- galleryName('patterns', 'sample-author-box', '著者紹介') %>
         <p class="specials-text">記事の末尾に出ます。紹介文が登録されていて、3本以上書いている著者にだけ出ます。</p>
         <%- partial('_partial/author-box', {post: authorPost}) %>
       </div>
@@ -243,21 +248,21 @@
           枠の見出し（「人気のタグ」など）はここに書かない。文字列を二重に持つと、
           サイドバー側で言い換えたときにこのページだけが古い名前を出す %>
       <div class="gallery-item">
-        <p class="gallery-name">カテゴリの枠</p>
+        <%- galleryName('patterns', 'sample-widget-category', 'カテゴリの枠') %>
         <p class="specials-text">よく読まれているカテゴリを上限8件で並べます。行の右の数字はそのカテゴリの記事の総数です。以下3つはサイドバーの列の幅で描いているので、本文の幅で見るより細くなっています。</p>
         <div class="gallery-sidebar-scale">
           <%- partial('_widget/category') %>
         </div>
       </div>
       <div class="gallery-item">
-        <p class="gallery-name">連載の枠</p>
+        <%- galleryName('patterns', 'sample-widget-series', '連載の枠') %>
         <p class="specials-text">よく読まれている連載を3件。連載名は長いのでチップにせず、カテゴリと同じ行の並びにします。</p>
         <div class="gallery-sidebar-scale">
           <%- partial('_widget/series') %>
         </div>
       </div>
       <div class="gallery-item">
-        <p class="gallery-name">タグの枠</p>
+        <%- galleryName('patterns', 'sample-widget-tag', 'タグの枠') %>
         <p class="specials-text">よく読まれているタグを10件。ここだけチップで並べます。名前が短く、数が多いためです。</p>
         <div class="gallery-sidebar-scale">
           <div class="blog-tags"><%- partial('_widget/tag') %></div>
@@ -268,9 +273,9 @@
     </main>
     <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar', {specialsToc: [
-        {id: 'elements', text: '要素'},
-        {id: 'components', text: '部品'},
-        {id: 'patterns', text: 'かたまり'},
+        {id: 'elements', text: '要素', children: galleryToc.elements},
+        {id: 'components', text: '部品', children: galleryToc.components},
+        {id: 'patterns', text: 'かたまり', children: galleryToc.patterns},
       ]}) %>
     </aside>
   </div>


### PR DESCRIPTION
`/specials/gallery/` のレビュー指摘 6件。いずれもギャラリー1ページと、そこが呼ぶ部品・CSS の中の話です。

## 1. 目次を部品ごとに

見本の題を `<p class="gallery-name">` から `<h3 id="…" class="gallery-name">` にして、サイドバーの目次から各部品へ飛べるようにしました。

- 目次は **3項目 → 3項目 + 入れ子 22項目**（要素3 / 部品12 / かたまり7）
- `_partial/toc-list` は #3081 で既に `items[].children` を受けて `toc-child` > `toc-level-3` を描けるようになっていたので、**拡張は不要でした**。`specialsToc` に `children` を渡しただけです
- id は英字の slug（`sample-icons` / `sample-summary-panel` …）。節見出しの id（`elements` / `components` / `patterns`）は変えていません
- 題と目次の項目は `galleryName(群, id, 題)` の1回の呼び出しで両方に出します。2箇所に書くと、片方だけ足したときに目次と見本がずれます（条件付きで出る「著者紹介」も自動で追従します）
- `.gallery-name` の大きさ（`text-body`）と太さ（bold）と下の空き（4px）は `.gallery-name`（0,1,0）が要素セレクタに勝つのでそのまま。`h1〜h6` から継ぐのは `line-height` が `leading-row`(1.4) → `leading-heading`(1.3) になる1点だけで、部品の題は見出しなので段としてはこちらが正です

## 2. 「統計の枠」の見本の崩れ

原因は、枠の中の行の並びを決める CSS が `.sidebar-stats .summary …` と**置き場所の側に束ねられていた**こと。`_partial/sidebar-summary-panel` を単体で置くと1つも効かず、`1481投稿` と詰まって出て、狭い幅では `12345 X` が折り返していました。

**部品の見た目は部品のクラスが持つ**形に移しました。

- 移したもの（宣言はそのまま、セレクタの `.sidebar-stats` を `.summary-panel` に置き換え）: 行の並び（`.summary` / `.summary li`）・桁そろえ（`.summary-count` の `width` と `tabular-nums`）・内訳の左の縦線（`li.summary-sub::before`）・内訳の色と幅の補正・2組目のラベルの前の空き
- `.sidebar-stats` に残したのは**置き場所の規則**だけ: 上の空き `margin-top: 30px`、`.sidebar-stats-chart` / `-chart-label` / `-note`、1024px 以下の `display: none`
- 部品の root が `.summary-panel` になるよう、`sidebar-summary-panel.ejs` の `<div class="summary-panels">` の包みを外しました。この partial が描く枠は #3004 以来1つだけなので、「パネルを1行に束ねる」包みは役を持っていません。`--summary-count-width` は `section.summary-panel` が持ちます

### 前後が変わらないことの確認

**コンパイル後の CSS の差分**（`node css.mjs` の出力を before / after で diff）は、**セレクタの置き換えと、包みを外したぶんの1ルール削除だけ**。宣言は1つも変わっていません。

```
- .sidebar-stats .summary-panels { flex-direction: column; margin-bottom: 0; }   ← 包みごと削除
- .sidebar-stats .summary          →  + .summary-panel .summary
- .sidebar-stats .summary li       →  + .summary-panel .summary li
- .sidebar-stats .summary-count    →  + .summary-panel .summary-count
- .sidebar-stats .summary li.summary-sub(::before / :first-of-type / :last-child / .summary-count)
                                   →  + .summary-panel .summary li.summary-sub(…)
- .sidebar-stats .summary-sub .summary-count, .summary-label  →  + .summary-panel .summary-sub …
- .sidebar-stats .summary + .summary-panel-label  →  + .summary-panel .summary + .summary-panel-label
```

詳細度は `.sidebar-stats X` → `.summary-panel X` で**すべて同じ**（`.summary li` は 0,2,1 のまま）。1つだけ `.summary + .summary-panel-label` が 0,2,0 → 0,3,0 に上がりますが、`.summary-panel-label` の `margin-top` を他に書いている場所は無く、`.tag-pool-panel` の中には `.summary` が無いので当たりません。移した先はファイルの後ろ（`.summary-panel` の塊の末尾）で、素の `.summary` / `.summary-count` / `.summary-panel-label` より後・`.tag-pool-panel` より前なので、順序でも変わりません。

`.summary-panel` を持つ他の2箇所（著者ページの表彰パネル、`/tags/` の `tag-pool-panel`）は中に `.summary` を持たないので、移した規則は1つも当たりません。本文の統計タイル（`summary-tiles` の素の形）も `.summary-panel` の外なので無傷です。

**実サイドバーのスクリーンショット比較**（before = このブランチを stash して `hexo clean && hexo generate` し直した生成物、after = 本ブランチ）を `/categories/Programming/`・`/articles/`・`/authors/` の `.sidebar-stats` @1280 で撮り、**3枚とも PNG のバイト列まで完全一致**しました。要素の外形（`x` / `y` / `width` / `height`）も一致しています。

見本の側は狙いどおり変わります（`/specials/gallery/` @1280）。

| | before | after |
| --- | --- | --- |
| 1行目 | `1481投稿  25599総シェア数` が1行に詰まって並ぶ | `1481 投稿` / `25599 総シェア数` が桁をそろえて縦に並ぶ |
| 内訳 | `12345X` が詰まり、左の縦線も出ない | `12345 X` に空きが入り、左に塊の縦線が出る |

## 3. 「記事のメタ情報」の見本からタイトルとカテゴリを外す

タイトルの下にカテゴリが出る形はサイトのどこにも無い（カテゴリはパンくずが名乗る #2837）ので、見本をメタ行＋タグの行だけにしました。生成 HTML から `archive-post-title` と `article-category-link` が消えています。

外れた `post/title` と `post/category` は、`ui_gallery.js` の判定が「ギャラリーが**直接**呼んだものだけを見本あり」とする作りなので、`NOT_SHOWN` に理由を書く側を採りました。カードの見本が孫として呼んでいることを拾わせる案は、ページの骨格（パンくず・サイドバー）まで見本に数えてしまうこの判定の前提（#3045）を崩すのでやめています。

## 4. 「タグのチップ」の2行にラベル

各行の前に `<span class="gallery-note">件数あり</span>` /「名前だけ」を置きました。アイコンの見本と同じ形・同じクラスです。

## 5. 冒頭の文を落とす

「どれもサイトで実際に動いているものを呼び出しているので、ここで見た形がそのまま各ページに出ます。」を削除（ページの作りの話 #2895）。

## 6. 「ページの位置」

既に `_partial/pagination-info` を呼んでいることを**確認しました**。変更はありません。

## 検証

- 目次: `toc-level-2` 3件 / `toc-level-3` 22件（`toc-child` の `ol` 3本）
- `/doctor/` の「共通部品の台帳」: `post/title` `post/category` は理由付きの対象外になり、警告に出ません。残っている警告 3件（`chart-tooltip-count` / `sidebar-index-series` / `sidebar-index-without`）は**この PR の前からのもの**（base の `ui_gallery.js` にも `gallery.ejs` にも登場しません）で、この issue の外です
- 統計の枠の見本 @375 / @1280: 数字とラベルの間が空き、`12345 X` は折り返さず、桁がそろって内訳の左に縦線が出ます
- 実サイドバー @1280 の画素比較: `/categories/Programming/` `/articles/` `/authors/` の3枚とも before と一致
- axe（`site-audit` / `/specials/gallery/`・`/categories/Programming/` @375,1280）: 新しい所見は増えていません。ギャラリーに元から出る `target-size` / `landmark-unique`（パンくずの見本によるもの）だけで、見出し階層の飛び（h2 → h3）も出ていません
- `make lint-css` / prettier / textlint（変更した `.ejs`）すべて通過

Closes #3088

🤖 Generated with [Claude Code](https://claude.com/claude-code)
