### PR TITLE
/categories・/tags・/authors のサイドバーに目次を付ける (#3116)

### DIFF
--- a/themes/future/layout/authors.ejs
+++ b/themes/future/layout/authors.ejs
@@ -72,6 +72,12 @@
     </main>
     <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar-index-authors') %>
+      <%# 目次は h2 の2節だけ。年タブは見出しではないので入れない。
+          /series/ と同じ specialsToc の形 (#3116) %>
+      <%- partial('_partial/sidebar', {specialsToc: [
+            {id: 'awards', text: 'Best Blogger of the Year'},
+            {id: 'authors', text: 'すべての著者'},
+          ]}) %>
     </aside>
   </div>
 </div>

--- a/themes/future/layout/categories.ejs
+++ b/themes/future/layout/categories.ejs
@@ -18,7 +18,8 @@
     ※各カテゴリの概要と規模、よく使われるタグを表示します。
     <%# 群で区切る (#2908)。群と並びは category_group_index() が1箇所で持ち、
         ヘッダーのドロップダウン・サイドバーと同じ群・同じ並びになる %>
-    <% category_group_index().forEach(function(g, gi, groups){ %>
+    <% const groups = category_group_index(); %>
+    <% groups.forEach(function(g, gi, groups){ %>
     <%# id は群の名前から。記事の見出しと同じく日本語のまま持つ %>
     <%- partial('_partial/group-heading', {id: 'group-' + g.name, text: g.name}) %>
     <ul class="category-index<%= gi === groups.length - 1 ? ' footer-gap' : '' %>">
@@ -54,6 +55,12 @@
     </main>
     <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar-index-categories') %>
+      <%# 目次は h2 → h3（群）の入れ子。/series/ と同じ specialsToc の形で持ち、
+          統計はページ自身の数字なので目次より上 (#2911 / #3116) %>
+      <%- partial('_partial/sidebar', {specialsToc: [{
+            id: 'categories', text: 'すべてのカテゴリ',
+            children: groups.map(function(g){ return {id: 'group-' + g.name, text: g.name}; }),
+          }]}) %>
     </aside>
   </div>
 </div>

--- a/themes/future/layout/tags.ejs
+++ b/themes/future/layout/tags.ejs
@@ -67,6 +67,16 @@
     </main>
     <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar-index-tags') %>
+      <%# 目次は h2 → h3 の入れ子。頭文字への移動は本文の tag-index-jump が
+          担うので子には入れない。/series/ と同じ specialsToc の形 (#3116) %>
+      <%- partial('_partial/sidebar', {specialsToc: [
+            {id: 'populartags', text: '人気のタグ', children: [
+              {id: 'tags-recent', text: '直近'},
+              {id: 'tags-total', text: '累計'},
+            ]},
+            {id: 'newtags', text: '新着タグ'},
+            {id: 'alltags', text: 'すべてのタグ'},
+          ]}) %>
     </aside>
   </div>
 </div>


### PR DESCRIPTION
## 概要

`/series/` のサイドバーにある目次（#3082 で導入）を、同じ立場の一覧ページ3枚に広げる。

Closes #3116

## 置き場所

issue の「サイドバーの一番下か？」は `/series/` の前例どおり: **統計の下＝サイドバーの一番下**。統計はそのページ自身の数字なので目次より上に置く（#2911 の規則のまま）。部品も `/series/` と同じ `specialsToc` → `_partial/sidebar` で、読んでいる節に印が付くスクロール追従（#2909）もそのまま効く。

## 目次の中身（本文の h2 → h3 に合わせる）

| ページ | h2 | h3（子） |
| --- | --- | --- |
| `/categories/` | すべてのカテゴリ | 群5つ（開発 / 基盤 / AI / セキュリティ / ビジネス） |
| `/tags/` | 人気のタグ / 新着タグ / すべてのタグ | 直近 / 累計（#3114 で h3 になった） |
| `/authors/` | Best Blogger of the Year / すべての著者 | なし（年タブは見出しではないので入れない） |

- `/tags/` の頭文字（A〜Z・五十音）は子に入れない。本文の `tag-index-jump` が既に担っていて、約30行をサイドバーに重ねると目次が頭文字表になる
- モバイル（1024px 以下）では `/series/` と同じく出ない（サイドバーの目次は落ちた位置では役に立たないため隠す #2452 の既存規則。`.toc-mobile` を足すかは範囲外）

## 検証

生成 HTML をパースして確認済み:

- 3ページとも `toc-section` が1つ、全リンクのアンカー（`#group-開発` 等の日本語 id 含む）が本文の `id` に解決する
- サイドバー内の順序が 統計 → 目次
- 軸の枠（人気のカテゴリ等）の混入なし（`specialsToc` の `isTocOnly` が抑止）
- `/series/` の既存目次は無変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)