### PR TITLE
期間・カテゴリ・タグ・著者のページに目次を出す

### DIFF
--- a/themes/future/layout/_partial/archive-all.ejs
+++ b/themes/future/layout/_partial/archive-all.ejs
@@ -1,26 +1,12 @@
 <%# 期間の一覧を時系列で並べる。全期間は年ごと、年ページは月ごとに束ねる (#2754)。
-    月ページはカード一覧（_partial/archive-post）なのでここを通らない %>
+    月ページはカード一覧（_partial/archive-post）なのでここを通らない。
+    束ね方（id と見出しの文言）は呼び出し側が groups で渡す。
+    同じ束をサイドバーの目次の子項目にも使うため (#3145) %>
 <div class="row">
   <%# main ではなく div。<main> は呼び出し側（archive.ejs）が h1 から包んでいる (#2925) %>
   <div class="blog-posts">
-    <%
-      const groups = [];
-      page.posts.each(function(post){
-        const key = is_year() ? post.date.format('MM') : post.date.format('YYYY');
-        if (!groups.length || groups[groups.length - 1].key !== key) {
-          groups.push({key: key, posts: []});
-        }
-        groups[groups.length - 1].posts.push(post);
-      });
-    %>
     <% groups.forEach(function(group, gi){ %>
-    <%
-      const id = is_year() ? 'posts-' + page.year + '-' + group.key : 'posts-' + group.key;
-      // 行の日付から年を落とすぶん、束ねている見出しが年を名乗る (#2773)。
-      // h1 と重なるが、h3 はスクロール中とアンカー着地時に単独で読まれる
-      const label = is_year() ? page.year + '年' + Number(group.key) + '月' : group.key + '年';
-    %>
-    <%- partial('_partial/group-heading', {id: id, text: label}) %>
+    <%- partial('_partial/group-heading', {id: group.id, text: group.label}) %>
     <%# アーカイブページの最後の要素なので footer-gap でフッター前の間隔を持つ %>
     <ul class="article-list<%= gi === groups.length - 1 ? ' footer-gap' : '' %>">
       <% group.posts.forEach(function(post){ %>

--- a/themes/future/layout/_partial/sidebar.ejs
+++ b/themes/future/layout/_partial/sidebar.ejs
@@ -19,12 +19,20 @@
     目次を出すページではページ内移動が主なので、カテゴリ一覧は出さない。
     Markdown のページは本文があるので、レイアウト側で組んだ目次の HTML を
     tocHtml で受け取る (#2559) %>
-<% const sToc = (typeof specialsToc === 'undefined') ? null : specialsToc; %>
+<% const sTocGiven = (typeof specialsToc === 'undefined') ? null : specialsToc; %>
+<%# 項目が1つのページでは出さない。「目次」の下に1行だけ並ぶ形になる。
+    数えるのは子まで含めた総数で、/categories/ のように h2 が1つで群が
+    子に並ぶ形も1項目とは数えない。Markdown のページの page_toc が
+    <li> の数で同じ判断をしているので、条件はそこと揃える (#2559 / #3145) %>
+<% const sTocCount = (sTocGiven || []).reduce(function(n, i){ return n + 1 + ((i.children || []).length); }, 0); %>
+<% const sToc = sTocCount >= 2 ? sTocGiven : null; %>
 <%# tocHtml は空で渡ることがある（見出しが足りないページ）。その場合は目次の枠を
     出さない。tocOnly は「このサイドバーはページ自身の目次のための場所」という
     レイアウト側の宣言で、目次を出せるかどうかとは別に、カテゴリ一覧を抑える %>
 <% const pageToc = (typeof tocHtml === 'undefined' || !tocHtml) ? null : tocHtml; %>
-<% const isTocOnly = (typeof tocOnly !== 'undefined' && tocOnly) || !!sToc; %>
+<%# 見出しが足りなくて目次を出せなかったページでも「目次のための場所」であることは
+    変わらないので、判定は渡された配列の側で行う %>
+<% const isTocOnly = (typeof tocOnly !== 'undefined' && tocOnly) || !!sTocGiven; %>
 <%# 検索はヘッダー右上に昇格した (#2399)。二重の導線は置かない %>
 <% if (is_post()) { %>
 <section class="toc-section" data-nosnippet>

--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -33,6 +33,26 @@
           ? popular_posts_in(site.posts.filter(function(p){ return p.date.format('YYYY') === page.year.toString(); }).toArray())
           // 全期間だけ経過年ペナルティが線形（下の呼び出しと揃える）
           : popular_posts_in(site.posts.toArray(), undefined, 'linear');
+    // 一覧の中の束（全期間は年ごと、年ページは月ごと #2754）。_partial/archive-all の
+    // 見出しと目次の子項目が同じ id・同じ文言を使うよう、ここで1度だけ組む。
+    // 月ページはカード一覧なので束ねない
+    const archiveGroups = [];
+    if (!is_month()) {
+      page.posts.each(function(post){
+        const key = is_year() ? post.date.format('MM') : post.date.format('YYYY');
+        if (!archiveGroups.length || archiveGroups[archiveGroups.length - 1].key !== key) {
+          archiveGroups.push({
+            key: key,
+            id: is_year() ? 'posts-' + page.year + '-' + key : 'posts-' + key,
+            // 行の日付から年を落とすぶん、束ねている見出しが年を名乗る (#2773)。
+            // h1 と重なるが、h3 はスクロール中とアンカー着地時に単独で読まれる
+            label: is_year() ? page.year + '年' + Number(key) + '月' : key + '年',
+            posts: [],
+          });
+        }
+        archiveGroups[archiveGroups.length - 1].posts.push(post);
+      });
+    }
     const periodToc = [];
     if (periodPopular) periodToc.push({id: 'popular', text: 'よく読まれている記事'});
     if (is_month()) {
@@ -42,7 +62,12 @@
     } else {
       periodToc.push({id: 'years', text: '年別'});
     }
-    periodToc.push({id: 'posts', text: '記事一覧'});
+    // 一覧の中の年（月）の見出しは「記事一覧」の子にする。フラットに並べると
+    // 上の「年別」節（年ページへのリンク）とラベルが重なって、同じ行き先に見える
+    periodToc.push({
+      id: 'posts', text: '記事一覧',
+      children: archiveGroups.map(function(g){ return {id: g.id, text: g.label}; }),
+    });
   %>
   <%# ランドマークは h1 から包む (#2925)。以前は記事一覧の部分だけが <main> で、
       h1・統計・グラフがランドマークの外にいた。中の一覧は div に下げてある %>
@@ -134,7 +159,7 @@
       </div>
     </div>
     <% } else { %>
-    <%- partial('_partial/archive-all', {pagination: config.archive}) %>
+    <%- partial('_partial/archive-all', {pagination: config.archive, groups: archiveGroups}) %>
     <% } %>
     <%# 前後の期間へのページャー (#2228)。連載ナビと同じ型（前が左・
         対象明示型のラベル＋行き先名）で、一覧を読み終えた位置に置く。

--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -19,6 +19,31 @@
     if (page.current > 1) items.push({label: page.current + 'ページ目'});
   %>
   <%- partial('_partial/breadcrumb', {items: items}) %>
+  <%# 節はテンプレートが作るので、目次も同じ並びをここで持つ（#2345 / #3116 と同じ
+      specialsToc の形）。「よく読まれている記事」は本数が足りないと出ないので、
+      本文と同じ変数で判定する。月ページは節が「記事一覧」だけになることがあり、
+      その場合は目次を出さない（判断は _partial/sidebar #3145）%>
+  <%
+    const periodPopular = page.current !== 1 ? '' :
+      is_month()
+        ? popular_posts_in(site.posts.filter(function(p){
+            return p.date.format('YYYYMM') === page.year.toString() + page.month.toString().padStart(2, '0');
+          }).toArray())
+        : is_year()
+          ? popular_posts_in(site.posts.filter(function(p){ return p.date.format('YYYY') === page.year.toString(); }).toArray())
+          // 全期間だけ経過年ペナルティが線形（下の呼び出しと揃える）
+          : popular_posts_in(site.posts.toArray(), undefined, 'linear');
+    const periodToc = [];
+    if (periodPopular) periodToc.push({id: 'popular', text: 'よく読まれている記事'});
+    if (is_month()) {
+      // 月ページは期間の中をさらに割る軸を持たない
+    } else if (is_year()) {
+      periodToc.push({id: 'months', text: '月別'});
+    } else {
+      periodToc.push({id: 'years', text: '年別'});
+    }
+    periodToc.push({id: 'posts', text: '記事一覧'});
+  %>
   <%# ランドマークは h1 から包む (#2925)。以前は記事一覧の部分だけが <main> で、
       h1・統計・グラフがランドマークの外にいた。中の一覧は div に下げてある %>
   <div class="row">
@@ -27,13 +52,9 @@
     <h1 class="list-page"><%- partial('_partial/svg-icon', {icon: 'calendar-stats'}) %><%= page.year%>年<%= page.month %>月<span class="list-sub-text">のすべての記事</span></h1>
     <%# その月の中でよく読まれている記事 (#2214)。カテゴリ・タグ・著者の
         詳細ページと同じく新着一覧の前。件数は記事数からヘルパーが決める %>
-    <% if (page.current === 1) { %>
-    <% const ym = page.year.toString() + page.month.toString().padStart(2, '0'); %>
-    <% const monthPopular = popular_posts_in(site.posts.filter(function(p){ return p.date.format('YYYYMM') === ym; }).toArray()); %>
-    <% if (monthPopular) { %>
+    <% if (periodPopular) { %>
     <%- partial('_partial/section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
-    <%- monthPopular %>
-    <% } %>
+    <%- periodPopular %>
     <% } %>
     <% } else if(is_year()) { %>
     <%# 単位の「年」は月ページの h1（2026年8月）と同じく数字側に付ける (#2209) %>
@@ -42,12 +63,9 @@
         優先度の高い順に、定番 → 月の探索 → 新着一覧と並べる。
         年内は経過年数がほぼ同じなので、ペナルティは相殺されて
         素直に PV 順になる %>
-    <% if (page.current === 1) { %>
-    <% const yearPopular = popular_posts_in(site.posts.filter(function(p){ return p.date.format('YYYY') === page.year.toString(); }).toArray()); %>
-    <% if (yearPopular) { %>
+    <% if (periodPopular) { %>
     <%- partial('_partial/section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
-    <%- yearPopular %>
-    <% } %>
+    <%- periodPopular %>
     <% } %>
     <%# 月ページへの唯一の導線 (#2219)。/articles/ の「年別」と同じ
         カード型で、新しい順の並びも揃える。
@@ -78,12 +96,9 @@
         経過年ペナルティは線形（decay: linear）。既定の2乗だと実質直近人気になり
         ホームの年間人気と完全に重複した（実測6/6）。線形なら歴代の定番が並び、
         重複は2/6まで下がる %>
-    <% if (page.current === 1) { %>
-    <% const allPopular = popular_posts_in(site.posts.toArray(), undefined, 'linear'); %>
-    <% if (allPopular) { %>
+    <% if (periodPopular) { %>
     <%- partial('_partial/section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
-    <%- allPopular %>
-    <% } %>
+    <%- periodPopular %>
     <% } %>
     <%- partial('_partial/section-heading', {id: 'years', text: '年別'}) %>
     <section class="archives">
@@ -153,6 +168,10 @@
     </main>
     <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
       <%- partial('_partial/sidebar-index-archive') %>
+      <%# 統計はページ自身の数字なので目次より上 (#2911 / #3116)。
+          軸の枠（人気のカテゴリ・連載・タグ）は一覧ページには置かないので
+          tocOnly で抑える (#2911 / #3025) %>
+      <%- partial('_partial/sidebar', {specialsToc: periodToc, tocOnly: true}) %>
     </aside>
   </div>
 </div>

--- a/themes/future/layout/author.ejs
+++ b/themes/future/layout/author.ejs
@@ -1,3 +1,18 @@
+<%# 節はテンプレートが作るので、目次も同じ並びをここで持つ（#2345 / #3116 と同じ
+    specialsToc の形）。表彰とプロフィールは見出しを持たないブロックなので入らない。
+    2項目に満たないページで目次を出さない判断は _partial/sidebar が持つ (#3145) %>
+<%
+  const isFirstPage = page.current === 1;
+  const authorPopular = isFirstPage
+    ? popular_posts_in(site.posts.filter(function(p){ return p.author === page.author; }).toArray())
+    : '';
+  const as = isFirstPage ? author_stats(page.author) : null;
+  const authorToc = [];
+  if (authorPopular) authorToc.push({id: 'popular', text: 'よく読まれている記事'});
+  if (as && as.topCategories.length) authorToc.push({id: 'topcategories', text: 'よく使うカテゴリ'});
+  if (as && as.topTags.length) authorToc.push({id: 'toptags', text: 'よく使うタグ'});
+  authorToc.push({id: 'posts', text: isFirstPage ? '新着記事' : '記事一覧'});
+%>
 <div class="container">
   <%# 著者名は真下の h1 が名乗るので出さない (#2837) %>
   <%- partial('_partial/breadcrumb', {items: [
@@ -11,7 +26,7 @@
     <main id="main" tabindex="-1" class="col-md-9 blog-posts">
   <div class="margin-top-30">
     <h1 class="list-page"><%- partial('_partial/svg-icon', {icon: 'user'}) %><%- page.author %><span class="list-sub-text">さんのページ</span></h1>
-    <% if (page.current === 1) { %>
+    <% if (isFirstPage) { %>
     <%# 累計・直近1年の数字と推移はサイドバーへ移した (#2911)。表彰とプロフィールは
         本文に残す。表彰は書き手にとっての意味が大きく、プロフィールは読者が
         その人を知る手がかりで、どちらも添えの数字とは別 %>
@@ -73,7 +88,6 @@
     <%# その著者の中でよく読まれている記事。タグ・カテゴリページと同じく
         新着一覧の直前に置き、ページ間でコンテンツ構成を揃える (#2189)。
         順位・件数の規則は共有ヘルパー（popular_posts_in）側 %>
-    <% const authorPopular = popular_posts_in(site.posts.filter(function(p){ return p.author === page.author; }).toArray()); %>
     <% if (authorPopular) { %>
     <%- partial('_partial/section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
     <%- authorPopular %>
@@ -92,7 +106,8 @@
         列そのものは中身が無くても残す。畳むと本文の幅がこのページだけ広くなり、
         一覧を行き来したときにカードの幅が揃わない (#2944) %>
     <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
-      <%- partial('_partial/sidebar', {showStats: true}) %>
+      <%# 統計はページ自身の数字なので目次より上 (#2911 / #3116) %>
+      <%- partial('_partial/sidebar', {showStats: true, specialsToc: authorToc}) %>
     </aside>
   </div>
 </div>

--- a/themes/future/layout/category.ejs
+++ b/themes/future/layout/category.ejs
@@ -1,3 +1,23 @@
+<%# 節はテンプレートが作るので、目次も同じ並びをここで持つ（/series/ や
+    /categories/ と同じ specialsToc の形 #2345 / #3116）。節の有無を決める値は
+    下の本文と同じ変数から引き、目次と本文で条件が割れないようにする。
+    2項目に満たないページで目次を出さない判断は _partial/sidebar が持つ (#3145) %>
+<%
+  const isFirstPage = page.current === 1;
+  const catAll = site.categories.findOne({name: page.category});
+  const popular = (isFirstPage && catAll) ? popular_posts_in(catAll.posts.toArray()) : '';
+  const cs = isFirstPage ? category_stats(page.category) : null;
+  // 関連カテゴリは1ページ目（一覧の前）と最終ページ（ページャーの下）に出る (#2213)
+  const hasRelatedCats = related_categories(page.category).length > 0;
+  const catToc = [];
+  if (popular) catToc.push({id: 'popular', text: 'よく読まれている記事'});
+  if (cs && cs.topTags.length) catToc.push({id: 'toptags', text: 'よく使われるタグ'});
+  if (isFirstPage && hasRelatedCats) catToc.push({id: 'relatedcategories', text: '関連カテゴリ'});
+  catToc.push({id: 'posts', text: isFirstPage ? '新着記事' : '記事一覧'});
+  if (!isFirstPage && page.current === page.total && hasRelatedCats) {
+    catToc.push({id: 'relatedcategories', text: '関連カテゴリ'});
+  }
+%>
 <div class="container">
   <%# 2ページ目以降はカテゴリ自身が現在地ではなくなるのでリンクにする。
       URL は page.base（hexo が採番したページの基点）から取る。
@@ -23,7 +43,7 @@
         <%- partial('_partial/svg-icon', {icon: 'rss'}) %>
       </a>
     </div>
-    <% if (page.current === 1) { %>
+    <% if (isFirstPage) { %>
     <%# カテゴリの役割を1文で名乗る (#2405)。何の記事かはタグチップが担うので
         トピックの列挙はしない。文言は source/_data/categories.yml %>
     <% const catDesc = site.data.categories && site.data.categories[page.category]; %>
@@ -41,12 +61,9 @@
     <% if (without) { %>
     <%- partial('_partial/more-link', {url: url_for(without.path), text: `${page.category}カテゴリの${without.name}以外の記事へ（${without.count}本）`}) %>
     <% } %>
-    <% const cs = category_stats(page.category); %>
     <%# そのカテゴリの中でよく読まれている記事。新着より前に置く。
         絞り込んだ直後の読者がまず知りたいのは「定番はどれか」であって、
         新しさは新着一覧が担う %>
-    <% const catAll = site.categories.findOne({name: page.category}); %>
-    <% const popular = catAll ? popular_posts_in(catAll.posts.toArray()) : ''; %>
     <% if (popular) { %>
     <%- partial('_partial/section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
     <%- popular %>
@@ -73,7 +90,8 @@
   </div>
     </main>
     <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
-      <%- partial('_partial/sidebar', {showStats: true}) %>
+      <%# 統計はページ自身の数字なので目次より上 (#2911 / #3116) %>
+      <%- partial('_partial/sidebar', {showStats: true, specialsToc: catToc}) %>
     </aside>
   </div>
 </div>

--- a/themes/future/layout/tag.ejs
+++ b/themes/future/layout/tag.ejs
@@ -1,3 +1,23 @@
+<%# 節はテンプレートが作るので、目次も同じ並びをここで持つ（#2345 / #3116 と同じ
+    specialsToc の形）。節の有無を決める値は下の本文と同じ変数から引く。
+    2項目に満たないページで目次を出さない判断は _partial/sidebar が持つ (#3145) %>
+<%
+  const isFirstPage = page.current === 1;
+  const tagAll = site.tags.findOne({name: page.tag});
+  const popular = (isFirstPage && tagAll) ? popular_posts_in(tagAll.posts.toArray()) : '';
+  const tc = isFirstPage ? tag_stats(page.tag) : null;
+  // 関連タグは1ページ目（一覧の前）と最終ページ（ページャーの下）に出る。
+  // 出す位置を決めているのは _partial/archive (#2088 / #2213)
+  const hasRelatedTags = related_tags(page.tag).length > 0;
+  const tagToc = [];
+  if (popular) tagToc.push({id: 'popular', text: 'よく読まれている記事'});
+  if (tc && tc.topCategories.length) tagToc.push({id: 'topcategories', text: 'よく使われるカテゴリ'});
+  if (isFirstPage && hasRelatedTags) tagToc.push({id: 'relatedtags', text: '関連タグ'});
+  tagToc.push({id: 'posts', text: isFirstPage ? '新着記事' : '記事一覧'});
+  if (!isFirstPage && page.current === page.total && hasRelatedTags) {
+    tagToc.push({id: 'relatedtags', text: '関連タグ'});
+  }
+%>
 <div class="container">
   <%# タグ名は真下の h1 が名乗るので出さない (#2837) %>
   <%- partial('_partial/breadcrumb', {items: [
@@ -12,14 +32,10 @@
   <div class="margin-top-30">
     <%# タグはページ種別を表す統一アイコン。カテゴリと違って個別の絵柄は割り当てない (#2336) %>
     <h1 class="list-page"><%- partial('_partial/svg-icon', {icon: 'tag'}) %><%- page.tag %> <span class="list-sub-text">タグ</span></h1>
-    <% if (page.current === 1) { %>
-    <% const summary = summary_tag(page.tag); %>
-    <% const ts = tag_stats(page.tag); %>
+    <% if (isFirstPage) { %>
     <%# そのタグの中でよく読まれている記事。新着より前に置く。
         絞り込んだ直後の読者がまず知りたいのは「定番はどれか」であって、
         新しさは新着一覧が担う %>
-    <% const tagAll = site.tags.findOne({name: page.tag}); %>
-    <% const popular = tagAll ? popular_posts_in(tagAll.posts.toArray()) : ''; %>
     <% if (popular) { %>
     <%- partial('_partial/section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
     <%- popular %>
@@ -28,7 +44,6 @@
         前に置き、著者ページと同じくカテゴリ→タグの順にする。
         カテゴリはタグと誤認しないようチップにせず、記事メタデータと同じ
         テキストリンク。添えは本数だけ。何を数えたかは見出しが名乗る (#3075) %>
-    <% const tc = tag_stats(page.tag); %>
     <% if (tc && tc.topCategories.length) { %>
     <%- partial('_partial/section-heading', {id: 'topcategories', text: 'よく使われるカテゴリ'}) %>
     <%- partial('_partial/tendency-panels', {kind: 'category', items: tc.topCategories.map(function(c){
@@ -48,7 +63,8 @@
         列そのものは中身が無くても残す。畳むと本文の幅がこのページだけ広くなり、
         一覧を行き来したときにカードの幅が揃わない (#2944) %>
     <aside class="col-md-3 blog-sidebar" aria-label="サイドバー">
-      <%- partial('_partial/sidebar', {showStats: true}) %>
+      <%# 統計はページ自身の数字なので目次より上 (#2911 / #3116) %>
+      <%- partial('_partial/sidebar', {showStats: true, specialsToc: tagToc}) %>
     </aside>
   </div>
 </div>


### PR DESCRIPTION
Closes #3145

サイドバーの目次（`.toc-section`）を、これまで持っていなかった4つのページ種に広げます。

## 節数の実測（変更前のビルドから）

| ページ種 | 枚数 | 節数（min / 中央値 / max） | 節 |
| --- | --- | --- | --- |
| `/articles/` | 1 | 3 / 3 / 3 | よく読まれている記事・年別・記事一覧 |
| `/articles/YYYY/` | 11 | 3 / 3 / 3 | よく読まれている記事・月別・記事一覧 |
| `/articles/YYYY/MM/` | 120 | 1 / 2 / 2 | よく読まれている記事・記事一覧 |
| カテゴリ個別（1ページ目） | 18 | 3 / 4 / 4 | よく読まれている記事・よく使われるタグ・関連カテゴリ・新着記事 |
| タグ個別（1ページ目） | 679 | 1 / 3 / 4 | よく読まれている記事・よく使われるカテゴリ・関連タグ・新着記事 |
| 著者個別（1ページ目） | 329 | 3 / 3 / 4 | よく読まれている記事・よく使うカテゴリ・よく使うタグ・新着記事 |
| 2ページ目以降（カテゴリ / タグ / 著者） | 123 | 1 / 1〜2 / 2 | 記事一覧（＋最終ページの関連タグ・関連カテゴリ） |

「記事一覧」に届くまでに読み飛ばす量（中央値）は、カテゴリが 6行＋8パネル、著者が 4パネル、タグが 3パネル（最大33）、`/articles/` が 6行＋11枚の年カード。どのページ種でも一覧の見出しは最初の画面には入りません。

## 出す / 出さないの線

**節が2項目に満たないページには出しません。**「目次」の下に1行だけ並ぶ形になるためで、Markdown のページの `page_toc`（`<li>` の数で同じ判断をしている #2559）と条件を揃えました。判断は `_partial/sidebar` の1箇所に置いてあるので、`specialsToc` を渡すすべてのページに同じ線が効きます。子を持つ形（`/categories/` の h2 1つ＋群5つ）は総数で数えるので、これまで出ていた目次は消えません。

結果、目次が出ないのは **月ページ 29/120**（「よく読まれている記事」が出ない古い月）、**タグ個別 74/768**、**2ページ目以降 78/123** です。

**ページ番号では切っていません。** タグの2ページ目以降で「関連タグ」は本文の 88% の位置にあり、25枚のカードを越えないと届きません。統計（`showStats`）が1ページ目だけなのは数字の話で、目次は節が2つあるかどうかだけで決めています。

## 置き場所

記事ページと同じ **サイドバーの `.toc-section`（sticky）** です。統計・グラフの**下**に置きました。`/series/` `/tags/` `/authors/` `/categories/` が #3116 で既にこの順（統計はページ自身の数字なので目次より上 #2911）なので、そこに揃えています。

**モバイル（1024px 以下）には `.toc-mobile` を出しません。** 記事ページがこれを持つのは、目次項目が中央値10で「10章のうちどれを読むか選ぶ」のが目次の仕事だからです。このページ群の節は2〜4件で、しかも最後の1つ（記事一覧）がそのページの目的そのもの、手前の節はいずれも短いブロックです。横並びのときサイドバーは空いているので目次はタダですが、縦積みでは本文の頭に1ブロック分の場所を取って、得られるのは1回のジャンプだけ──割に合わないと判断しました。#3116 の一覧ページ（`/tags/` `/authors/` `/series/` `/categories/`）も同じくサイドバーだけです。

## 実装

- 新しいクラス・サイズ・partial は作っていません。既存の `specialsToc`（#2345 / #3116）と `_partial/toc-list` をそのまま使います。見出しは `_partial/section-heading` が既に `id` を持っているので、アンカーの追加もありません。
- 節の有無を決める値（`popular` / `category_stats` / `related_tags` など）は目次と本文で**同じ変数**から引くようにレイアウトを整理しました。条件が2箇所に分かれて片方だけ出る状態を作らないためです。
- `archive.ejs` は3つの枝（全期間 / 年 / 月）で別々に `popular_posts_in` を呼んでいたのを `periodPopular` の1つにまとめました。
- `tag.ejs` の未使用変数 `summary`（`summary_tag` の呼び出し）を落としました。
- 期間ページは軸の枠（人気のカテゴリ・連載・タグ）を持たないので `tocOnly: true` で抑えています（#2911 / #3025）。

## 検証

`hexo generate`（10,364ファイル）の生成 HTML を python で機械照合しました。

- 対象1,222ページで、**サイドバーの目次の項目列が `<main>` 内の `h2.bottom-content-header` の並びと完全一致**（順序・文言とも）。
- **すべてのアンカーの飛び先 `id` がページ内に実在**。
- 目次の枠が2つ出るページ・2項目未満の目次・節が2つ以上あるのに目次が無いページはいずれも0件。
- 回帰: 記事ページ（サイドバー目次＋`.toc-mobile`）、`/tags/` `/categories/` `/authors/` `/series/`、特設8ページ、`/doctor/`、ホームの目次と軸の枠が変わっていないこと。
- `textlint`（変更した `.ejs` 5本）・`css_lint.mjs`・`font_size_lint.mjs` は指摘なし。

## 範囲外

ホーム（`/`）にも「よく読まれている記事・特集・新着記事」の3節がありますが、あそこのサイドバーは記事を見つける3つの軸（#2880）が入る唯一の場所なので、目次を足すと役が競合します。別の判断として issue に残します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
