### PR TITLE
Markdown の特設ページにもフッター前の 56px を持たせる (#3132)

### DIFF
--- a/themes/future/layout/page.ejs
+++ b/themes/future/layout/page.ejs
@@ -12,7 +12,8 @@
   <% const tocHtml = page_toc(page.content); %>
   <div class="row">
     <main id="main" tabindex="-1" class="col-md-9 blog-posts">
-      <article class="article blog-item">
+      <%# 本文がページの最後の要素なので footer-gap でフッター前の間隔を持つ %>
+      <article class="article blog-item footer-gap">
         <div class="article-inner">
           <%# 1024px 以下ではサイドバーの目次が本文の下に落ちて役に立たないので、
               記事と同じく本文の直前に畳んだ目次を出す (#2452) %>


### PR DESCRIPTION
## 16px の出どころ

`page.ejs` は本文の器（`main > article.article.blog-item`）に `footer-gap` を持っていなかった。フッターの前に残っていたのは、本文の最後のブロック（段落・箇条書き）自身の `margin-bottom: 1rem`（bootstrap-subset の `p` / `ul` 既定 = 16px）だけ。

`main.col-md-9` は `.row`（`display: flex`）のフレックスアイテムなので新しい BFC を作り、中の子要素の margin が外へ抜けない。そのため 16px が `main` の高さに含まれたまま、そこにフッターが接していた。

## 付けた場所と理由

`main` の直下＝`<article class="article blog-item">` に `footer-gap` を足した。EJS の特設ページ（`gallery.ejs` / `guidelines.ejs` / `httf.ejs` ほか）が `main` 直下の器に `footer-gap` を置いているのと同じ位置で、`_partial/archive-all.ejs` の「アーカイブページの最後の要素なので footer-gap でフッター前の間隔を持つ」と同じ流儀。

```diff
-      <article class="article blog-item">
+      <%# 本文がページの最後の要素なので footer-gap でフッター前の間隔を持つ %>
+      <article class="article blog-item footer-gap">
```

**16 + 56 = 72px にはならない。** `article` / `.article-inner` / `.article-entry` はいずれも padding も border も持たない（コンパイル後の `site.css` に `.article-inner` のルールは1つも無く、`.article-entry` にも padding / border の宣言が無い）ので、最後のブロックの 16px は `article` の 56px と margin collapse して 56px になる。実測でも 3枚とも増分がちょうど +40px（= 56 − 16）で、足し算にはなっていない。

CSS は触っていない（`footer-gap` は既存の共通クラス）。

## before / after

幅1280、本文の最終可視要素の下端 → フッター上端。issue と同じ走査（レイアウト用の wrapper と、閉じた `<details>` の中身は数えない）。

| ページ | before | after |
| --- | --- | --- |
| `/specials/` | 16px | **56px** |
| `/specials/markdown/` | 18.8px[^1] | **58.8px**[^1] |
| `/specials/styleguide/` | 16px | **56px** |
| `/`（対照） | 56px | 56px |
| `/specials/gallery/`（対照） | 56px | 56px |
| `/categories/Programming/`（対照） | 56px | 56px |
| `/articles/20260727a/`（対照） | 0px | 0px |

[^1]: 記法ガイドだけ最終要素が脚注の戻りリンク（インラインの `span`）で、行ボックスより 2.8px 低い箱を持つ。ブロックとしての間隔は他の2枚と同じ 56px（増分が 3枚とも +40px でそろう）。

対照4枚は動いていない。記事ページは全幅の `article-appendix` がフッターに接する意図どおり 0px のまま。

3枚のフッター際のスクリーンショットも before / after で撮り、ネイビーの帯が本文に貼り付いていた状態が解消して `/specials/gallery/` と同じ空きになることを目で確認した。

Closes #3132

🤖 Generated with [Claude Code](https://claude.com/claude-code)
