### PR TITLE
Tech Cast の埋め込みの角丸を箱の段（8px）に寄せる (#3127)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -2566,11 +2566,11 @@ article a {
 }
 
 /* 特設ページの Spotify プレイヤー (#2854)。iframe は既定でインラインなので、
-   ブロックにしないと前後に行間ぶんの隙間が入る。角丸は Spotify が
-   埋め込みコードで案内している見え方 */
+   ブロックにしないと前後に行間ぶんの隙間が入る。角丸は Spotify の案内（12px）
+   ではなく箱の段に乗せる。中間の段階は置かない (#3127) */
 .podcast-embed {
   display: block;
-  border-radius: 12px;
+  border-radius: card-radius;
 }
 
 /* ワンライナーの折り返し */


### PR DESCRIPTION
## やったこと

`.podcast-embed` の `border-radius: 12px` を `card-radius`（8px）に。角丸の段（4 / 8 / 999px）の外にあった唯一のサイト側の値（issue の全数調査どおり）。

コメントの「Spotify が案内している見え方」は 12px の根拠だったので、「案内ではなく箱の段に乗せる」に書き換えた。

## 検証

コンパイル後の site.css で `.podcast-embed { border-radius: 8px }` を確認。`make lint-css` 通過。見た目は http://localhost:4005 で確認可（別途起動）

Closes #3127

🤖 Generated with [Claude Code](https://claude.com/claude-code)