### PR TITLE
deploy.yml のジョブに timeout-minutes を付ける (#3136)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,8 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    # 実績は3〜4分。既定の360分だと、固まった1本が concurrency の列を塞ぎ続ける (#3136)
+    timeout-minutes: 20
     env:
       TZ: Asia/Tokyo
     steps:
@@ -75,6 +77,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: build
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## やったこと

build ジョブに `timeout-minutes: 20`（実績3〜4分）、deploy ジョブに `timeout-minutes: 10`（実績1分未満）。既定の360分だと固まった1本が concurrency の列を塞ぎ続ける。

## 経緯

2026-08-31 に run 33346068211 の「Build with hexo」が約2時間 hang し、後続5本が cancelled・最新1本が pending のままサイトが2時間更新されなかった（手動 cancel で復旧）。YAML は parse 検証済み。

Closes #3136

🤖 Generated with [Claude Code](https://claude.com/claude-code)