### PR TITLE
/doctor の「投稿が途切れている著者」を「リマインドしたい著者」にする

### DIFF
--- a/themes/future/layout/doctor.ejs
+++ b/themes/future/layout/doctor.ejs
@@ -22,7 +22,7 @@
       {id: 'ontology-suggestions', text: 'オントロジーへの追加提案（親子の候補）', label: '親子の候補', count: ontoSuggest.suggestions.length},
       {id: 'ontology', text: 'タグの親子関係（オントロジー）', label: 'オントロジー登録', count: onto.nodeCount},
       {id: 'text-suggestions', text: '本文に何度も出てくるのにタグが付いていない記事', label: 'タグ付け漏れ候補', count: textSuggest.posts.length},
-      {id: 'dormant', text: '投稿が途切れている著者', label: '投稿が途切れた著者', count: dormant.recent.length},
+      {id: 'dormant', text: 'リマインドしたい著者', label: 'リマインドしたい著者', count: dormant.recent.length},
       {id: 'ui-partials', text: '共通部品の台帳', label: '共通部品', count: uiParts.rows.length},
     ];
     const heading = (id) => partial('_partial/section-heading', SECTIONS.find(s => s.id === id));
@@ -183,7 +183,7 @@
         <% }) %>
       </div>
       <ul class="doctor-list">
-        <%# 投稿が途切れた著者の列と同じ扱い。数十件が横に流れるので、
+        <%# リマインドしたい著者の列と同じ扱い。数十件が横に流れるので、
             区切りの「、」ではなく行間と余白で分ける (#2418) %>
         <li class="doctor-inline-row">
           <span class="doctor-note">親も子も無い根タグ（<%= onto.standalone.length %>件）</span>
@@ -218,7 +218,6 @@
           声かけは「まず昨年まで書いていた人、駄目なら一昨年の人」の順に進めるので、
           左に昨年・右に一昨年を並べて、そのまま上から当たれるようにする %>
       <%- heading('dormant') %>
-      ※今年まだ投稿が無い著者。<code>連続N年</code> は続けて書いていた最長の年数で、<%= dormant.streakYears %>年以上のときだけ出します
       <% if (dormant.recent.length) { %>
       <div class="doctor-cols">
         <% [thisYear - 1, thisYear - 2].forEach(function(y){ %>


### PR DESCRIPTION
## 概要

/doctor の節名「投稿が途切れている著者」は、名指しされた著者に対してセンシティブに読める。運営の用途（声かけ・リマインド）をそのまま名乗る「リマインドしたい著者」に改名する。

あわせて、憶測を生みうる注釈「※今年まだ投稿が無い著者。連続N年 は続けて書いていた最長の年数で、3年以上のときだけ出します」を外す。

## 変更

- `themes/future/layout/doctor.ejs` の SECTIONS（件数タイル・目次・見出しの3箇所が同じ定義から出る）と注釈行のみ。抽出ロジック（`scripts/doctor.js`）は変えない

## 確認

- 生成した `public/doctor/index.html` で新名称が6箇所（タイル・モバイル目次・本文見出し・サイドバー目次）に出ること、旧名称・注釈が0件になったこと、年別の列と連続N年の印がそのまま描かれることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)