### PR TITLE
一覧を束ねる h3 を _partial/group-heading にそろえる (#3099)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -3568,7 +3568,7 @@ ul.tag-list {
   font-weight: 700;
   color: var(--ink-strong);
 }
-/* 節見出しの直後に来るときは、その見出しの下の空きが既に区切っている */
+/* 器の先頭に立つときは上を空けない。前に区切るものが無い */
 .group-heading:first-child {
   margin-top: 0;
 }

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -3234,17 +3234,6 @@ ul.tag-list {
 .article-list .title a {
   color: var(--ink-strong);
 }
-/* 年・月の区切り。罫線を持たず直前の空きで階層を作るのは
-   .article-entry h3 と同じ。サイズだけは一覧の行に合わせて本文と同じ 1.2em */
-.article-list-period {
-  margin: 32px 0 10px;
-  font-size: text-body;
-  font-weight: 700;
-}
-.article-list-period:first-child {
-  margin-top: 0;
-}
-
 /*Archive*/
 .archive-list {
   display: flex;
@@ -3571,13 +3560,17 @@ ul.tag-list {
 .category-list-link {
   padding: 0 6px 0 0;
 }
-/* 群の見出し。節見出し（.bottom-content-header）の下の段で、/categories/ の群 (#2908) と
-   /series/ の年 (#3081) が使う。年の内訳のような添えは太らせず一段薄くする */
+/* 群の見出し（_partial/group-heading）。節見出し（.bottom-content-header）の下の段。
+   罫線を持たず直前の空きで階層を作る。添えは太らせず一段薄くする */
 .group-heading {
   margin: 32px 0 0;
   font-size: text-lead;
   font-weight: 700;
   color: var(--ink-strong);
+}
+/* 節見出しの直後に来るときは、その見出しの下の空きが既に区切っている */
+.group-heading:first-child {
+  margin-top: 0;
 }
 .group-heading-meta {
   margin-left: 8px;
@@ -3589,6 +3582,9 @@ ul.tag-list {
    見出しとカードの間隔がカード同士の間隔（24px）と同じになる */
 .group-heading + .series-panels {
   margin-top: 0;
+}
+.group-heading + .article-list {
+  margin-top: 8px;
 }
 /* /categories/ の一覧。1件は 名前＋統計 / 説明 / タグ の3段構成。
    17件を縦に積むと長いので、幅があるときは2列にする。

--- a/themes/future/layout/_partial/archive-all.ejs
+++ b/themes/future/layout/_partial/archive-all.ejs
@@ -20,8 +20,7 @@
       // h1 と重なるが、h3 はスクロール中とアンカー着地時に単独で読まれる
       const label = is_year() ? page.year + '年' + Number(group.key) + '月' : group.key + '年';
     %>
-    <%# アンカーの形は _partial/section-heading と同じ。アイコンと末尾への移動は headerlink.js が補う %>
-    <h3 id="<%= id %>" class="article-list-period"><a href="#<%= id %>" class="headerlink" title="<%= label %>"></a><%= label %></h3>
+    <%- partial('_partial/group-heading', {id: id, text: label}) %>
     <%# アーカイブページの最後の要素なので footer-gap でフッター前の間隔を持つ %>
     <ul class="article-list<%= gi === groups.length - 1 ? ' footer-gap' : '' %>">
       <% group.posts.forEach(function(post){ %>

--- a/themes/future/layout/_partial/group-heading.ejs
+++ b/themes/future/layout/_partial/group-heading.ejs
@@ -1,0 +1,6 @@
+<%# 節の中で一覧を年・月・群に束ねる見出し。節見出し（_partial/section-heading）の
+    1つ下の段。aria-label とリンクのアイコン、見出し末尾への移動は headerlink.js が補う。
+    meta を渡すと見出しの行の右に添えを置く（「7連載・全46本」など）。
+    text と meta の間の空白は読み上げのための区切り（「2026年7連載」と続けて読まれない）%>
+<% const groupMeta = typeof meta !== 'undefined' && meta; %>
+<h3 id="<%= id %>" class="group-heading"><a href="#<%= id %>" class="headerlink" title="<%= text %>"></a><%= text %><% if (groupMeta) { %> <span class="group-heading-meta"><%= groupMeta %></span><% } %></h3>

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -19,7 +19,8 @@
     <%# 群で区切る (#2908)。群と並びは category_group_index() が1箇所で持ち、
         ヘッダーのドロップダウン・サイドバーと同じ群・同じ並びになる %>
     <% category_group_index().forEach(function(g, gi, groups){ %>
-    <h3 class="group-heading"><%= g.name %></h3>
+    <%# id は群の名前から。記事の見出しと同じく日本語のまま持つ %>
+    <%- partial('_partial/group-heading', {id: 'group-' + g.name, text: g.name}) %>
     <ul class="category-index<%= gi === groups.length - 1 ? ' footer-gap' : '' %>">
       <% g.categories.forEach(function(c){ %>
       <li class="category-index-item">

--- a/themes/future/layout/gallery.ejs
+++ b/themes/future/layout/gallery.ejs
@@ -83,6 +83,12 @@
         <%- partial('_partial/section-heading', {id: 'sample-heading-meta', text: '添えつき', meta: '全327本'}) %>
       </div>
       <div class="gallery-item">
+        <%- galleryName('components', 'sample-group-heading', '群の見出し') %>
+        <p class="specials-text">節の中で一覧を年・月・群に束ねます。節見出しの1つ下の段で、右に件数の添えを置けます。左にラベルを置いて横に並べる「ラベル付きの行」とは役が違い、こちらは縦に積む一覧を区切ります。</p>
+        <%- partial('_partial/group-heading', {id: 'sample-group', text: '群の見出し'}) %>
+        <%- partial('_partial/group-heading', {id: 'sample-group-meta', text: '2026年', meta: '7連載・全46本'}) %>
+      </div>
+      <div class="gallery-item">
         <%- galleryName('components', 'sample-more-link', '一覧への導線') %>
         <p class="specials-text">節や枠の下に置く、全件（または次の集合）への行き先です。文言は行き先の見出しと同じ語にし、末尾の矢印が「そこへ行く」を表します。</p>
         <%- partial('_partial/more-link', {url: '/series/', text: '連載一覧へ'}) %>

--- a/themes/future/layout/series.ejs
+++ b/themes/future/layout/series.ejs
@@ -28,8 +28,11 @@
           著者は連載をまたいで重なるため、名前で寄せてから数える (#2572) %>
       <% const list = byYear.get(year); %>
       <% const yearAuthors = new Set(list.flatMap((s) => s.authors)); %>
-      <%# 年と内訳の間の空白は読み上げのための区切り。「2026年7連載」と続けて読まれない %>
-      <h3 id="series-<%= year %>" class="group-heading"><%= year %>年 <span class="group-heading-meta"><%= list.length %>連載・全<%= list.reduce((sum, s) => sum + s.total, 0) %>本・著者<%= yearAuthors.size %>名</span></h3>
+      <%- partial('_partial/group-heading', {
+            id: 'series-' + year,
+            text: year + '年',
+            meta: list.length + '連載・全' + list.reduce((sum, s) => sum + s.total, 0) + '本・著者' + yearAuthors.size + '名',
+          }) %>
       <%# .series-panels がパネルの横並びレイアウトを持つ（トップの「連載から探す」と同じ部品） %>
       <div class="series-panels row g-4">
         <% list.forEach(function(s){ %>


### PR DESCRIPTION
一覧を年・月・群に束ねる h3 が `.group-heading`（`/series/`・`/categories/`）と `.article-list-period`（期間ページ）の2つの形に割れていたのを、`_partial/group-heading.ejs` の1つに寄せました。

## やったこと

- `_partial/group-heading.ejs` を新設（`id` / `text` / `meta`）。`/series/`・`/categories/`・`_partial/archive-all.ejs` の3箇所から呼ぶ
- `.article-list-period` の規則を落として `.group-heading` に寄せる
- `/categories/` の h3 に `id` を付ける（群の名前から）
- ギャラリーの「部品」に見本「群の見出し」を、節見出しの直後に足す

## 決めたこと

**大きさは `text-lead`（18px）にそろえた。** 期間ページの h3 は `text-body`（15.6px）で本文と同じ大きさだったので、束ねる見出しであることが大きさから読み取れなかった。上の節見出し h2（24px）と一覧の行（14px）の間の段として `text-lead` が合う。

**アンカーは3箇所とも持つ。** 期間ページだけが持っていた形にそろえた。`headerlink.js` は h1〜h6 を一律に扱うので h3 でもアイコンと末尾への移動が効く（実測: hover でアイコンが出る）。`/series/` の `id`（サイドバーの目次の飛び先）はそのまま。`/categories/` の `id` は群の名前から `group-開発` の形にした。記事の見出しの `id` が既に日本語なので、そこにそろえている。

**間隔は 32px / 8px。** `.group-heading` の `margin-top: 32px` はそのまま、`.article-list-period` が持っていた `margin-bottom: 10px` は `.group-heading + .article-list { margin-top: 8px }`（4の倍数）に置き換えた。`.article-list-period:first-child { margin-top: 0 }` に当たっていた「節見出しの直後は上を空けない」は `.group-heading:first-child` で同じ振る舞いを保つ（生成 HTML で期間ページの先頭の h3 が `.blog-posts` の first-child であることを確認済み）。

期間ページの見出しに添え（本数）は足していない。この issue の範囲外。

## before / after（h3 の y 座標・実測 1280px）

h3 の**数・`id`・テキストは4ページとも一致**。

| ページ | h3 | 変化 |
| --- | --- | --- |
| `/series/` | 8 | y の差 **0.0px**（同じクラス・同じ値。`id` も同じ） |
| `/categories/` | 5 | y の差 **0.0px**（`id` が無し → `group-開発` ほかに付いた） |
| `/articles/` | 11 | 先頭 0.0px、以降 +1.1 / +2.2 / +3.4 … +11.2px |
| `/articles/2026/` | 8 | 先頭 0.0px、以降 +1.1 / +2.3 / +3.4 … +7.8px |

期間ページのずれは**見出し1本あたり +1.1px の累積だけ**で、内訳は
`高さ 20.3 → 23.4px（+3.1、15.6px → 18px のぶん）` − `見出しと一覧の間 10 → 8px（−2.0）` = **+1.1px**。
先頭の見出しは `:first-child` で上の空きが 0 のままなので動いていない。大きさの変化以外の差は出ていません。

## 台帳・ギャラリー

- `/doctor/` の共通部品の台帳に `group-heading 3画面: _partial/archive-all.ejs、categories.ejs、series.ejs`。見本ありとして出る
- 「見本も理由も無い部品」の警告は **3件のまま**（`chart-tooltip-count` / `sidebar-index-series` / `sidebar-index-without`）で増えていない
- ギャラリーの見本は meta 無し・meta ありの2つ

## axe / lint

- `site-audit`（`/articles/` `/series/` `/categories/` `/specials/gallery/` × 375 / 1280）で `heading-order` をはじめ新しい所見なし。残るエラー1・警告7はパンくずの target-size やページ重量など既存のもの
  - 途中で1件だけ増やして直しています。ギャラリーの meta 付きの見本を節見出しと同じ「添えつき」にしたところ、「同じ文字で行き先が違うリンク」に上がったので `2026年` に変えました（2種 → 1種、残りは既存の「設計」）
- `make lint-css` / textlint（変更した .ejs 5本）ともに通過。`scripts/` は触っていないので prettier は対象外

Closes #3099

🤖 Generated with [Claude Code](https://claude.com/claude-code)
