### PR TITLE
連載一覧と特設ページに「関連タグ」を置く (#3095)

### DIFF
--- a/themes/future/layout/advent-calendar.ejs
+++ b/themes/future/layout/advent-calendar.ejs
@@ -100,6 +100,13 @@
           .sort((a, b) => b.date - a.date);
       %>
       <%- partial('_partial/post-panel-grid', {posts: revivalPosts}) %>
+
+      <%- partial('_partial/section-heading', {id: 'relatedtags', text: '関連タグ'}) %>
+      <div class="blog-tags">
+        <%- partial('_partial/tag-chips', {items: [
+            {name: 'アドベントカレンダー', path: '/tags/アドベントカレンダー/'},
+          ]}) %>
+      </div>
     </div>
   </div>
     </main>
@@ -107,6 +114,7 @@
       <%- partial('_partial/sidebar', {specialsToc: [
         {id: 'calendars', text: '歴代のアドベントカレンダー'},
         {id: 'revival', text: 'ブログで読めるアドベントカレンダー記事'},
+        {id: 'relatedtags', text: '関連タグ'},
       ]}) %>
     </aside>
   </div>

--- a/themes/future/layout/httf.ejs
+++ b/themes/future/layout/httf.ejs
@@ -63,6 +63,14 @@
         kyoproPosts.sort((a, b) => b.date - a.date);
       %>
       <%- partial('_partial/post-panel-grid', {posts: kyoproPosts}) %>
+
+      <%- partial('_partial/section-heading', {id: 'relatedtags', text: '関連タグ'}) %>
+      <div class="blog-tags">
+        <%- partial('_partial/tag-chips', {items: [
+            {name: '競技プログラミング', path: '/tags/競技プログラミング/'},
+            {name: 'AtCoder', path: '/tags/AtCoder/'},
+          ]}) %>
+      </div>
     </div>
   </div>
     </main>
@@ -71,6 +79,7 @@
         {id: 'why', text: 'フューチャーが HACK TO THE FUTURE を開催する理由'},
         {id: 'contests', text: '歴代のコンテスト'},
         {id: 'kyopro', text: '競技プログラミングの記事'},
+        {id: 'relatedtags', text: '関連タグ'},
       ]}) %>
     </aside>
   </div>

--- a/themes/future/layout/publications.ejs
+++ b/themes/future/layout/publications.ejs
@@ -35,6 +35,14 @@
         </li>
         <% }) %>
       </ul>
+
+      <%- partial('_partial/section-heading', {id: 'relatedtags', text: '関連タグ'}) %>
+      <div class="blog-tags">
+        <%- partial('_partial/tag-chips', {items: [
+            {name: '出版', path: '/tags/出版/'},
+            {name: '外部寄稿', path: '/tags/外部寄稿/'},
+          ]}) %>
+      </div>
     </div>
   </div>
     </main>
@@ -42,6 +50,7 @@
       <%- partial('_partial/sidebar', {specialsToc: [
         {id: 'books', text: '書籍'},
         {id: 'magazines', text: '技術誌への寄稿'},
+        {id: 'relatedtags', text: '関連タグ'},
       ]}) %>
     </aside>
   </div>

--- a/themes/future/layout/series.ejs
+++ b/themes/future/layout/series.ejs
@@ -31,7 +31,7 @@
       <%# 年と内訳の間の空白は読み上げのための区切り。「2026年7連載」と続けて読まれない %>
       <h3 id="series-<%= year %>" class="group-heading"><%= year %>年 <span class="group-heading-meta"><%= list.length %>連載・全<%= list.reduce((sum, s) => sum + s.total, 0) %>本・著者<%= yearAuthors.size %>名</span></h3>
       <%# .series-panels がパネルの横並びレイアウトを持つ（トップの「連載から探す」と同じ部品） %>
