### PR TITLE
出版・寄稿の一覧の執筆者3名を姓のみからフルネームにする (#2988)

### DIFF
--- a/source/_posts/2022/20220128a_フューチャー社員が行ったIT系技術誌への寄稿まとめ(2017～2022年).md
+++ b/source/_posts/2022/20220128a_フューチャー社員が行ったIT系技術誌への寄稿まとめ(2017～2022年).md
@@ -16,11 +16,11 @@ magazines:
   - name: "Software Design 2017年10月号"
     url: https://gihyo.jp/magazine/SD/archive/2017/201710
     work: "脆弱性スキャナVuls入門"
-    by: 林、枇榔晃裕、牛田、神戸康多
+    by: 林優二郎、枇榔晃裕、牛田隆之、神戸康多
   - name: "Software Design 2018年1月号"
     url: https://gihyo.jp/magazine/SD/archive/2018/201801
     work: "脆弱性管理サービスFutureVuls登場"
-    by: 林、牛田、枇榔晃裕
+    by: 林優二郎、牛田隆之、枇榔晃裕
   - name: "Software Design 2019年3月号"
     url: https://gihyo.jp/magazine/SD/archive/2019/201903
     work: "ES2015〜2018を踏まえた、今どきのJavaScriptの書き方"
@@ -36,7 +36,7 @@ magazines:
   - name: "WEB+DB PRESS Vol.120"
     url: https://gihyo.jp/magazine/wdpress/archive/2021/vol120
     work: "最新Vue.js 3 コアチームが解説！ 第2〜4章"
-    by: 太田
+    by: 太田洋介
   - name: "Software Design 2021年7月号"
     url: https://gihyo.jp/magazine/SD/archive/2021/202107
     work: "［特別企画］WSL 2本格入門"


### PR DESCRIPTION
Closes #2988

## やったこと

`/specials/publications/` で姓のみになっていた3名を、出版社のページの記載（issue のコメント）どおりフルネームにした。直したのは `source/_posts/2022/20220128a_*.md` のフロントマター `magazines[].by` の3行だけ。本文の「林さん」「牛田さん」「太田さん」はそのまま。

| 号 | before | after |
| --- | --- | --- |
| Software Design 2017年10月号 | 林、枇榔晃裕、牛田、神戸康多 | 林優二郎、枇榔晃裕、牛田隆之、神戸康多 |
| Software Design 2018年1月号 | 林、牛田、枇榔晃裕 | 林優二郎、牛田隆之、枇榔晃裕 |
| WEB+DB PRESS Vol.120 | 太田 | 太田洋介 |

並びは本文の章の順（第1章 林 → 第2章 枇榔・牛田 → 第3章 牛田 → 神戸）と一致していたので変えていない。

## 確認

- 変更した記事の textlint 通過（`no-publication-without-tag` #3102 を含む。手元の `node_modules` に新しいローカルルールが無くて一度 "No rules found" になったので `npm install` してから回した）
- `by` は `scripts/publications.js` が文字列のまま出すので、表示側の変更は無い

🤖 Generated with [Claude Code](https://claude.com/claude-code)
