### PR TITLE
記事の行（ランキング・関連記事・被参照）を _partial/post-list-item にする (#3097)

### DIFF
--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -153,7 +153,7 @@ hexo.extend.helper.register('popular_posts_in', function (posts, limit, decay) {
   // ランキング・関連記事・被参照記事も .nav の中に置いて同じ形にしている。
   // 列は CSS（.popular-in-list）が持つ
   const items = ranked
-    .map(({ post }) => postListItem(post, 'featured-posts-item', { withThumb: true }))
+    .map(({ post }) => postListItem(this, post, 'featured-posts-item', { withThumb: true }))
     .join('');
   return `<ul class="nav popular-in-list">${items}</ul>`;
 });

--- a/scripts/lib/post_list.js
+++ b/scripts/lib/post_list.js
@@ -2,87 +2,52 @@
 
 const { getSNSCnt } = require('./sns');
 
-/**
- * 記事リストの li マークアップを組み立てる。
- *
- * 「関連記事」「この記事を参照している記事」「よく読まれている記事」で
- * 別々に書かれていて表示形式がずれていたため、ここに寄せる。
- *
- * 並びはタイトル -> NEW -> (日付 / 反響) の順。読み手は「何の記事か」を
- * 見てから「古くないか」「評判はどうか」を確認するため、
- * 判断の順序に合わせている。NEW を出すかは呼び出し側が決める（newLabel の注記）。
- */
-
-// 反響が0のときは何も出さない。0と表示されると寂しく見えるため。
-// ♡ だけ span で包むのは、記号は少し大きくしないと線が潰れる一方、
-// 数字は日付と同じ大きさに揃えたいため（#2453）
-const snsLabel = (permalink) => {
-  const n = getSNSCnt(permalink);
-  return n > 0
-    ? `<span class="snscount"><span class="snscount-icon">&#9825;</span>${n}</span>`
-    : '';
-};
-
-// 公開から30日以内なら NEW を付ける。
+// 公開から30日以内かどうか。
 //
-// **出すのはランキングだけ**（呼び出し側が withNew で渡す、#2788）。
+// **NEW を出すのはランキングだけ**（呼び出し側が withNew で渡す、#2788）。
 // 関連記事は関連度順、参照している記事は張られたリンクの記録で、どちらも
 // 新しさが並びの理由ではない。実測では参照している記事の92%が NEW
 // （12ページ中10ページが全行 NEW）で、しかも並びが日付降順なので二重だった。
 // 関連記事は逆に全期間で0.5%しか出ず、出るのは同じ連載の同時期の記事。
 // ランキングは PV 順で新しさと無関係なので、「まだ読んでいないかもしれない
 // 新顔」の合図として働く（74行中14行）
-const newLabel = (date) => {
+const isRecent = (date) => {
   const threshold = new Date();
   threshold.setDate(threshold.getDate() - 30);
-  return threshold.toISOString() <= date.toISOString() ? `<span class="newitem">NEW</span>` : '';
+  return threshold.toISOString() <= date.toISOString();
 };
 
 /**
- * サムネの箱。索引記事の表（thumb タグ #2790）も同じ markup を使う。
+ * 記事の行1件。「関連記事」「この記事を参照している記事」「よく読まれている記事」が
+ * 同じ形を共有する。markup は _partial/post-list-item.ejs が1箇所で持ち、
+ * ここは渡すデータを整えるだけ (#3097)。
  *
- * 同じ行のタイトルと同じ行き先のリンクなので、タブ移動と読み上げからは外す (#2845)。
- * サムネの無い記事は空文字を返す。行の左端を揃える必要がある一覧・ランキングだけ、
- * 呼び出し側（postListItem）が同じ大きさの空き枠に差し替える
- */
-const thumbIcon = (post) =>
-  post.thumbnail
-    ? `<a href="/${post.path}" class="post-list-icon" tabindex="-1" aria-hidden="true"><img src="${post.thumbnail}" alt="" width="72" height="48" loading="lazy"></a>`
-    : '';
-
-/**
+ * @param {object} ctx           呼び出し元のテンプレートのローカル（helper の this）。
+ *                               lib の関数は this を持たないので partial を引くために受け取る
  * @param {object} post          Hexo の post
  * @param {string} itemClass     li に付けるクラス
  * @param {object} [opts]
  * @param {string} [opts.titleAttr]  a の title 属性。省略時は lede
  * @param {boolean} [opts.withThumb] タイトルの左に小さいサムネを添える (#2230)
- * @param {{html: string, className: string}} [opts.rankMark]
- *        行頭に出す順位の丸。ランキング用 (#2249)。中身も段のクラスも呼び出し側が決める。
- *        何位がどの段か・数字を出すか記号にするかはランキング側の都合なので、
- *        ここは受け取った通りに包むだけにしている (#2681)
- * @param {boolean} [opts.withNew]   NEW を出す (#2788)
+ * @param {{html: string, className: string}} [opts.rankMark] 行頭に出す順位の丸 (#2249)
+ * @param {boolean} [opts.withNew]   公開30日以内なら NEW を出す (#2788)
  */
 const postListItem = (
+  ctx,
   post,
   itemClass,
   { titleAttr, withThumb = false, rankMark = null, withNew = false } = {},
-) => {
-  const attr = (titleAttr === undefined ? post.lede : titleAttr) || '';
-  const rankLabel = rankMark
-    ? `<span class="post-list-rank${rankMark.className ? ' ' + rankMark.className : ''}">${rankMark.html}</span>`
-    : '';
-  const body =
-    `<a href="/${post.path}" title="${attr}">${post.title}</a>` +
-    `${withNew ? newLabel(post.date) : ''}` +
-    // 関連記事・ランキングの日付は鮮度の目安なので年月まで (#2404)。
-    // 日まで出すのは、日付が並びの座標になる時系列リストと記事自身だけ
-    `<span class="post-meta"><span class="post-meta-date">${post.date.format('YYYY.MM')}</span>${snsLabel(post.permalink)}</span>`;
-  if (!withThumb) {
-    return `<li class="${itemClass}">${rankLabel}${body}</li>`;
-  }
-  // 行の左端を揃えるため、サムネの無い記事はここでだけ同じ大きさの空き枠に置き換える
-  const thumb = thumbIcon(post) || `<span class="post-list-icon post-list-icon-empty"></span>`;
-  return `<li class="${itemClass} post-list-item-thumb">${rankLabel}${thumb}<div class="post-list-body">${body}</div></li>`;
-};
+) =>
+  ctx
+    .partial('_partial/post-list-item', {
+      post,
+      itemClass,
+      titleAttr,
+      withThumb,
+      rankMark,
+      isNew: withNew && isRecent(post.date),
+      snsCount: getSNSCnt(post.permalink),
+    })
+    .trim();
 
-module.exports = { snsLabel, newLabel, postListItem, thumbIcon };
+module.exports = { postListItem };

--- a/scripts/popular_posts.js
+++ b/scripts/popular_posts.js
@@ -32,7 +32,7 @@ const rankMark = (rank, crownSvg) => {
 };
 
 // caps は各段の終端順位（累積）。[10, 25] なら 10位まで表示 + 25位まで畳み
-const rankingList = (posts, crownSvg, caps = [RANKING_DISPLAY_COUNT, RANKING_MAX_COUNT]) => {
+const rankingList = (ctx, posts, crownSvg, caps = [RANKING_DISPLAY_COUNT, RANKING_MAX_COUNT]) => {
   // 順位はマークアップ側で振る。CSS カウンタだと「10件で畳む」定数と
   // 二重管理になる。畳んだ側は11位から続く
   const items = (list, offset) =>
@@ -40,7 +40,7 @@ const rankingList = (posts, crownSvg, caps = [RANKING_DISPLAY_COUNT, RANKING_MAX
       .map((post, i) =>
         // NEW を出すのはここだけ (#2788)。PV 順の並びは新しさと無関係なので、
         // 「まだ読んでいないかもしれない新顔」の合図として働く
-        postListItem(post, 'featured-posts-item', {
+        postListItem(ctx, post, 'featured-posts-item', {
           withThumb: true,
           rankMark: rankMark(offset + i + 1, crownSvg),
           withNew: true,
@@ -151,6 +151,7 @@ hexo.extend.helper.register('popular_posts', function (term = 'weekly') {
   // アイコンのパスは svg-icon.ejs の辞書が1箇所で持つ決まりなので、
   // JS 側にパスを書き写さずヘルパーの実行文脈から partial を引く (#2681)
   return rankingList(
+    this,
     popularPosts,
     this.partial('_partial/svg-icon', { icon: 'crown' }).trim(),
     caps,

--- a/scripts/reference_posts.js
+++ b/scripts/reference_posts.js
@@ -29,9 +29,9 @@ hexo.extend.helper.register('list_reference_posts', function () {
   const shown = collapses ? referencePosts.slice(0, VISIBLE) : referencePosts;
   const hidden = collapses ? referencePosts.slice(VISIBLE) : [];
 
-  // マークアップは lib/post_list.js に集約している
+  // マークアップは _partial/post-list-item.ejs に集約している
   const items = (posts) =>
-    posts.map((p) => postListItem(p, 'reference-posts-item', { withThumb: true })).join('');
+    posts.map((p) => postListItem(this, p, 'reference-posts-item', { withThumb: true })).join('');
 
   // ul の直下に details は置けないため、畳む分は別の ul にして details で包む
   const more =

--- a/scripts/related_posts.js
+++ b/scripts/related_posts.js
@@ -102,7 +102,7 @@ function pickRelatedPosts(posts, series) {
 }
 
 // HTMLを生成するロジックを共通関数として外に切り出す
-function generateRelatedPostsHtml(posts, series) {
+function generateRelatedPostsHtml(ctx, posts, series) {
   posts = pickRelatedPosts(posts, series);
 
   let visible = posts.slice(0, DISPLAY_COUNT);
@@ -119,9 +119,9 @@ function generateRelatedPostsHtml(posts, series) {
     return `<p class="related-posts-none">No related post.</p>`;
   }
 
-  // マークアップは lib/post_list.js に集約している。title は lede だけ
+  // マークアップは _partial/post-list-item.ejs に集約している。title は lede だけ
   // （postListItem の既定）。score は並び順を決める内部の重みで読者には出さない (#3076)
-  const item = (related) => postListItem(related, 'related-posts-item', { withThumb: true });
+  const item = (related) => postListItem(ctx, related, 'related-posts-item', { withThumb: true });
 
   // 語彙と作りはランキング・参照記事の畳みに揃える (#2249)
   const moreHtml = more.length
@@ -221,7 +221,7 @@ hexo.extend.helper.register('list_related_posts', function () {
       `[INFO] Related Posts: No tag-related posts found for "${post.title}". Falling back to category.`,
     );
     const categoryPosts = getCategoryRelatedPosts(this, post, isExcluded);
-    return generateRelatedPostsHtml(categoryPosts, post.series);
+    return generateRelatedPostsHtml(this, categoryPosts, post.series);
   }
 
   // IDF は展開後の頻度で計算する。抽象タグ（CSS 等）は展開後に大量の記事が
@@ -286,5 +286,5 @@ hexo.extend.helper.register('list_related_posts', function () {
   }
 
   // 最終的な記事リストをHTMLに変換して返す
-  return generateRelatedPostsHtml(relatedPosts, post.series);
+  return generateRelatedPostsHtml(this, relatedPosts, post.series);
 });

--- a/scripts/thumb.js
+++ b/scripts/thumb.js
@@ -20,8 +20,6 @@
  * この時点で全記事が DB に入っている。
  */
 
-const { thumbIcon } = require('./lib/post_list');
-
 hexo.extend.tag.register('thumb', function (args) {
   const id = (args[0] || '').trim();
   if (!id) return '';
@@ -33,5 +31,8 @@ hexo.extend.tag.register('thumb', function (args) {
     hexo.log.warn(`thumb: 記事 ${id} が見つかりません`);
     return '';
   }
-  return thumbIcon(post);
+  // 絵の markup は行の部品と共有する (#3097)。タグプラグインには this.partial が
+  // 無いので、テーマのビューを直接引いて描く
+  const view = hexo.theme.getView('_partial/post-list-icon.ejs');
+  return view.renderSync({ post }).trim();
 });

--- a/scripts/ui_gallery.js
+++ b/scripts/ui_gallery.js
@@ -19,6 +19,7 @@ const fs = require('fs');
 const path = require('path');
 
 const LAYOUT_DIR = path.join(hexo.theme_dir, 'layout');
+const SCRIPT_DIR = path.join(hexo.base_dir, 'scripts');
 const GALLERY = 'gallery.ejs';
 
 // 見本を出さない部品と、その理由。
@@ -46,6 +47,7 @@ const NOT_SHOWN = {
   'sidebar-index-tags': '同上（/tags/）',
   'sidebar-stats-index':
     '一覧ページのサイドバーの中身。渡された統計とグラフを並べるだけで、単体では形を持たない',
+  'post-list-icon': '行に添えるサムネ。記事の行（post-list-item）の見本の中に実物が出ている',
   'post/title':
     '記事の題。一覧のカード（archive-post）の見本の中に実物が出ている。メタ情報の見本には入れない',
   'post/category':
@@ -59,8 +61,10 @@ const NOT_SHOWN = {
   sidebar: 'サイドバー。実物がこのページの右に出ている',
 };
 
-// partial('_partial/svg-icon') / partial('svg-icon') / partial('../category-icon')
-// / partial('_widget/tag.ejs') をすべて同じ名前に寄せる
+// 参照の書き方は '_partial/svg-icon' / 'svg-icon' / '../category-icon' /
+// '_widget/tag.ejs' と揺れるので、すべて同じ名前に寄せる。
+// **この行に呼び出しの形をそのまま書かない。** 下の走査が自分自身を読んで、
+// 例に挙げた部品の呼び出し元にこのファイルが並ぶ
 function normalize(ref) {
   return ref
     .replace(/\.ejs$/, '')
@@ -68,13 +72,13 @@ function normalize(ref) {
     .replace(/^_partial\//, '');
 }
 
-function listFiles(dir) {
+function listFiles(dir, ext) {
   const out = [];
   (function walk(d) {
     for (const name of fs.readdirSync(d)) {
       const p = path.join(d, name);
       if (fs.statSync(p).isDirectory()) walk(p);
-      else if (name.endsWith('.ejs')) out.push(p);
+      else if (name.endsWith(ext)) out.push(p);
     }
   })(dir);
   return out;
@@ -84,7 +88,7 @@ let cache = null;
 
 function buildIndex() {
   if (cache) return cache;
-  const files = listFiles(LAYOUT_DIR);
+  const files = listFiles(LAYOUT_DIR, '.ejs');
   const rel = (p) =>
     p
       .replace(LAYOUT_DIR + path.sep, '')
@@ -94,9 +98,20 @@ function buildIndex() {
   // 部品 = _partial/ と _widget/ の下の .ejs
   const parts = files.map(rel).filter((f) => f.startsWith('_partial/') || f.startsWith('_widget/'));
 
+  // helper も呼び出し元に数える。呼び出し元が多くて描画が重複するときは
+  // helper から this.partial(…) を呼んでよい (#3031) ので、テンプレートだけを
+  // 舐めると helper からしか呼ばれない部品が「呼び出し元が無い」に落ちる
+  const scripts = listFiles(SCRIPT_DIR, '.js');
+  const scriptRel = (p) =>
+    'scripts/' +
+    p
+      .replace(SCRIPT_DIR + path.sep, '')
+      .split(path.sep)
+      .join('/');
+
   const callers = new Map(); // 部品名 -> 呼び出し元のファイル
-  for (const f of files) {
-    const name = rel(f);
+  for (const f of files.concat(scripts)) {
+    const name = f.startsWith(SCRIPT_DIR) ? scriptRel(f) : rel(f);
     const text = fs.readFileSync(f, 'utf8');
     for (const m of text.matchAll(/partial\(\s*['"]([^'"]+)['"]/g)) {
       const target = normalize(m[1]);

--- a/themes/future/layout/_partial/post-list-icon.ejs
+++ b/themes/future/layout/_partial/post-list-icon.ejs
@@ -1,0 +1,7 @@
+<%# 行に添えるサムネの箱 (#3097)。記事の行（post-list-item）と、索引記事の
+    表（#2790）が同じ絵を使う。寸法は 72×48 で、これより小さくしない (#2777)。
+
+    同じ行の題と同じ行き先なので、タブ移動と読み上げからは外す (#2845)。
+    サムネの無い記事は何も出さない。行の左端をそろえる必要があるところだけ、
+    呼び出し側が同じ大きさの空き枠に差し替える -%>
+<% if (post.thumbnail) { %><a href="/<%= post.path %>" class="post-list-icon" tabindex="-1" aria-hidden="true"><img src="<%= post.thumbnail %>" alt="" width="72" height="48" loading="lazy"></a><% } %>

--- a/themes/future/layout/_partial/post-list-item.ejs
+++ b/themes/future/layout/_partial/post-list-item.ejs
@@ -1,0 +1,43 @@
+<%# 記事を1行で並べる部品 (#3097)。ランキング・関連記事・被参照記事・
+    一覧ページの「よく読まれている記事」が同じ形を持つ。
+
+    並びは 題 → NEW → (年月 / 反響)。読み手は「何の記事か」を見てから
+    「古くないか」「評判はどうか」を確かめるので、判断の順序に合わせる。
+
+    引数:
+      post       記事（path / title / lede / date / thumbnail を読む）
+      itemClass  li に付けるクラス
+      titleAttr  a の title 属性。省略時は lede
+      withThumb  題の左に小さいサムネを添える (#2230)
+      rankMark   {html, className} か null。行頭に出す順位の丸 (#2249)。
+                 何位がどの段か・数字を出すか記号にするかはランキング側の
+                 都合なので、ここは受け取った通りに包むだけにする (#2681)
+      isNew      NEW を出す (#2788)
+      snsCount   反響の数。0 のときは出さない（0と表示されると寂しく見える）
+
+    **行の中に改行を出さない。** .nav の中では題がブロックになるので、
+    要素の間に空白が入ると順位の丸と題の頭がずれる。そのため各行の末尾で
+    テンプレート側の改行を落としている -%>
+<%
+  const rank = typeof rankMark === 'undefined' ? null : rankMark;
+  const thumbed = typeof withThumb !== 'undefined' && withThumb;
+  const fresh = typeof isNew !== 'undefined' && isNew;
+  const sns = typeof snsCount === 'undefined' ? 0 : snsCount;
+  const attr = (typeof titleAttr === 'undefined' ? post.lede : titleAttr) || '';
+-%>
+<li class="<%= itemClass %><%= thumbed ? ' post-list-item-thumb' : '' %>"><% if (rank) { -%>
+<span class="post-list-rank<%= rank.className ? ' ' + rank.className : '' %>"><%- rank.html %></span><% } -%>
+<% if (thumbed) { -%>
+<%# サムネの無い記事は同じ大きさの空き枠に置き換えて、行の左端をそろえる -%>
+<%- partial('post-list-icon', {post: post}).trim() || '<span class="post-list-icon post-list-icon-empty"></span>' %><div class="post-list-body"><% } -%>
+<a href="/<%= post.path %>" title="<%= attr %>"><%= post.title %></a><% if (fresh) { -%>
+<span class="newitem">NEW</span><% } -%>
+<%# 日付は鮮度の目安なので年月まで (#2404)。日まで出すのは、日付が並びの
+    座標になる時系列リストと記事自身だけ -%>
+<span class="post-meta"><span class="post-meta-date"><%= post.date.format('YYYY.MM') %></span><% if (sns > 0) { -%>
+<%# ♡ だけ span で包むのは、記号は少し大きくしないと線が潰れる一方、
+    数字は日付と同じ大きさにそろえたいため (#2453) -%>
+<span class="snscount"><span class="snscount-icon">&#9825;</span><%= sns %></span><% } -%>
+</span><% if (thumbed) { -%>
+</div><% } -%>
+</li>

--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -249,12 +249,12 @@
       <div class="doctor-single">
         <section>
           <%- heading('ui-partials') %>
-          ※テンプレートで共通化されている部品と、それを使っている画面です。見本は <a href="/specials/gallery/">部品ギャラリー</a> にあります
+          ※テンプレートで共通化されている部品と、その呼び出し元です。テンプレートのほか、描画が重複する部品を呼ぶ helper (#3031) も数えます。見本は <a href="/specials/gallery/">部品ギャラリー</a> にあります
           <ul class="doctor-list">
             <% uiParts.rows.forEach(function(r){ %>
             <li>
               <code><%= r.name %></code>
-              <span class="doctor-note"><%= r.callers.length %>画面<% if (r.callers.length) { %>: <%= r.callers.join('、') %><% } %><% if (!r.shown && r.reason) { %>／見本なし: <%= r.reason %><% } %></span>
+              <span class="doctor-note"><%= r.callers.length %>件<% if (r.callers.length) { %>: <%= r.callers.join('、') %><% } %><% if (!r.shown && r.reason) { %>／見本なし: <%= r.reason %><% } %></span>
             </li>
             <% }) %>
           </ul>

--- a/themes/future/layout/gallery.ejs
+++ b/themes/future/layout/gallery.ejs
@@ -16,6 +16,9 @@
 <%
   const samples = ui_gallery_samples();
   const samplePost = samples.post;
+  // 順位の丸を2つ並べるので、2行目は別の記事にする。同じ記事が2度出ると
+  // 順位で何が変わるのかが読み取れない
+  const sampleSecondPost = samples.panelPosts.find(function(p){ return p.thumbnail && p.path !== samplePost.path; }) || samplePost;
   // 著者紹介は「_profile.yml に about があり投稿3本以上」でしか出ない (#2567)。
   // 条件を満たす記事でないと見本が空になる
   const authorPost = site.posts.sort('date', -1).toArray()
@@ -198,6 +201,32 @@
         <%- partial('_partial/tendency-panels', {kind: 'tag', items: recent_popular_tags(3).map(function(t){
               return {name: t.name, path: t.path, title: `${t.name} タグの記事へ`, note: `${t.count}本`};
             })}) %>
+      </div>
+      <div class="gallery-item">
+        <%- galleryName('components', 'sample-post-list-item', '記事の行') %>
+        <p class="specials-text">ランキング・関連記事・参照している記事など、記事を1行で並べるところに出ます。左に小さなサムネイル、題の下に年月と反応の数を置きます。順位の丸が付くのはランキングだけで、1位は数字を王冠に置き換えます。</p>
+        <%# 行の形は器で決まるので .nav の中に置く。外に出すと題が横に流れて
+            年月が次の行へ落ちない (#3057) %>
+        <ul class="nav featured-post-link">
+          <%- partial('_partial/post-list-item', {
+                post: samplePost, itemClass: 'featured-posts-item', withThumb: true, isNew: true,
+                snsCount: totalSNSCnt(samplePost.permalink),
+                rankMark: {html: partial('_partial/svg-icon', {icon: 'crown'}).trim() + '<span class="sr-only">1</span>', className: 'post-list-rank-first'},
+              }) %>
+          <%- partial('_partial/post-list-item', {
+                post: sampleSecondPost, itemClass: 'featured-posts-item', withThumb: true,
+                snsCount: totalSNSCnt(sampleSecondPost.permalink),
+                rankMark: {html: '2', className: 'post-list-rank-high'},
+              }) %>
+        </ul>
+        <div class="nav">
+          <ul class="related-post-link">
+            <%- partial('_partial/post-list-item', {
+                  post: samplePost, itemClass: 'related-posts-item', withThumb: true,
+                  snsCount: totalSNSCnt(samplePost.permalink),
+                }) %>
+          </ul>
+        </div>
       </div>
       <div class="gallery-item">
         <%- galleryName('components', 'sample-social-button', '共有ボタン') %>


### PR DESCRIPTION
## やったこと

ランキング・関連記事・被参照記事・一覧ページの「よく読まれている記事」の1行を組んでいた
`scripts/lib/post_list.js` の文字列生成を `_partial/post-list-item.ejs` に移しました。
`postListItem` は呼び出し元の `this` を受け取って `partial` を呼ぶだけの薄い関数になり、
JS の中に行の markup は残っていません。

- **`themes/future/layout/_partial/post-list-item.ejs`（新規）** — 順位の丸・サムネ（無ければ同じ大きさの空き枠）・
  題（`title` 属性）・NEW・年月・♡ を組む。受け取るのはデータだけ（`post` / `itemClass` /
  `titleAttr` / `withThumb` / `rankMark` / `isNew` / `snsCount`）。順位の丸の中身と段のクラスは
  これまでどおり呼び出し側が決める (#2681)
- **`themes/future/layout/_partial/post-list-icon.ejs`（新規）** — サムネの箱（`a.post-list-icon > img` 72×48）だけの部品
- **`scripts/lib/post_list.js`** — `snsLabel` / `newLabel` / `thumbIcon` を廃し、数（`getSNSCnt`）と
  判定（公開30日以内）だけを返す形に。`postListItem(ctx, post, itemClass, opts)` に
  引数を1つ足し、呼び出し元4つ（`ga4_pv.js` / `popular_posts.js` / `related_posts.js` /
  `reference_posts.js`）から `this` を渡す
- 判断の理由（#2404 年月まで / #2845 サムネはタブ順から外す / #2681 順位の中身は呼び出し側 /
  #2788 NEW / #2453 ♡ の大きさ）は EJS 側のコメントへ移動

### `thumbIcon`（索引記事の表の `{% thumb %}`）の扱い

**同じ partial を共有できたので寄せました。** タグプラグインには `this.partial` が無いので、
`hexo.theme.getView('_partial/post-list-icon.ejs').renderSync({ post })` で描いています。
サムネの箱の markup が partial と JS の2箇所に残らない形になりました。
出力は `hexo.post.render` で直接レンダリングして **before と1文字も違わない**ことを確認しています。

## before / after の突き合わせ

`hexo clean` の後に生成した before / after の `public/` から、`<li class="featured-posts-item…">` /
`related-posts-item` / `reference-posts-item` を全ページぶん抜き出して1行ずつ比べました。

| | before | after |
| --- | --- | --- |
| 生成 HTML | 2,936 ファイル | 2,936 ファイル |
| 行を含むページ | 2,020 | 2,021（+1 = ギャラリーの見本） |
| 行の総数 | 16,592 | 16,595（+3 = 見本の3行） |
| ページごとの行数の食い違い | — | 0ページ |
| **バイト一致した行** | — | **16,027** |
| 差分のあった行 | — | 565（457ページ・延べ54記事） |

**空白正規化なしのバイト比較で、差分は565行すべてが `title` 属性と題の文字参照だけ**でした
（`html.unescape` すると一致）。EJS の `<%= %>` が属性値を正しくエスケープするようになったためです。
空白だけの差分は0件です。

| 文字 | 行数 | 記事数 |
| --- | --- | --- |
| `&` → `&amp;` | 235 | 25 |
| `"` → `&#34;` | 126 | 9 |
| `'` → `&#39;` | 129 | 14 |
| `<` → `&lt;` | 23 | 2 |
| `>` → `&gt;` | 75 | 6 |

このうち **93行（5記事）は before の `title` 属性が壊れていました。** lede の中の生の `"` が
属性を途中で閉じてしまい、残りが属性名として解釈される状態です。

```
before  title="…に書きましたが、"ブログ連載"という企画が…"
after   title="…に書きましたが、&#34;ブログ連載&#34;という企画が…"
```

対象は `/articles/20200908/` `/articles/20210513b/` `/articles/20220722a/` `/articles/20230127a/`
`/articles/20250616a/` を指す行です。

## ギャラリーと台帳

- `/specials/gallery/#sample-post-list-item` に「記事の行」を追加。実物に存在する組だけ出しています
  （順位あり＋サムネあり＝ランキング2行、順位なし＋サムネあり＝関連記事1行）。
  題と日付の並びが器で決まる (#3057) ので、実物と同じく `.nav` の中に置いています
- `/doctor/` の台帳に `post-list-item`（見本あり）と `post-list-icon`（見本なし・理由あり）が並びます。
  「見本も理由も無い」の警告は **3件のまま**（`chart-tooltip-count` / `sidebar-index-series` /
  `sidebar-index-without`）で増えていません
- 台帳が `scripts/**/*.js` も舐めるようにしました。helper から `this.partial(…)` を呼ぶ形 (#3031) を
  数えないと、helper からしか呼ばれない部品が「呼び出し元が無い」に落ちます。
  ラベルは「N画面」から「N件」にしています

## 検証

- axe / キーボード走査（`/` `/articles/20260727a/` `/categories/Programming/` `/specials/gallery/` × 375 / 1280）で
  新しい所見はありません。出るのはパンくずのヒットエリア・ヘッダーのタブ停止数・記事の空セルヘッダなど、
  この変更の前からあるものだけです
- ホームのランキング・記事末の関連記事・ギャラリーの見本を 375 / 1280 で目視確認
- `prettier --check` / `textlint`（変更した `.ejs` 4本）/ `make lint-css` はいずれも通っています

### 検証の注記（この PR の範囲外）

`{% thumb %}` は **db.json の無い cold build では何も出しません**（`thumb: 記事 … が見つかりません` の
警告が39件出ます）。before / after のどちらの生成物にも索引の表のサムネが1つも無く、この PR の前からの
挙動です。CI の `deploy.yml` も db.json をキャッシュしないので本番も同じはずですが、原因も直し方も
この issue とは別なので触っていません。

Closes #3097

🤖 Generated with [Claude Code](https://claude.com/claude-code)
