### PR TITLE
「◯◯一覧へ」の導線 .more-link を部品にする (#3098)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -839,6 +839,7 @@ bootstrap-subset → theme-styles.styl の順で `/css/site.css` に連結する
     全件への導線（ホームの連載・特設の枠、サイドバーの人気のタグ、記事末の連載ナビと
     著者紹介の `.more-link`、ヘッダーのドロップダウンの `.header-dropdown-more`）は
     `ink-mute`。hover は他の添えのリンクと同じ `ink-strong` ＋下線（#2699）
+    - **markup は `_partial/more-link` が1箇所で持つ**（#3098。引数は `url` と `text`）
     - **青をやめたら手がかりを別に足す。** 14px の1行では色しか手がかりが無くなるので、
       末尾に `>`（`chevron-right`）を置く。ドロップダウンの側は面 hover と
       仕切りの線を持つ行なので記号は要らない

--- a/themes/future/layout/_partial/archive.ejs
+++ b/themes/future/layout/_partial/archive.ejs
@@ -139,7 +139,7 @@
     </div>
     <%# 記法ガイドはパネルに出していない。全件は /specials/ が持つ %>
     <% if (sharedMore) { %>
-    <p class="more-link"><a href="<%= sharedMore.url %>"><%= sharedMore.text %><%- partial('svg-icon', {icon: 'chevron-right', class_name: 'svg-icon-trailing'}).trim() %></a></p>
+    <%- partial('more-link', {url: sharedMore.url, text: sharedMore.text}) %>
     <% } %>
   </section>
 <% } %>

--- a/themes/future/layout/_partial/article.ejs
+++ b/themes/future/layout/_partial/article.ejs
@@ -148,7 +148,7 @@
             <%# 連載を読み終えた読者が次に行きたいのは他の連載だが、そこへはホームに
                 戻るしかなかった (#2449)。ホームの「連載から探す」と同じ .more-link で
                 /series/ へ出す（枠の外・右下という位置もホームと同じ） %>
-            <p class="more-link"><a href="/series/">連載一覧へ<%- partial('svg-icon', {icon: 'chevron-right', class_name: 'svg-icon-trailing'}).trim() %></a></p>
+            <%- partial('more-link', {url: '/series/', text: '連載一覧へ'}) %>
           </nav>
           <% } %>
           <section class="social-area" data-nosnippet>

--- a/themes/future/layout/_partial/author-box.ejs
+++ b/themes/future/layout/_partial/author-box.ejs
@@ -30,9 +30,8 @@
         <a class="author-box-name" href="<%- url_for(authorPath) %>"><%= author %></a>
         <%# about は <br /> を含むのでエスケープしない %>
         <p class="author-box-about"><%- about %></p>
-        <%# 導線は紹介文の続きなので、丸の右の列（= 本文の左端）に置く。
-            .more-link の既定は右寄せだが、ここでは本文に揃える %>
-        <p class="more-link"><a href="<%- url_for(authorPath) %>">執筆記事一覧へ（<%= total %>本）<%- partial('svg-icon', {icon: 'chevron-right', class_name: 'svg-icon-trailing'}).trim() %></a></p>
+        <%# 導線は紹介文の続きなので、丸の右の列（= 本文の左端）に置く %>
+        <%- partial('more-link', {url: url_for(authorPath), text: `執筆記事一覧へ（${total}本）`}) %>
       </div>
     </div>
   </div>

--- a/themes/future/layout/_partial/more-link.ejs
+++ b/themes/future/layout/_partial/more-link.ejs
@@ -1,0 +1,4 @@
+<%# 全件、または次の集合への行き先 (#2899)。url が行き先、text が文言で、
+    「◯◯一覧へ」のように行き先の見出しと同じ語にする。「（N本）」のような
+    添えも文言の一部として渡す -%>
+<p class="more-link"><a href="<%- url %>"><%= text %><%- partial('svg-icon', {icon: 'chevron-right', class_name: 'svg-icon-trailing'}).trim() %></a></p>

--- a/themes/future/layout/_partial/panel-card.ejs
+++ b/themes/future/layout/_partial/panel-card.ejs
@@ -44,7 +44,7 @@
     <div class="panel-meta"><%- panelMeta %></div>
     <% } %>
     <% if (panelMore) { %>
-    <p class="more-link"><a href="<%= panelMore.url %>"><%= panelMore.text %><%- partial('svg-icon', {icon: 'chevron-right', class_name: 'svg-icon-trailing'}).trim() %></a></p>
+    <%- partial('more-link', {url: panelMore.url, text: panelMore.text}) %>
     <% } %>
   </div>
 </div>

--- a/themes/future/layout/_partial/sidebar.ejs
+++ b/themes/future/layout/_partial/sidebar.ejs
@@ -69,7 +69,7 @@
 <section class="sidebar-series" data-nosnippet>
 <h2 class="margin-top-30">人気の連載</h2>
 <%- partial('_widget/series.ejs') %>
