### PR TITLE
We're hiring のラベルが訪問済みで紫になる漏れを打ち消す (#3113)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2113,6 +2113,12 @@ body {
   color: var(--ink-strong);
   text-decoration: none;
 }
+/* visited も打ち消す (#3113)。節が article-entry を持つため本文の
+   .article-entry a:visited（紫）がラベルに届くが、紫は地の文の参照リンクの
+   語彙で、カードのラベルは .panel-title と同じく常時 ink-strong (#2699) */
+.career-counseling .article-card a:visited {
+  color: var(--ink-strong);
+}
 /* 絞り込みを解く導線を持つ、見出しの直下の注記。地の文なので本文と同じ大きさで、
    1.2em は .article-entry 配下にしか効かないのでここで明示する。
    対になる「◯◯以外の記事へ」（カテゴリページ側）は .more-link に寄せた (#2900)。


### PR DESCRIPTION
## やったこと

We're hiring のラベルだけが訪問済みで紫（`link-visited`）になっていたのを、常時 `ink-strong` に打ち消しました（PR #3119 のフォローアップ。1ルール6行の追加のみ）。

## 判断の理由

- **あえてではなく漏れ。** CSS コメントに残る意図は「カードの中のタイトルなので `.panel-title` と同じ `ink-strong`」（#2699）で、連載・特設パネル・一覧カード・関連記事の行のタイトルはどれも visited で変わらない。変わるのはこのラベルだけだった
- **原因**: 節が導入文の体裁のために `article-entry` クラスを持ち、本文用の `.article-entry a:visited`（詳細度 0,2,1）が `.hiring-card-label`（0,1,0）に勝つ。hover / focus は既存の打ち消し（0,3,1）で戻るため、「静止だと紫・触ると黒」という中途半端な状態だった
- 紫は地の文の参照リンクの語彙（「青は本文の色。レイアウトの部品には使わない」#2893 と同じ線）なので、カードのラベルには合わない

## 検証

- `make css` + `make lint-css` 通過
- 生成 CSS に `.career-counseling .article-card a:visited { color: var(--ink-strong) }`（0,3,1）が出力されていることを確認。`:visited` に書けるのは色系のプロパティだけという制約の内側

🤖 Generated with [Claude Code](https://claude.com/claude-code)
