### PR TITLE
{% thumb %} を DB ではなくソースから引き、cold build で出るようにする (#3121)

### DIFF
--- a/scripts/thumb.js
+++ b/scripts/thumb.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
+const { parse } = require('hexo-front-matter');
+
 /**
  * 索引記事の表にサムネイルを出すタグ (#2790)。日付のセルに入れ、日付の上に積む。
  *
@@ -15,18 +19,43 @@
  * リンクの文字列も半数（682件中344件）が実タイトルと違い、連載名を落とした
  * 短縮テーマ名になっている（「go mod tidy」／「Go 1.27のgo mod tidyの更新点」）。
  * どちらも series から引ける情報ではないので、機械が埋めるのは絵だけにする。
- *
- * 本文の描画は before_generate フィルタ（hexo 本体の render_post）で走るため、
- * この時点で全記事が DB に入っている。
  */
+
+// タグはレンダリングの途中で走るので、cold build（db.json 無し＝本番のデプロイは
+// 毎回これ）では、その時点でまだ DB に入っていない記事を引けない。読み込み順に
+// 左右されないよう、DB ではなくソースのフロントマターから引く (#3121)。
+// scripts/ はホットリロードされないので、対応表もプロセスの生存中は作り直さない。
+let index = null;
+
+function postIndex() {
+  if (index) return index;
+  index = new Map();
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      // 記事IDはファイル名の先頭。permalink の :year:month:day:postid と同じ形で、
+      // postid を持たない古い記事は日付だけになる
+      const id = /^(\d{8}[a-z]*)[-_]/.exec(entry.name);
+      if (!id || !entry.name.endsWith('.md')) continue;
+      const data = parse(fs.readFileSync(full, 'utf8'));
+      index.set(id[1], {
+        path: `articles/${id[1]}/`,
+        thumbnail: data.thumbnail || '',
+      });
+    }
+  };
+  walk(path.join(hexo.source_dir, '_posts'));
+  return index;
+}
 
 hexo.extend.tag.register('thumb', function (args) {
   const id = (args[0] || '').trim();
   if (!id) return '';
-  const post = hexo.locals
-    .get('posts')
-    .toArray()
-    .find((p) => p.path === `articles/${id}/`);
+  const post = postIndex().get(id);
   if (!post) {
     hexo.log.warn(`thumb: 記事 ${id} が見つかりません`);
     return '';


### PR DESCRIPTION
## 原因

`{% thumb %}`（#2790）はタグの実行時に `hexo.locals.get('posts')` から記事を探していた。タグは本文のレンダリングの途中で走るので、cold build（`db.json` 無し＝本番のデプロイは毎回これ）では、その時点でまだ DB に入っていない記事——索引記事より後に読み込まれる記事——を引けない。cold build の警告39件（`thumb: 記事 20260128a が見つかりません` 等）はすべてこのパターンで、**#2790 の導入以来、本番では一度も絵が出ていなかった**。手元の `hexo s` は前回ビルドの `db.json` で動くため気づけなかった。ソースのコメント「本文の描画は before_generate フィルタで走るため、この時点で全記事が DB に入っている」も事実と違っていた。

## 直し方

`scripts/thumb.js` で DB を引くのをやめ、`source/_posts` のフロントマターから `記事ID → { path, thumbnail }` の対応表を最初の呼び出し時に1度だけ作って引く。読み込み順に左右されないので cold / warm のどちらでも同じ結果になる。

- 記事ID はファイル名の先頭（`^(\d{8}[a-z]*)[-_]`）。permalink の `:year:month:day:postid` と同じ形で、`postid` を持たない古い記事（412本）は日付だけになる。全1,481本が衝突なしで対応表に載る
- `thumbnail` を持たない記事は今までどおり何も出さない
- 対応表に無い ID は今までどおり `hexo.log.warn` して空文字（打ち間違いに気づくため）
- 絵の描画は今までどおり `_partial/post-list-icon.ejs` を `renderSync`（#3111 の形）。partial は `post.path` と `post.thumbnail` しか読まないので plain object を渡す。partial 側は触っていない
- 対応表は hexo プロセスの生存中は作り直さない。`scripts/` 自体がホットリロードされないので同じ制約

### フロントマターの読み方

**hexo が同梱する `hexo-front-matter` の `parse` を require できたのでそちらを採った**（正規表現でのフォールバックは不要だった）。依存は増えていない。1,481本の読み込みは実測 90ms。

## 検証

同じ worktree で修正前後それぞれ cold build（`db.json` / `public` 無しから）して生成物を比べた。

| | before | after |
| --- | --- | --- |
| `thumb:` の警告 | 39 | **0** |
| 表の中の `post-list-icon` | 0 | **39** |
| `post-list-icon` の総数 | 15,435 | 15,474（+39） |

- 表の中の39箇所は `{% thumb %}` の総数と一致する。索引記事ごとの内訳もソースのタグ数とそろっている（20260421a 9／20260728a 8／20260518a 7／20260127a 6／20260630a 4／20260615a 3／20260827a 2）
- `src` はフロントマターの `thumbnail` と**全39件で一致**（生成物の `src` とソースの `thumbnail:` を突き合わせて差分0件。39件とも重複のない記事ID）
- 表の外の行は変わっていない。`post-list-item-thumb` 16,595／`post-list-body` 16,595／`post-list-icon-empty` 1,160 が before / after で同値で、増分は表の39箇所ちょうど

`/articles/20260127a/` と `/articles/20260421a/` をスクリーンショットして、日付のセルに 72×48 の絵が日付の上に積まれていることを確認した。SKIP 行・未公開行には絵が出ない。なお `/articles/20251031a/`（秋のブログ週間2025）はソースに `{% thumb %}` を1つも持たないので、この修正の前後で変わらない。

`node .claude/skills/site-audit/audit.mjs --base http://localhost:4004 /articles/20260127a/ --widths 375,1280` で新しい所見なし（`width` / `height` は partial が持っている）。`npx prettier --check "scripts/**/*.js" "*.mjs"` / `make lint-css` ともに通過。

Closes #3121

🤖 Generated with [Claude Code](https://claude.com/claude-code)
