### PR TITLE
ダークモードで mermaid の flowchart 以外に白い紙を敷く (#3106)

### DIFF
--- a/themes/future/css-src/_variables.styl
+++ b/themes/future/css-src/_variables.styl
@@ -29,6 +29,9 @@ rule-strong = #ccc    // focus / hover でひとつ強める
 // 前者だけがテーマで入れ替わる。後者は on-dark-strong（暗地の文字の段）で、
 // ダークでも白のまま
 surface-base = #fff
+// 焼き付いた図の紙。mermaid の flowchart 以外は線も文字も白い紙を前提に色が
+// 焼かれているので、暗い地でも紙だけは白のまま置く（記事に貼った画像と同じ扱い）
+figure-paper = #fff
 surface-tint = #f5f5f5 // 静止した面。チップ・タブ帯・表のヘッダ
 surface-mute = #eee
 // 表のセルの罫線。行を目で追う役をこの線が担っているので、枠（rule-base）より

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -52,6 +52,7 @@
   --rule-strong: rule-strong;
 
   --surface-base: surface-base;
+  --figure-paper: figure-paper;
   --surface-tint: surface-tint;
   --surface-mute: surface-mute;
 
@@ -5436,6 +5437,17 @@ pre.mermaid,
 .article-entry pre.mermaid .edgeLabel rect {
   fill: var(--surface-base) !important;
   opacity: 1 !important;
+}
+
+/* flowchart 以外（radar / sequence / gantt / er / state / block）は文字（#333）も
+   線も白い紙を前提に焼き付いていて、線だけ塗り直す手が届かない（gantt の帯や
+   sequence の矢印まで追うと型ごとの規則が要る）。xychart が自分で持っている
+   白い背景の rect と同じく、図の紙を白のまま敷く。記事に貼った白地の画像と同じ
+   扱いで、暗い地の上では白い図として出る。角は画像と同じ radius-small */
+.article-entry .mermaid-svg svg:not([aria-roledescription^="flowchart"]),
+.article-entry pre.mermaid svg:not([aria-roledescription^="flowchart"]) {
+  background: var(--figure-paper);
+  border-radius: radius-small;
 }
 
 /* /articles/20260602a/ で崩れたため */

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -5450,10 +5450,21 @@ pre.mermaid,
   border-radius: radius-small;
 }
 
-/* /articles/20260602a/ で崩れたため */
+/* 文字は ink-strong。ただし見えている下敷きは rect ではなく HTML ラベル
+   （span.edgeLabel と中の p）の背景 rgba(232,232,232,.8) で、暗い地では
+   明るい文字が明るい灰に乗って消えていた（/articles/20260602a/ #3106）。
+   背景も rect と同じ面のトークンにする。SVG 内の規則は #mermaid-<id> 付き（1,1,0）
+   なので !important が要る */
 .article-entry pre.mermaid .edgeLabel,
-.article-entry .mermaid-svg .edgeLabel {
-  color: var(--ink-strong);
+.article-entry .mermaid-svg .edgeLabel,
+.article-entry pre.mermaid .edgeLabel p,
+.article-entry .mermaid-svg .edgeLabel p {
+  color: var(--ink-strong) !important;
+  background-color: var(--surface-base) !important;
+}
+.article-entry pre.mermaid .edgeLabel .label text,
+.article-entry .mermaid-svg .edgeLabel .label text {
+  fill: var(--ink-strong) !important;
 }
 
 /* ラベルは foreignObject に計測時のサイズで固定embedされるが、計測時のフォント


### PR DESCRIPTION
Closes #3106

## 現象

/articles/20260417a/ の radar 図で、軸ラベル・凡例・題（`#333`）がダークモードのページの地（`#1b1b1f`）に沈む（比 **1.4**）。#2746 の手当ては flowchart の線・矢印・エッジラベルだけで、他の型には届いていなかった。

## やったこと

`.article-entry .mermaid-svg svg:not([aria-roledescription^="flowchart"])`（と `pre.mermaid` のフォールバック）に **白い紙 `figure-paper`（`#fff`、テーマで反転しない）** を敷き、角は画像と同じ `radius-small`。トークンは `_variables.styl` に1つ足した（白い面 `surface-base` はダークで反転し、`on-dark-strong` は文字の役なので、どちらとも役が違う）。

## 判断

- **線だけ塗り直す手は採らない。** flowchart 以外は文字（`#333`）も線も白い紙を前提に焼き付いていて、gantt の帯（`#fff400` の黄・白）や sequence の矢印・ライフラインまで追うと型ごとの規則が要る。xychart が自分で持つ白い背景 rect と同じ形にそろえ、**記事に貼った白地の画像と同じ扱い**にする（#2746 の「箱の地と文字は焼き付いたまま」の延長）
- flowchart（43枚）は今の透明＋線の塗り直しのまま。`aria-roledescription` が `flowchart` で始まるものを除外

## 確認

- SVG キャッシュ57枚の内訳: flowchart-v2 43 / xychart 6 / er 2 / sequence 2 / gantt 1 / block 1 / radar 1 / stateDiagram 1
- キャッシュの各型1枚ずつをサイトの CSS で `data-theme="dark"` に描き、playwright で実効値を測った: flowchart は背景透明のまま、他の8枚は `rgb(255,255,255)`・角 4px。radar のラベル `#333` は紙との比 **12.63**
- `make lint-css` 通過。実際の記事ページでの確認は続けてコメントに書く

🤖 Generated with [Claude Code](https://claude.com/claude-code)