### PR TITLE
/tags/ の「直近」「累計」を統計の枠から群の見出しにする (#3100)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -3592,6 +3592,11 @@ ul.tag-list {
 .group-heading + .article-list {
   margin-top: 8px;
 }
+/* チップは自分の上マージンしか持たないので、そのままだと見出しとの間が
+   チップどうしの行間より狭くなり、見出しが1行目に貼り付いて見える */
+.group-heading + .blog-tags {
+  margin-top: 4px;
+}
 /* /categories/ の一覧。1件は 名前＋統計 / 説明 / タグ の3段構成。
    17件を縦に積むと長いので、幅があるときは2列にする。
    auto-fit + minmax で、狭い幅では自動的に1列へ落ちる */
@@ -5362,17 +5367,6 @@ p.more-link {
   text-decoration: underline;
   background-color: transparent;
 }
-/* /tags/ の「人気のタグ」2列パネル（直近1年/累計 #2358）。
-   summary-panel の枠と小ラベルを継ぎ、チップが収まるよう下側だけ広げる。
-   row の負のトップマージンはカラム自身のガターと相殺するため対策不要 */
-.tag-pool-panel {
-  padding-bottom: 12px;
-}
-/* 既定の 2px はタイル数値用の詰め。チップ相手だとラベルが貼り付いて見える */
-.tag-pool-panel .summary-panel-label {
-  margin-bottom: 10px;
-}
-
 /* サムネの無い連載の空き枠。.panel-thumb img と同じ寸法 */
 .panel-thumb-empty {
   display: block;

--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -14,36 +14,27 @@
           説明的にしていたが、#2877 でタグだけになった） %>
       <%- partial('_partial/section-heading', {id: 'populartags', text: '人気のタグ'}) %>
       <%# 「直近」（PV を経過年ペナルティで割った順 #3028）と
-          「累計」（全期間のシェア効率）を2列で並べて両方見せる (#2358)。
+          「累計」（全期間のシェア効率）を h3 で束ねて両方見せる (#2358)。
           タブ切り替えは上のグラフのタブと見た目が重複するためやめた。
-          枠と小ラベルは詳細ページの統計パネル（#2276）と同じ部品。
-          並びは鮮度が主目的のセクションなので「いま」を左にする。
-          **ラベルは時間の向きだけを名乗る。** 左は #3028 で窓を持たなくなったので
+          並びは鮮度が主目的のセクションなので「いま」を先にする。
+          **横に2列で並べない。** チップの束は行ごとに右端が変わるので、
+          縦にそろった切れ目ができず、束の境目が読めない。
+          **ラベルは時間の向きだけを名乗る。** 「直近」は #3028 で窓を持たなくなったので
           「直近1年」とは書けないが、経過年で割るぶん新しい記事が効くという向きは
           変わらないので「直近」。物差しそのもの（PV / シェア効率）は
           チップの title が持つ。ここは「人気のタグ」の節なので、
           ラベルに「シェア」と書くとタグ自体がシェアされたように読める %>
-      <div class="row g-4 tag-pool-panels">
-        <div class="col-12 col-md-6">
-          <section class="summary-panel tag-pool-panel h-100">
-            <span class="summary-panel-label">直近</span>
-            <div class="blog-tags">
-              <%- partial('_widget/tag.ejs', {limit: 30}) %>
-            </div>
-          </section>
-        </div>
-        <div class="col-12 col-md-6">
-          <section class="summary-panel tag-pool-panel h-100">
-            <span class="summary-panel-label">累計</span>
-            <div class="blog-tags">
-              <div class="widget">
-                <%- partial('_partial/tag-chips', {items: ranking_tags().map(function(t){
-                      return {name: t.name, path: t.path, count: t.count,
-                              title: `${t.name} の記事 ${t.count}本（総シェア ${t.shareCount}）`};
-                    })}) %>
-              </div>
-            </div>
-          </section>
+      <%- partial('_partial/group-heading', {id: 'tags-recent', text: '直近'}) %>
+      <div class="blog-tags">
+        <%- partial('_widget/tag.ejs', {limit: 30}) %>
+      </div>
+      <%- partial('_partial/group-heading', {id: 'tags-total', text: '累計'}) %>
+      <div class="blog-tags">
+        <div class="widget">
+          <%- partial('_partial/tag-chips', {items: ranking_tags().map(function(t){
+                return {name: t.name, path: t.path, count: t.count,
+                        title: `${t.name} の記事 ${t.count}本（総シェア ${t.shareCount}）`};
+              })}) %>
         </div>
       </div>
       <%# 「今年初出」ではなく件数固定の新着。トップページの「新着記事」と同じ語彙 %>


### PR DESCRIPTION
## やったこと

`/tags/` の「人気のタグ」節で、「直近」「累計」の2つの箱が統計の枠のクラス（`summary-panel` / `summary-panel-label` ＋ 打ち消しの `.tag-pool-panel`）を借りていた。#3088 で `.summary-panel` が `_partial/sidebar-summary-panel`（統計の枠）自身のクラスになったので、統計ではないもの（チップの束）への流用をやめる。

- 2箱を **`_partial/group-heading` の h3 ＋ チップ**に組み替えた（#3081 で `/series/` の年の束ねに当てた判断を、同じ状況に当てる）
- ラベルの文言（「直近」「累計」）と並び（直近が先）は変えていない
- h3 の `id` は `tags-recent` / `tags-total`。`meta` は渡さない（件数は各チップの右肩が持っている）
- `_widget/tag.ejs` と `ranking_tags()` は触っていない。入れ物だけの変更

見出しの階層は h1「タグ一覧」→ h2「人気のタグ」→ h3「直近」「累計」で、`heading-order` は通っている。

## 2列か縦積みか → **縦積み**

枠を外した状態の2列（`col-12 col-md-6`）と縦積みを、生成後の HTML から作った同条件のページで 1280px を見比べて決めた。

**2列を採らない理由**（スクリーンショットで見たもの）:

- チップの束は行ごとに右端が変わるので、**左右の切れ目に縦にそろった線ができない**。実測で左の束の右端と右の束の左端の距離は行ごとに 47px 〜 137px（3倍近くばらつく）。枠があったときはこの境目を枠線が引いていた
- 左右に**同じ名前のチップが重複して出る**（設計・ガイドライン・ドキュメント・技術選定・DockerCompose）。切れ目が読めないまま同じ名前が並ぶと、1つの束の中の重複に見える
- 見出しが列の頭に立つとはいえ、h3「累計」がページの中ほど（x≈460px）から始まる。このページの他の見出しはすべて本文列の左端から始まるので、そこだけ位置が変わる
- 2列だとチップの束を `row.g-4` の中に入れることになり、row の負のトップマージンを h3 のために打ち消す CSS が要る。**CSS を1つ消すために別の CSS を足すことになる**

**縦積みの利点**: 同じページの下にある「新着タグ」「すべてのタグ」も本文列いっぱいのチップの束なので、節をまたいで形がそろう。h3 の 32px と h2 の 48px で、群の切れ目より節の切れ目のほうが広いことが空きだけで読める。

縦の長さは 1280px で 472px（2列）→ 532px（縦積み）で、60px 増えるだけだった。375px では列が積まれるので両者ほぼ同じ（896px / 884px）。

## before / after の確認

- **チップの中身は同一**。生成後の `/tags/index.html` から `tag-list-link` を全部抜き出して突き合わせ、**764件が href・title・表示文字列とも完全一致**（`identical: True`）
- `summary-panel` の出現は 5 → 1。残る1つはサイドバーの統計の枠で、これが本来の持ち主
- `tag-pool-panel` 0、`summary-panel-label` 0、`group-heading` 2
- スクリーンショット（375 / 1280）で、h2「人気のタグ」の下に h3 が2つ並ぶ階層・チップの束の切れ目・下の「新着タグ」との区切りを確認した

## 消した CSS

```styl
.tag-pool-panel { padding-bottom: 12px; }
.tag-pool-panel .summary-panel-label { margin-bottom: 10px; }
```

代わりに足したのは、`group-heading` の既存の隣接規則（`+ .series-panels` / `+ .article-list`）に倣った1つだけ。

```styl
.group-heading + .blog-tags { margin-top: 4px; }
```

チップは自分の上マージンしか持たないので、そのままだと見出しとチップの間（4px）がチップどうしの行間（11px）より狭くなり、見出しが1行目に貼り付いて見えていた。4px は `space-step` の倍数。

## 検査

- `node .claude/skills/site-audit/audit.mjs --base http://localhost:4004 /tags/ --widths 375,768,1280` … **エラー 0**。警告2件は本文までのタブ停止数（ヘッダーの検索ヒントのタグ10件・ナビ）で、この変更とは無関係の既存のもの。`heading-order` の指摘は無し
- `make lint-css` … 解決漏れの識別子なし／ベンダー接頭辞の同居なし／`font-size` は段に収まる
- textlint（`.ejs`）… 指摘なし

Closes #3100

🤖 Generated with [Claude Code](https://claude.com/claude-code)
