### PR TITLE
ヘッダーのパネルの上の空きと、引き出しの組の区切りを直す (#3142)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -569,6 +569,9 @@ Header and header elements
    グリッドだと行の高さが左右で揃い、件数の少ない群の下に空きが出る */
 .header-dropdown-grid {
   width: 420px;
+  /* 上だけ 16px なのは、行が持つ 8px を群のラベルが持たないため (#3142)。
+     ラベル側ではなく器に足すのは、多段組では列ごとに先頭の群が変わるから */
+  padding-top: (space-step * 4);
   columns: 190px;
   column-gap: (space-step * 2);
 }
@@ -622,7 +625,9 @@ Header and header elements
    （検索のヒントパネルと同じ扱い） */
 .header-dropdown-label {
   margin: 0 0 (space-step * 2);
-  padding: 0 (space-step * 3);
+  /* 上の 8px は、行が持つ padding をラベルが持たないぶんの補い (#3142)。
+     これでパネルの上下がどちらも 16px になる */
+  padding: (space-step * 2) (space-step * 3) 0;
   font-size: text-meta;
   line-height: leading-row;
   font-weight: 700;
@@ -846,14 +851,18 @@ Header and header elements
     font-weight: 700;
     color: var(--ink-strong);
   }
-  /* パネルは畳まれず、その場に並ぶ。浮かせる必要が無いので枠も影も持たない */
+  /* パネルは畳まれず、その場に並ぶ。浮かせる必要が無いので枠も影も持たない。
+     左の 16px は、組のラベルと中身の境目 (#3142)。畳みの引き金が無いので
+     どこまでが中身かを示すのは位置だけで、**範囲を示す手はこの1つに留める**
+     （縦罫を足すと太字のラベルと二重に名乗ることになる）。
+     値は既に段差を持っている連載（.header-dropdown-label ~ … の 16px）に合わせた */
   .header-dropdown,
   .header-dropdown-grid {
     position: static;
     visibility: visible;
     opacity: 1;
     width: auto;
-    padding: 0 0 (space-step * 3);
+    padding: 0 0 (space-step * 3) (space-step * 4);
     border: 0;
     border-radius: 0;
     transition: none;


### PR DESCRIPTION
Closes #3142

CSS だけの変更で、生成 CSS の差分は3宣言だけ（`padding-top: 16px` / `padding: 8px 12px 0` / `padding: 0 0 12px 16px`）。

## PC のドロップダウン: 上の空きを下とそろえる

「カテゴリ・連載だけ上が詰まって見える」の正体は、**パネルの先頭が行かラベルか**の違いだった。
行（`.header-dropdown-item`）は自分で `padding: 8px 12px` を持つので、パネルの padding 8px と合わせて 16px になる。カテゴリ・連載はラベルで始まってその 8px が無く、上だけ 8px だった。下端は最後の行（連載は「連載一覧へ」）が 8px を持つのでどのパネルも 16px で、**上下が非対称**になっていたことになる。

パネルの枠から先頭の要素までの距離:

| パネル | 先頭の要素 | before | after | 下端（変更なし） |
| --- | --- | --- | --- | --- |
| カテゴリ | 群のラベル（枠付き） | 8px | **16px** | 16px |
| 連載 | 「人気の連載」ラベル | 8px | **16px** | 16px |
| リソース | 行 | 16px | 16px | 16px |
| アクティビティ | 行 | 16px | 16px | 16px |

- 連載は `.header-dropdown-label` に `padding-top: 8px` を足した（行が持っている padding をラベルが持たないぶんの補い）
- カテゴリはラベル側ではなく器（`.header-dropdown-grid`）に `padding-top: 16px` を足した。多段組なので**列ごとに先頭の群が変わり**、ラベルに margin を持たせても2列目以降には効かないため
- 追加した値はどちらも `space-step` の倍数。新しい色もサイズの段も足していない

## モバイルの引き出し: 組のラベルと中身の左端をずらす

引き出しの中の左端（`.container` の内側からの距離）:

| | before | after |
| --- | --- | --- |
| 組のラベル（カテゴリ / 連載 / リソース / アクティビティ） | 12px | 12px |
| カテゴリ: 群のラベルの文字 | 12px | 28px |
| カテゴリ / リソース / アクティビティ: 行 | **12px** | **28px** |
| 連載: 「人気の連載」 | 28px | 44px |
| 連載: 行 | 28px | 44px |
| 連載: 「連載一覧へ」 | 12px | 28px |

**パネル（`.header-dropdown`）の左に 16px を足して中身を丸ごと下げた**。判断は3つ。

- **項目側を字下げる。ラベル側は弱めない。** 引き出しの組のラベルは横帯の `summary`（引き金）の代わりで、その組の名前を名乗る唯一の部品。弱めると名前が読めなくなる。CLAUDE.md の「**親と子のどちらか片方だけに印を置く**」に照らすと、印（太字・`ink-strong`）は親が持っているので、子に足すのは印ではなく**位置**になる
- **範囲を示す手はこの1つだけにする。** 縦罫を引く案は採らない。太字のラベルが既に名前を名乗っているので、「**群を表す手はその場所で1つだけ持つ**」（#2908 / サイドバーの群）に当たる
- **16px は連載から採った値。** issue が「連載は違和感が無い」と言っている通り、連載だけは既に `.header-dropdown-label ~ .header-dropdown-item` の 16px の段差を持っていた。同じ値を残り3つにも与えた形。中身を丸ごと下げるので、**連載の中の親子関係（人気の連載 → 行 / 連載一覧へ）は今までのまま**平行移動する
- PC 側は `@media (max-width: 991px)` の中だけの変更なので影響しない。多段組の列数も変わらない（375px で1列・991px で3列、before と同じ）

行が深くなるぶんの実測: `.header-dropdown-row` は `white-space: nowrap` なので、いちばん長い連載名「サービス間通信とIDL（インターフェース記述言語）」を 13px で測ると 304.4px。375px の端末で連載の行に残る幅は 307px（`351 - 44`）で収まる。溢れても `.header-nav` は `overflow-y: auto` を持つので overflow-x が auto に計算され、ページではなく引き出しの中で送られる。

## 「人気の連載」ラベルは残す

issue は「消したほうがすっきりするかも／どちらでも良い」だが、**既存の規則と衝突するので残す**側を採った。

連載パネルは `popular_series(6)` の6件で、78ある連載の抜粋。**「全件でないことはラベルが名乗り、条件は `title` が持つ」**（#2670）が効く場所で、カテゴリパネルにラベルが無いのは**あちらが全18件だから**。ラベルを外すと、抜粋であることを名乗る部品がパネルから消える（同じ理由で検索窓のヒントパネルは「人気のタグ」を持っている）。

なお、上の空きの調整でラベルの上が 8px 空いたので、「詰まって見える」ほうの不満はラベルを残したまま解消している。

## 確認

- `make css` の前後 diff が上記3宣言だけであることを確認
- `make lint-css`（`css_lint` / `font_size_lint`）ともに通過
- EJS は触っていないので `hexo generate` は不要（CLAUDE.md の確認表）

見るところ:

- **PC（1025px 以上）**: 4つのドロップダウンに順に hover。カテゴリ・連載の上の空きがリソース・アクティビティと同じ見え方になり、どのパネルも上下が同じ空きになっていること
- **モバイル（992px 未満）**: ハンバーガーを開き、「カテゴリ」「リソース」「アクティビティ」の見出しと中身の左端がずれて、組の切れ目が読めること。連載は関係が変わらずそのまま右へ寄ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