-<p class="more-link"><a href="/series/">連載一覧へ<%- partial('svg-icon', {icon: 'chevron-right', class_name: 'svg-icon-trailing'}).trim() %></a></p>
+<%- partial('more-link', {url: '/series/', text: '連載一覧へ'}) %>
 </section>
 <%# タグはカテゴリと並べて置く (#2885)。どちらもブログ内の記事を見つける軸で、
     サイドバーの用途はそこに限る (#2880)。カテゴリを先にするのは粗い軸から
@@ -80,7 +80,7 @@
 <div class="blog-tags">
   <%- partial('_widget/tag.ejs') %>
 </div>
-<p class="more-link"><a href="/tags/">タグ一覧へ<%- partial('svg-icon', {icon: 'chevron-right', class_name: 'svg-icon-trailing'}).trim() %></a></p>
+<%- partial('more-link', {url: '/tags/', text: 'タグ一覧へ'}) %>
 </section>
 <% } %>
 <% if (is_post() || sToc || pageToc) { %>

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -39,7 +39,7 @@
         「へ」を付ける形 (#2899) %>
     <% const without = category_without_tag(page.category); %>
     <% if (without) { %>
-    <p class="more-link"><a href="<%- url_for(without.path) %>"><%= page.category %>カテゴリの<%= without.name %>以外の記事へ（<%= without.count %>本）<%- partial('_partial/svg-icon', {icon: 'chevron-right', class_name: 'svg-icon-trailing'}).trim() %></a></p>
+    <%- partial('_partial/more-link', {url: url_for(without.path), text: `${page.category}カテゴリの${without.name}以外の記事へ（${without.count}本）`}) %>
     <% } %>
     <% const cs = category_stats(page.category); %>
     <%# そのカテゴリの中でよく読まれている記事。新着より前に置く。

--- a/themes/future/layout/gallery.ejs
+++ b/themes/future/layout/gallery.ejs
@@ -83,6 +83,11 @@
         <%- partial('_partial/section-heading', {id: 'sample-heading-meta', text: '添えつき', meta: '全327本'}) %>
       </div>
       <div class="gallery-item">
+        <%- galleryName('components', 'sample-more-link', '一覧への導線') %>
+        <p class="specials-text">節や枠の下に置く、全件（または次の集合）への行き先です。文言は行き先の見出しと同じ語にし、末尾の矢印が「そこへ行く」を表します。</p>
+        <%- partial('_partial/more-link', {url: '/series/', text: '連載一覧へ'}) %>
+      </div>
+      <div class="gallery-item">
         <%- galleryName('components', 'sample-breadcrumb', 'パンくず') %>
         <p class="specials-text">上の階層への道筋だけを出します。現在地は真下の見出しが名乗るので出しません（ページを繰っているときだけ「Nページ目」が現在地として残ります）。1項目しか無いときはパンくず自体を出しません。</p>
         <%- partial('_partial/breadcrumb', {items: [


### PR DESCRIPTION
## やったこと

`_partial/more-link.ejs`（引数 `url` / `text`）を作り、手書きしていた7箇所を置き換えました。

| 置き換えた場所 | 渡す `url` | 渡す `text` |
| --- | --- | --- |
| `_partial/sidebar.ejs`（人気の連載） | `/series/` | 連載一覧へ |
| `_partial/sidebar.ejs`（人気のタグ） | `/tags/` | タグ一覧へ |
| `_partial/article.ejs`（連載ナビ） | `/series/` | 連載一覧へ |
| `_partial/archive.ejs`（特集の節の下） | `sharedMore.url` | `sharedMore.text` |
| `_partial/panel-card.ejs`（パネルの中） | `panelMore.url` | `panelMore.text` |
| `_partial/author-box.ejs`（著者紹介） | `url_for(authorPath)` | `` `執筆記事一覧へ（${total}本）` `` |
| `category.ejs`（◯◯以外の記事） | `url_for(without.path)` | `` `${page.category}カテゴリの${without.name}以外の記事へ（${without.count}本）` `` |

文言は呼び出し側が組んで渡す形にしました。「（N本）」のような添えも文言の一部です。
`url_for` を通していた2箇所は、通した結果を `url` に渡しています。

`.header-dropdown-more`（ヘッダーの「連載一覧へ」）は issue のとおり別部品のままです。

## 出力が変わっていないこと

`origin/main`（`d68be70d`）と本ブランチをそれぞれ `hexo clean && hexo generate` して、
`public/**/*.html` から `<p class="more-link">…</p>` を全部抜き出して突き合わせました。

- before: 821ページ・975ブロック / after: 821ページ・976ブロック
- **ブロックが違うページは `/specials/gallery/` の1つだけ**で、増えた1件は今回足した見本です。
  before の2件はどちらも after にそのまま残っています
- 代表ページはファイル全体をバイト単位で比較して同一を確認しました:
  `/`、`/articles/20260727a/`（連載ナビ無し）、`/articles/20260423a/`（連載ナビ有り）、
  `/categories/Programming/`、`/series/`、`/tags/`

partial は末尾に改行を持たない形（`category-icon.ejs` と同じ）にしてあります。
そのぶん `.trim()` を呼び出し側に足さずに、空白まで含めて元と同じ HTML が出ます。

## ギャラリーと台帳

- `/specials/gallery/` の「部品」に **一覧への導線**（`#sample-more-link`）を足しました。
  節見出しの隣＝同じ「節の部品」の並びです
- `/doctor/` の共通部品の台帳に `more-link 6画面: _partial/archive.ejs、_partial/article.ejs、
  _partial/author-box.ejs、_partial/panel-card.ejs、_partial/sidebar.ejs、category.ejs` が
  「見本あり」で出ています。「見本も理由も無い」の警告は before と同じ3件
  （`chart-tooltip-count` / `sidebar-index-series` / `sidebar-index-without`）のままで、増えていません

## 消したコメント

`_partial/author-box.ejs` の「`.more-link` の既定は右寄せだが、ここでは本文に揃える」を落としました。
#3017 で `text-align: right` の宣言ごと無くなっていて、いまは事実と違います。
「導線は紹介文の続きなので、丸の右の列（= 本文の左端）に置く」は置き場所の理由なので残しています。

CSS は触っていません。`p.more-link`（#3017）のセレクタはそのまま当たります。

Closes #3098

🤖 Generated with [Claude Code](https://claude.com/claude-code)
