### PR TITLE
ギャラリーの記事メタ情報見本に文字数・閲覧数を追加

### DIFF
--- a/themes/future/layout/gallery.ejs
+++ b/themes/future/layout/gallery.ejs
@@ -174,6 +174,13 @@
         <ul class="blog-info">
           <li class="blog-info-item"><%- partial('_partial/post/date', {post: samplePost, class_name: 'archive-article-date', date_format: 'YYYY.MM.DD'}) %></li>
           <%- post_author_link(samplePost) %>
+          <li class="blog-info-break" aria-hidden="true"></li>
+          <li class="blog-info-item blog-info-metric"><span title="コードブロックと折りたたみ（details）の中身、空白を除いた本文の文字数です。インラインコードは含みます"><%= char_count(samplePost) %></span></li>
+          <%# 実物（article.ejs）と同じく、集計値の無い記事は閲覧数の項目ごと出ない %>
+          <% const samplePV = get_ga4_pv(samplePost.path); %>
+          <% if (samplePV) { %>
+          <li class="blog-info-item blog-info-metric"><span title="Google Analytics による閲覧数です。毎日 9:00 JST に更新されます"><%= samplePV %> View</span></li>
+          <% } %>
         </ul>
         <div class="article-header-tags"><%- partial('_partial/post/tag', {post: samplePost}) %></div>
       </div>


### PR DESCRIPTION
## 変更内容

`themes/future/layout/gallery.ejs` の sample-post-meta（部品ギャラリー「記事のメタ情報」の見本）に、文字数と閲覧数（PV）の2項目を追加しました。

## 背景

見本の `.blog-info` は日付・著者の2項目しか出しておらず、説明文（「日付・著者・文字数・閲覧数を1行に並べ、タグはその下の行に置きます」）とも、記事ページの実物（`_partial/article.ejs` のメタ行）とも食い違っていました。実体側を正とし、実物と同じマークアップ（`blog-info-break` の区切り、`blog-info-metric` の項目、title 属性による補足）で揃えています。

- 文字数は実物と同じく `char_count(samplePost)` で描画
- PV は実物と同じく `get_ga4_pv()` を呼び、集計値の無い記事では項目ごと出ない（`article.ejs` と同じ振る舞い）

Fixes #3129

## 検証

- `gallery.ejs` が EJS としてコンパイルできることを確認済み（ejs 3 で compile）
- サイト全体のビルド（hexo generate）は記事データ一式が必要で重いため未実施です。追加した項目は `article.ejs` で全記事に対して稼働している実装をそのまま写したものです

🤖 Generated with [Claude Code](https://claude.com/claude-code)