### PR TITLE
特設ページの関連タグを収集キーと同じ定数から出し、出版の記事に「出版」タグを lint で求める (#3101)

### DIFF
--- a/.textlint/textlint-rule-no-publication-without-tag/index.js
+++ b/.textlint/textlint-rule-no-publication-without-tag/index.js
@@ -1,0 +1,73 @@
+/**
+ * frontmatter に books / magazines を書いた記事は「出版」タグを持つ (#3101)。
+ *
+ * /specials/publications/ の一覧は books / magazines から作り、同じページの
+ * 「関連タグ」は「出版」タグを指す。片方だけ書くと一覧には載るのにタグページには
+ * 出ない記事ができる。答えが決まっている検査なので /doctor ではなく linter に置く (#2706)。
+ *
+ * frontmatter は textlint の AST に中身が出ないので、原文の先頭の `---` ブロックを
+ * 自分で読む（no-invalid-post-taxonomy と同じ）。どのタグを付けるかは決まっているが、
+ * 位置（tags の並びのどこか）は書き手に任せるので --fix は持たない。
+ */
+const path = require("path");
+
+const FRONT_MATTER_RE = /^---\r?\n([\s\S]*?\r?\n)---/;
+const REQUIRED_TAG = "出版";
+
+function unquote(value) {
+  return value.replace(/^["']|["']$/g, "").trim();
+}
+
+// tags の値を読む。ブロック形式（`- 値`）とフロー形式（`[a, b]`）の両方を受ける
+function readTags(frontMatter) {
+  const head = /^tags:[ \t]*(.*)$/m.exec(frontMatter);
+  if (!head) return null;
+  const inline = head[1].trim();
+  if (inline.startsWith("[")) {
+    return inline
+      .slice(1, inline.lastIndexOf("]"))
+      .split(",")
+      .map((raw) => unquote(raw))
+      .filter(Boolean);
+  }
+  const items = [];
+  for (const line of frontMatter.slice(head.index + head[0].length + 1).split(/\r?\n/)) {
+    const item = /^\s+-\s+(.*)$/.exec(line);
+    if (!item) break;
+    const value = unquote(item[1]);
+    if (value) items.push(value);
+  }
+  return items;
+}
+
+function reporter(context) {
+  const { Syntax, RuleError, report, getSource } = context;
+  const filePath = context.getFilePath() || "";
+  if (!/\.md$/i.test(filePath) || !filePath.includes(`${path.sep}source${path.sep}_posts${path.sep}`)) {
+    return {};
+  }
+  return {
+    [Syntax.Document](node) {
+      const source = getSource(node);
+      const matched = FRONT_MATTER_RE.exec(source);
+      if (!matched) return;
+      const frontMatter = matched[1];
+      const publication = /^(books|magazines):/m.exec(frontMatter);
+      if (!publication) return;
+      const tags = readTags(frontMatter) || [];
+      if (tags.includes(REQUIRED_TAG)) return;
+      const tagsAt = frontMatter.indexOf("tags:");
+      const base = node.range[0] + matched[0].indexOf(frontMatter);
+      report(
+        node,
+        new RuleError(
+          `${publication[1]} を書いた記事には「${REQUIRED_TAG}」タグを付けます` +
+            "（/specials/publications/ の一覧と関連タグの行き先をそろえるため #3101）",
+          { index: base + (tagsAt < 0 ? publication.index : tagsAt) }
+        )
+      );
+    },
+  };
+}
+
+module.exports = reporter;

--- a/.textlint/textlint-rule-no-publication-without-tag/package.json
+++ b/.textlint/textlint-rule-no-publication-without-tag/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "textlint-rule-no-publication-without-tag",
+  "version": "1.0.0",
+  "private": true,
+  "description": "frontmatter に books / magazines を書いた記事が「出版」タグを持つことを求める textlint ルール",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/.textlintrc
+++ b/.textlintrc
@@ -72,6 +72,7 @@
     "no-invalid-post-taxonomy": true,
     "no-markdown-image": true,
     "no-mismatched-code-fence": true,
+    "no-publication-without-tag": true,
     "no-unmarked-external-link": {
       "exemptFiles": [
         "layout/advent-calendar.ejs",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1709,7 +1709,10 @@ bootstrap-subset → theme-styles.styl の順で `/css/site.css` に連結する
     **ページ本文にはそう書かない**（#2895。読者に語るのは中身であって、
     ページの作り方と収録の運用ではない）
   - 書き方は `.claude/skills/publish-qiita/SKILL.md` の「フロントマター整備」が持つ。
-    **タグに `出版` を付けるだけでは載らない**ので、公開手順の側に書いておく
+    **タグに `出版` を付けるだけでは載らない**ので、公開手順の側に書いておく。
+    逆に `books:` / `magazines:` を書いた記事に `出版` タグが無いと、一覧には載るのに
+    ページの「関連タグ」の行き先（`/tags/出版/`）には出ない。**textlint の
+    `no-publication-without-tag` が止める**（#3101）
 - **特設・固定ページはルート直下に置かず `/specials/` 配下に切る**（#2344）。
   GitHub Pages のプロジェクトサイトが `future-architect.github.io/<リポジトリ名>/` に生えるため、
   ルート直下のパスは将来のリポジトリ名と衝突しうる（/arch-guidelines/ 等は既に別リポジトリが占有）。

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "textlint-rule-no-japanese-only-inline-code": "file:.textlint/textlint-rule-no-japanese-only-inline-code",
         "textlint-rule-no-markdown-image": "file:.textlint/textlint-rule-no-markdown-image",
         "textlint-rule-no-mismatched-code-fence": "file:.textlint/textlint-rule-no-mismatched-code-fence",
+        "textlint-rule-no-publication-without-tag": "file:.textlint/textlint-rule-no-publication-without-tag",
         "textlint-rule-no-unmarked-external-link": "file:.textlint/textlint-rule-no-unmarked-external-link",
         "textlint-rule-preset-ja-technical-writing": "^12.0.2",
         "textlint-rule-prh": "^6.1.0"
@@ -140,6 +141,11 @@
       "license": "MIT"
     },
     ".textlint/textlint-rule-no-mismatched-code-fence": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    ".textlint/textlint-rule-no-publication-without-tag": {
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
@@ -9823,6 +9829,10 @@
         "match-index": "^1.0.3",
         "textlint-rule-helper": "^2.3.0"
       }
+    },
+    "node_modules/textlint-rule-no-publication-without-tag": {
+      "resolved": ".textlint/textlint-rule-no-publication-without-tag",
+      "link": true
     },
     "node_modules/textlint-rule-no-unmarked-external-link": {
       "resolved": ".textlint/textlint-rule-no-unmarked-external-link",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "textlint-rule-no-invalid-post-taxonomy": "file:.textlint/textlint-rule-no-invalid-post-taxonomy",
     "textlint-rule-no-markdown-image": "file:.textlint/textlint-rule-no-markdown-image",
     "textlint-rule-no-mismatched-code-fence": "file:.textlint/textlint-rule-no-mismatched-code-fence",
+    "textlint-rule-no-publication-without-tag": "file:.textlint/textlint-rule-no-publication-without-tag",
     "textlint-rule-no-unmarked-external-link": "file:.textlint/textlint-rule-no-unmarked-external-link",
     "textlint-rule-preset-ja-technical-writing": "^12.0.2",
     "textlint-rule-prh": "^6.1.0"

--- a/scripts/lib/series.js
+++ b/scripts/lib/series.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// 索引記事の判定に使うタグ。/series/ の関連タグもここから引く (#3101)
+const INDEX_TAG = 'インデックス';
+
 /**
  * 連載記事に前 / 次 と索引へのリンクを出すヘルパー。
  *
@@ -154,13 +157,13 @@ function build(site) {
   // 系統リンクの行き先は索引記事（無ければ先頭の記事）。/series/ 一覧と同じ規則
   const destOf = (name) => {
     const posts = groups.get(name);
-    const index = posts.find((p) => p.tags && p.tags.some((t) => t.name === 'インデックス'));
+    const index = posts.find((p) => p.tags && p.tags.some((t) => t.name === INDEX_TAG));
     return { name, path: (index || posts[0]).path };
   };
 
   const series = new Map(); // 記事のパス -> その記事から見た連載
   for (const [name, posts] of groups) {
-    const index = posts.find((p) => p.tags && p.tags.some((t) => t.name === 'インデックス'));
+    const index = posts.find((p) => p.tags && p.tags.some((t) => t.name === INDEX_TAG));
 
     // 落とすのはナビの表示だけ。記事の title そのものは触らない
     const nav = posts.map((p) => ({ path: p.path, title: navTitle(p.title, name) }));
@@ -192,7 +195,7 @@ function build(site) {
   return {
     byPath: series,
     list: [...groups].map(([name, posts]) => {
-      const index = posts.find((p) => p.tags && p.tags.some((t) => t.name === 'インデックス'));
+      const index = posts.find((p) => p.tags && p.tags.some((t) => t.name === INDEX_TAG));
       return {
         name,
         total: posts.length,
@@ -265,4 +268,4 @@ function navLinkedPaths(site, post) {
   return s ? s.linked : NONE;
 }
 
-module.exports = { seriesOf, navLinkedPaths, allSeries, seriesStats };
+module.exports = { INDEX_TAG, seriesOf, navLinkedPaths, allSeries, seriesStats };

--- a/scripts/series.js
+++ b/scripts/series.js
@@ -3,7 +3,7 @@
 // 連載ナビ本体。グループ化と題名の整形は lib/series.js にある
 // （related_posts / reference_posts も同じ結果を使うため）
 
-const { seriesOf, allSeries, seriesStats } = require('./lib/series');
+const { INDEX_TAG, seriesOf, allSeries, seriesStats } = require('./lib/series');
 
 hexo.extend.helper.register('series_nav', function (post) {
   return seriesOf(this.site, post);
@@ -19,6 +19,11 @@ hexo.extend.helper.register('recent_series', function (limit = 2, minPosts = 3) 
 // /series/ 一覧ページ（#2304）。更新が新しい順の全連載
 hexo.extend.helper.register('all_series', function () {
   return allSeries(this.site);
+});
+
+// /series/ の関連タグ。索引記事の判定と同じ値 (#3101)
+hexo.extend.helper.register('series_index_tag', function () {
+  return INDEX_TAG;
 });
 
 // /series/ の統計。累計と直近1年 (#2572)

--- a/themes/future/layout/advent-calendar.ejs
+++ b/themes/future/layout/advent-calendar.ejs
@@ -40,8 +40,10 @@
         // 参加レポート（「Qiita Advent Calendar 20XX に参加します」）を公開年で引く。
         // タグ「アドベントカレンダー」のうち、series を持つもの（リバイバル連載の
         // 索引記事）とカレンダーに登録された記事そのものを除いた残り
+        // 関連タグのチップも同じ配列から出す (#3101)
+        const RELATED_TAGS = ['アドベントカレンダー'];
         const reports = {};
-        const reportTag = site.tags.findOne({name: 'アドベントカレンダー'});
+        const reportTag = site.tags.findOne({name: RELATED_TAGS[0]});
         if (reportTag) reportTag.posts.forEach(function(p){
           if (p.series) return;
           const m = String(p.path || '').match(/^articles\/(.+?)\/$/);
@@ -103,9 +105,7 @@
 
       <%- partial('_partial/section-heading', {id: 'relatedtags', text: '関連タグ'}) %>
       <div class="blog-tags">
-        <%- partial('_partial/tag-chips', {items: [
-            {name: 'アドベントカレンダー', path: '/tags/アドベントカレンダー/'},
-          ]}) %>
+        <%- partial('_partial/tag-chips', {items: RELATED_TAGS.map(function(name){ return {name: name, path: '/tags/' + name + '/'}; })}) %>
       </div>
     </div>
   </div>

--- a/themes/future/layout/guidelines.ejs
+++ b/themes/future/layout/guidelines.ejs
@@ -25,9 +25,12 @@
         // フロントマターに専用キーは足さない（見えない語彙になり、入稿ツール側の
         // 対応も要る）。本文が張っている外部リンクで節に自動分類し、
         // どのサイトにもリンクしない記事（タグの緩い使われ方）は自然に落ちる
+        // 関連タグのチップも同じ配列から出す。収集キーとチップの値を別々に書くと、
+        // タグを名寄せしたときに片方だけ直ることがある (#3101)
+        const RELATED_TAGS = ['ガイドライン', 'コーディング規約'];
         const seen = new Set();
         const posts = [];
-        ['ガイドライン', 'コーディング規約'].forEach(function(name){
+        RELATED_TAGS.forEach(function(name){
           const t = site.tags.findOne({name: name});
           if (t) t.posts.forEach(function(p){
             if (!seen.has(p._id)) { seen.add(p._id); posts.push(p); }
@@ -58,10 +61,7 @@
 
       <%- partial('_partial/section-heading', {id: 'relatedtags', text: '関連タグ'}) %>
       <div class="blog-tags">
-        <%- partial('_partial/tag-chips', {items: [
-              {name: 'ガイドライン', path: '/tags/ガイドライン/'},
-              {name: 'コーディング規約', path: '/tags/コーディング規約/'},
-            ]}) %>
+        <%- partial('_partial/tag-chips', {items: RELATED_TAGS.map(function(name){ return {name: name, path: '/tags/' + name + '/'}; })}) %>
       </div>
     </div>
   </div>

--- a/themes/future/layout/httf.ejs
+++ b/themes/future/layout/httf.ejs
@@ -52,9 +52,11 @@
       <%
         // タグ「競技プログラミング」∪「AtCoder」から自動収集。
         // 「コンテスト」タグは統合予定 (#2334) のため収集キーにしない
+        // 関連タグのチップも同じ配列から出す (#3101)
+        const RELATED_TAGS = ['競技プログラミング', 'AtCoder'];
         const seen = new Set();
         const kyoproPosts = [];
-        ['競技プログラミング', 'AtCoder'].forEach(function(name){
+        RELATED_TAGS.forEach(function(name){
           const t = site.tags.findOne({name: name});
           if (t) t.posts.forEach(function(p){
             if (!seen.has(p._id)) { seen.add(p._id); kyoproPosts.push(p); }
@@ -66,10 +68,7 @@
 
       <%- partial('_partial/section-heading', {id: 'relatedtags', text: '関連タグ'}) %>
       <div class="blog-tags">
-        <%- partial('_partial/tag-chips', {items: [
-            {name: '競技プログラミング', path: '/tags/競技プログラミング/'},
-            {name: 'AtCoder', path: '/tags/AtCoder/'},
-          ]}) %>
+        <%- partial('_partial/tag-chips', {items: RELATED_TAGS.map(function(name){ return {name: name, path: '/tags/' + name + '/'}; })}) %>
       </div>
     </div>
   </div>

--- a/themes/future/layout/series.ejs
+++ b/themes/future/layout/series.ejs
@@ -47,13 +47,12 @@
       </div>
     <% }) %>
 
-    <%# 連載の索引記事はすべて「インデックス」タグを持つ (#3095) %>
+    <%# 連載の索引記事の判定に使うタグ。値は scripts/lib/series.js が持ち、ここでは helper で引く (#3101) %>
+    <% const RELATED_TAGS = [series_index_tag()]; %>
     <div class="footer-gap">
       <%- partial('_partial/section-heading', {id: 'relatedtags', text: '関連タグ'}) %>
       <div class="blog-tags">
-        <%- partial('_partial/tag-chips', {items: [
-            {name: 'インデックス', path: '/tags/インデックス/'},
-          ]}) %>
+        <%- partial('_partial/tag-chips', {items: RELATED_TAGS.map(function(name){ return {name: name, path: '/tags/' + name + '/'}; })}) %>
       </div>
     </div>
 

--- a/themes/future/layout/techcast.ejs
+++ b/themes/future/layout/techcast.ejs
@@ -61,17 +61,16 @@
       <%- partial('_partial/section-heading', {id: 'posts', text: 'ポッドキャストの記事'}) %>
       <p class="specials-text margin-bottom-20">番組の立ち上げや収録の裏側は、ブログ側の記事にも書いています。</p>
       <%
-        // タグ「ポッドキャスト」から自動収集
-        const podcastTag = site.tags.findOne({name: 'ポッドキャスト'});
+        // タグ「ポッドキャスト」から自動収集。関連タグのチップも同じ配列から出す (#3101)
+        const RELATED_TAGS = ['ポッドキャスト'];
+        const podcastTag = site.tags.findOne({name: RELATED_TAGS[0]});
         const podcastPosts = podcastTag ? podcastTag.posts.sort('-date').toArray() : [];
       %>
       <%- partial('_partial/post-panel-grid', {posts: podcastPosts}) %>
 
       <%- partial('_partial/section-heading', {id: 'relatedtags', text: '関連タグ'}) %>
       <div class="blog-tags">
-        <%- partial('_partial/tag-chips', {items: [
-            {name: 'ポッドキャスト', path: '/tags/ポッドキャスト/'},
-          ]}) %>
+        <%- partial('_partial/tag-chips', {items: RELATED_TAGS.map(function(name){ return {name: name, path: '/tags/' + name + '/'}; })}) %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Closes #3101

## やったこと

### 1. 関連タグのチップと記事の収集キーを1つの定数に（4ページ）

ガイドライン / Tech Cast / アドベントカレンダー / HTTF で、同じタグ名がレイアウトの中に2回（`site.tags.findOne({name: '…'})` とチップの `{name: '…'}`）書かれていた。先頭で `const RELATED_TAGS = [...]` を1回宣言し、収集ループとチップ（`RELATED_TAGS.map(...)`）の両方がそれを読む。タグを名寄せしたときに片方だけ直る形を無くす。

### 2. `/series/` は索引記事の判定と同じ値を helper で引く

`scripts/lib/series.js` の3箇所にあった `'インデックス'` を定数 `INDEX_TAG` にし、`series_index_tag()` helper で公開。レイアウトはそれを `RELATED_TAGS` に入れる。値が JS と EJS の2ファイルに割れていたのを1箇所に（#2768「一致をコメントで主張しない」）。

### 3. 出版・寄稿は textlint ルール `no-publication-without-tag`

出版のページはフロントマターの `books:` / `magazines:` から作り、関連タグの「出版」はそれと独立していた。**`books:` / `magazines:` を書いた記事は「出版」タグを持つ**ことを求めるローカルルールを足す（`no-invalid-post-taxonomy` と同じ型。決定的な検査は linter に置く #2706）。`--fix` は持たない。

- 対象は `source/_posts/` の `.md` だけ。frontmatter を原文から読む
- いま該当する20記事は全部「出版」タグを持っている（違反0）
- `package.json` の `file:` 依存と `package-lock.json` を更新。**マージ後は `npm install` が要る**（新しいローカルルールを node_modules に繋ぐため）
- CLAUDE.md の出版の節に1行足した

## 確認

- `@textlint/kernel` でルールを直接回し、実記事20本で違反0、`books:` があって「出版」タグの無い合成例は `tags:` の行で検出、`source/specials/` 配下は対象外
- `prettier --check`・textlint（5本の `.ejs`）通過
- 配信 HTML の確認（チップと記事の収集結果が変わっていないこと）は続けてコメントに書く

🤖 Generated with [Claude Code](https://claude.com/claude-code)