### PR TITLE
円の角丸を 50% から 999px にそろえる

### DIFF
--- a/themes/future/css-src/_variables.styl
+++ b/themes/future/css-src/_variables.styl
@@ -284,7 +284,7 @@ sidebar = hexo-config("sidebar")
 //
 // 角丸は3段だけ: 小物（チップ・サムネイル・操作部品）= radius-small、
 // 箱（カード・コードブロック・note・details）= card-radius、
-// ピル = 999px・円 = 50%。中間の段（3/5/6/10px）は置かない。
+// ピル・円 = 999px（円も同じ値。#3126）。中間の段（3/5/6/10px）は置かない。
 // 段が増えると「どれを使うか」の判断ができなくなる（ink の3段と同じ理屈 #2534）
 card-radius = 8px
 radius-small = 4px

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1144,7 +1144,7 @@ Footer
   /* Lighthouse の target-size（最低24px）を満たす段。記事のシェアボタンと同じ */
   width: 34px;
   height: 34px;
-  border-radius: 50%;
+  border-radius: 999px;
   background-color: var(--navy-raised);
   color: var(--on-dark);
   text-decoration: none;
@@ -2350,7 +2350,7 @@ ul.social-button li {
   padding: 0;
   color: var(--brand-navy);
   border: 1px solid var(--rule-base);
-  border-radius: 50%;
+  border-radius: 999px;
   box-sizing: border-box;
   text-decoration: none;
   transition: background-color hover-speed ease, border-color hover-speed ease,
@@ -2452,7 +2452,7 @@ button.share-btn {
   width: 28px;
   height: 28px;
   padding: 0;
-  border-radius: 50%;
+  border-radius: 999px;
   text-decoration: none;
 }
 .icon-link:hover,
@@ -3697,7 +3697,7 @@ ul.tag-list {
   justify-content: center;
   width: 48px;
   height: 48px;
-  border-radius: 50%;
+  border-radius: 999px;
   background: var(--brand-navy);
   color: var(--on-dark-strong);
   font-size: text-title;
@@ -4003,7 +4003,7 @@ a.series-nav-item:hover .series-nav-item-title {
   height: 26px;
   /* 行の gap（10px）だけだとサムネに貼り付いて見えるので、順位の側で足す */
   margin-right: 6px;
-  border-radius: 50%;
+  border-radius: 999px;
   /* 地は最下段（4位以下）の色。塗る段はクラスで上書きする */
   background: var(--surface-mute);
   /* この地の上で 5.34 で AA。ink の3段のうち ink-faint まで薄くすると


### PR DESCRIPTION
## 背景

スタイルガイドは角丸を3段（小さな部品 4px / 箱 8px / ピル・円 999px）と定めているが、円の実装が `999px` と `50%` の2通りに割れていた。いずれも正方形の箱なので描画結果は同一で、見た目は変わらないが「角丸は3段だけ」という規則を検証すると偽になっていた。

## やったこと

`themes/future/css-src/theme-styles.styl` の5セレクタを `border-radius: 999px` に統一した（実測で `50%` はこの5箇所のみ。issue記載の数と一致）。

- `.footer-icon`
- `.share-btn`
- `.icon-link`
- `.author-box-initial`
- `.post-list-rank`

あわせて `themes/future/css-src/_variables.styl` の角丸トークンの説明コメント（「ピル = 999px・円 = 50%」）も、実装と矛盾しないよう「ピル・円 = 999px」に直した。

角丸のトークン（`radius-small` / `card-radius`）はどちらも px 固定値で、ピル・円用の変数は無かったため、既存の9箇所と同じ `999px` の直書きに合わせた。

## 等価確認

変更前後で `make css` を実行し `public/css/site.css` を diff。差分は該当5箇所の `50%` → `999px` の置換のみで、他の差分は無い。

```
1305c1305 / 2023c2023 / 2095c2095 / 2905c2905 / 3120c3120
<   border-radius: 50%;
---
>   border-radius: 999px;
```

`make lint-css` も実行し、問題なし（解決漏れの識別子なし・ベンダー接頭辞の同居なし・font-size は段に収まっている）。

## 対象外にしたもの

- `highlight.styl` / `_variables.styl` 側に `border-radius: 50%` の宣言は無く、対象は `theme-styles.styl` の5箇所のみ。
- 既存の `999px` は9箇所（ページャの丸・メダル・タグチップ・引き出しの棒など）で、issueの記載と一致。今回は変更していない。

Closes #3126

🤖 Generated with [Claude Code](https://claude.com/claude-code)