-      <div class="series-panels row g-4<%= yi === years.length - 1 ? ' footer-gap' : '' %>">
+      <div class="series-panels row g-4">
         <% list.forEach(function(s){ %>
         <div class="col-12 col-md-6 col-lg-4">
           <%# 期間は連載の活動期間（初回〜最新）。単月で終わった連載は1つだけ名乗る %>
@@ -47,6 +47,16 @@
       </div>
     <% }) %>
 
+    <%# 連載の索引記事はすべて「インデックス」タグを持つ (#3095) %>
+    <div class="footer-gap">
+      <%- partial('_partial/section-heading', {id: 'relatedtags', text: '関連タグ'}) %>
+      <div class="blog-tags">
+        <%- partial('_partial/tag-chips', {items: [
+            {name: 'インデックス', path: '/tags/インデックス/'},
+          ]}) %>
+      </div>
+    </div>
+
     </main>
     <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar-index-series') %>
@@ -55,7 +65,7 @@
       <%- partial('_partial/sidebar', {specialsToc: [{
             id: 'series', text: 'すべての連載',
             children: years.map(function(y){ return {id: 'series-' + y, text: y + '年'}; }),
-          }]}) %>
+          }, {id: 'relatedtags', text: '関連タグ'}]}) %>
     </aside>
   </div>
 </div>

--- a/themes/future/layout/techcast.ejs
+++ b/themes/future/layout/techcast.ejs
@@ -66,6 +66,13 @@
         const podcastPosts = podcastTag ? podcastTag.posts.sort('-date').toArray() : [];
       %>
       <%- partial('_partial/post-panel-grid', {posts: podcastPosts}) %>
+
+      <%- partial('_partial/section-heading', {id: 'relatedtags', text: '関連タグ'}) %>
+      <div class="blog-tags">
+        <%- partial('_partial/tag-chips', {items: [
+            {name: 'ポッドキャスト', path: '/tags/ポッドキャスト/'},
+          ]}) %>
+      </div>
     </div>
   </div>
     </main>
@@ -74,6 +81,7 @@
         {id: 'listen', text: '最新エピソード'},
         {id: 'episodes', text: 'エピソード一覧'},
         {id: 'posts', text: 'ポッドキャストの記事'},
+        {id: 'relatedtags', text: '関連タグ'},
       ]}) %>
     </aside>
   </div>


### PR DESCRIPTION
Closes #3095

## やったこと

`/specials/guidelines/` だけが末尾に持っていた「関連タグ」（`section-heading` ＋ `tag-chips`）を、同じ形で5ページに置いた。サイドバーの目次にも「関連タグ」を足した（`/series/` は h2「すべての連載」と並ぶ2つ目の項目）。

| ページ | タグ（記事数） | 根拠 |
| --- | --- | --- |
| `/series/` | インデックス（90） | 連載の索引記事が持つタグ |
| Tech Cast | ポッドキャスト（2） | 「ポッドキャストの記事」の収集キー |
| アドベントカレンダー | アドベントカレンダー（13） | 「歴代のアドベントカレンダー」の収集キー |
| HTTF | 競技プログラミング（13）・AtCoder（4） | 「競技プログラミングの記事」の収集キー |
| 出版・寄稿 | 出版（22）・外部寄稿（4） | `books:` / `magazines:` を持つ記事のタグ |

## 判断

- **当てるタグは、そのページが記事を集めている元のタグ。** ページの実装が既に名指ししているものなので、新しい語彙を持ち込まない（ガイドラインが「ガイドライン」「コーディング規約」を置いているのと同じ）
- **部品は作らない。** 6ページで同じ6行だが、ガイドラインと同じくインラインで書く。textlint（`.ejs`）から見える位置にリンクがあるほうを優先し、見本を持たない partial を増やさない
- `/series/` は最後の年の行が持っていた `footer-gap` を「関連タグ」の側へ移した

## 確認

- textlint（5本の `.ejs`）通過
- 配信 HTML の確認は続けてコメントに書く

🤖 Generated with [Claude Code](https://claude.com/claude-code)