### PR TITLE
期間ページの「よく読まれている記事」に7〜10位のおかわりを足す (#3144)

### DIFF
--- a/scripts/ga4_pv.js
+++ b/scripts/ga4_pv.js
@@ -104,20 +104,25 @@ hexo.extend.helper.register('popular_series', function (limit = 6, minPosts = 3)
 
 // 推薦の件数は記事数から決める。推薦が全記事の半分を超えると
 // 一覧の並べ替えにしかならず、新着とほぼ同じ顔ぶれになるため、
-// 2件には4本以上、4件には8本以上、6件には12本以上を要求する (#2173 / #2272)
-function recommendLimit(count) {
+// 2件には4本以上、4件には8本以上、6件には12本以上を要求する (#2173 / #2272)。
+// extended を渡した呼び出し（期間ページのおかわり #3144）だけ 10件の段を持ち、
+// 比は同じなので 20本以上を要求する
+function recommendLimit(count, extended) {
   if (count <= 3) return 0;
   if (count <= 7) return 2;
   if (count <= 11) return 4;
+  if (extended && count >= 20) return 10;
   return 6;
 }
 
 // 指定した記事の中から PV の多い順に取り出す。カテゴリ・タグの一覧ページで
 // 「よく読まれている記事」を出すのに使う（#2033 / #2034）。
 // limit を省略すると記事数に応じた件数になる。
-// decay に 'linear' を渡すと経過年ペナルティが線形（≒年平均PV）になる
-hexo.extend.helper.register('popular_posts_in', function (posts, limit, decay) {
-  if (limit === undefined) limit = recommendLimit(posts.length);
+// decay に 'linear' を渡すと経過年ペナルティが線形（≒年平均PV）になる。
+// foldAfter を渡すと、その件数までを開いた状態で置き、残りを details で畳む
+// （#3144。/articles/ と /articles/yyyy/ だけ）
+hexo.extend.helper.register('popular_posts_in', function (posts, limit, decay, foldAfter = 0) {
+  if (limit === undefined) limit = recommendLimit(posts.length, foldAfter > 0);
   if (limit === 0) return '';
   // PV は累積なので、古い記事ほど有利になる。経過年数で割って、
   // 何年もかけて積んだ数字と最近読まれている数字を並べられるようにする。
@@ -152,8 +157,18 @@ hexo.extend.helper.register('popular_posts_in', function (posts, limit, decay) {
   // 題を1行の塊にして日付・♡を次の行に落とすのは .nav a（display: block）。
   // ランキング・関連記事・被参照記事も .nav の中に置いて同じ形にしている。
   // 列は CSS（.popular-in-list）が持つ
-  const items = ranked
-    .map(({ post }) => postListItem(this, post, 'featured-posts-item', { withThumb: true }))
-    .join('');
-  return `<ul class="nav popular-in-list">${items}</ul>`;
+  const list = (part) =>
+    `<ul class="nav popular-in-list">${part
+      .map(({ post }) => postListItem(this, post, 'featured-posts-item', { withThumb: true }))
+      .join('')}</ul>`;
+
+  // 残りが1件だけなら畳む意味がないので開いたまま出す（ランキングと同じ扱い）
+  if (foldAfter === 0 || ranked.length <= foldAfter + 1) return list(ranked);
+
+  // 畳みは details。文言・見た目はホームのランキングの2段目と同じ (#2249)
+  return `${list(ranked.slice(0, foldAfter))}
+<details class="popular-in-more">
+  <summary>残り ${ranked.length - foldAfter}本を表示</summary>
+  ${list(ranked.slice(foldAfter))}
+</details>`;
 });

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -4126,6 +4126,7 @@ a.series-nav-item:hover .series-nav-item-title {
 }
 .reference-post-more > summary,
 .related-posts-more > summary,
+.popular-in-more > summary,
 .ranking-more > summary {
   /* 行と同じ余白 */
   padding: (space-step * 2) 0;
@@ -4136,6 +4137,7 @@ a.series-nav-item:hover .series-nav-item-title {
 }
 .reference-post-more > summary:hover,
 .related-posts-more > summary:hover,
+.popular-in-more > summary:hover,
 .ranking-more > summary:hover {
   color: var(--ink-strong);
 }
@@ -4143,6 +4145,7 @@ a.series-nav-item:hover .series-nav-item-title {
    ブロック向けの余白で、.article-entry details と .toc-mobile も同じ理由で
    外している）。畳んだ状態だと「残り N本を表示」の下に24pxの空きが残る。
    下の余白は節の間隔が持つ */
+.popular-in-more,
 .ranking-more {
   padding-bottom: 0;
 }

--- a/themes/future/layout/archive.ejs
+++ b/themes/future/layout/archive.ejs
@@ -30,9 +30,9 @@
             return p.date.format('YYYYMM') === page.year.toString() + page.month.toString().padStart(2, '0');
           }).toArray())
         : is_year()
-          ? popular_posts_in(site.posts.filter(function(p){ return p.date.format('YYYY') === page.year.toString(); }).toArray())
+          ? popular_posts_in(site.posts.filter(function(p){ return p.date.format('YYYY') === page.year.toString(); }).toArray(), undefined, undefined, 6)
           // 全期間だけ経過年ペナルティが線形（下の呼び出しと揃える）
-          : popular_posts_in(site.posts.toArray(), undefined, 'linear');
+          : popular_posts_in(site.posts.toArray(), undefined, 'linear', 6);
     // 一覧の中の束（全期間は年ごと、年ページは月ごと #2754）。_partial/archive-all の
     // 見出しと目次の子項目が同じ id・同じ文言を使うよう、ここで1度だけ組む。
     // 月ページはカード一覧なので束ねない
@@ -87,7 +87,8 @@
     <%# その年の中でよく読まれている記事 (#2214)。読者にまず見せたい
         優先度の高い順に、定番 → 月の探索 → 新着一覧と並べる。
         年内は経過年数がほぼ同じなので、ペナルティは相殺されて
-        素直に PV 順になる %>
+        素直に PV 順になる。
+        初期表示6件＋7〜10位のおかわり（#3144。20本以上の年だけ）%>
     <% if (periodPopular) { %>
     <%- partial('_partial/section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
     <%- periodPopular %>
@@ -120,7 +121,8 @@
         ここだけ欠く非一貫の方が害が大きいと判断を見直した (#2407)。
         経過年ペナルティは線形（decay: linear）。既定の2乗だと実質直近人気になり
         ホームの年間人気と完全に重複した（実測6/6）。線形なら歴代の定番が並び、
-        重複は2/6まで下がる %>
+        重複は2/6まで下がる。
+        初期表示6件＋7〜10位のおかわり（#3144。投稿量が桁違いに多い期間ページだけ）%>
     <% if (periodPopular) { %>
     <%- partial('_partial/section-heading', {id: 'popular', text: 'よく読まれている記事'}) %>
     <%- periodPopular %>


### PR DESCRIPTION
`/articles/`（全期間）と `/articles/yyyy/`（年ページ）の「よく読まれている記事」に、7〜10位のおかわりを足しました。初期表示は6件のままです。

## 畳み方に `<details>` を選んだ理由

ページ内で開く畳みの型は、このサイトに既に2つあります。

| 型 | 使っているところ | 性格 |
| --- | --- | --- |
| `<details>` | ホームのランキング（`ranking-more` #2249 / #2309）・被参照記事・関連記事・モバイル目次 | 行の続きをその場で開く |
| checkbox の `:checked` ＋兄弟結合子 | モバイルの引き出し（#2883）・ランキングのタブ（#2852） | 帯を覆う／排他で切り替える |

**今回は「6件の続きの4件をその場で開く」なので `<details>` 側**です。checkbox が使われているのは、`details` の入れ子構造では表現できない形（帯の外まで覆う引き出し、ラジオグループとしての排他切り替え）に限られていて、ここはそれに当たりません。

キーボードの面でも `<summary>` は素で focusable・Enter / Space で開閉するので、#2852 の「`label` に `tabindex` を付けて凌がない」に引っかかりません。閉じる手段も同じ `<summary>` がそのまま持ちます。

導線の見た目・文言は**ホームのランキングの2段目をそのまま借りました**（「残り 4本を表示」）。`.more-link` は「別ページへの行き先」の部品（#2893 / #2899）で、ページ内で開く導線に流用すると実態以上のことを名乗るので使っていません。CSS も新しい宣言は足さず、既に3クラスが共有している `> summary` のセレクタリストに `.popular-in-more` を1行足しただけです。

行は既存の `postListItem` のまま。この節はもともと順位の丸（`post-list-rank` / `post-list-rank-high`）を持たない（持つのはホームのランキングだけ）ので、10位まで伸ばしても丸の色分けの話は出てきません。生成 HTML でも `post-list-rank` は0件でした。

## 件数の段

`recommendLimit` の「推薦が全記事の半分を超えると一覧の並べ替えにしかならない」（#2173 / #2272）はそのままで、**10件の段だけ足して20本以上を要求**しています（2件に4本、4件に8本、6件に12本、10件に20本で比は同じ）。この段は `foldAfter` を渡した呼び出し（＝期間ページ）でしか効きません。

結果、**20本に満たない2018年（14本）だけは6件のままでおかわりが出ません**。残りが1件だけになる場合に前段へ吸収するのもランキングと同じ扱いにしています。

## 7〜10位の実測

`/articles/`（経過年ペナルティは線形）:

| # | 記事 | PV |
| --- | --- | --- |
| 7 | 設計ドキュメント腐る問題、Git管理で運用してみた結果 | 36,300 |
| 8 | PostgreSQLで連番を自動生成するIDENTITY列。SERIALとどちらを使うべきか | 25,700 |
| 9 | VSCodeでGitLensを使う | 28,300 |
| 10 | 龍が如く7のすごいテストをなぜ我々は採用できないのか | 29,100 |

`/articles/2026/`: 7 今なぜ「アルゴリズム」を学ぶのか？ / 8 テクニカルライティングガイドラインを公開しました / 9 DynamoDB設計ガイドラインを公開しました / 10 アーキテクチャガイドライン振り返り（2025年）

`/articles/2025/`: 7 PostgreSQLの全文検索機能を試してみる / 8 バッチ設計ガイドラインを公開しました / 9 PostgreSQL設計ガイドラインのご紹介 / 10 PostgreSQL 18の新機能「B-treeインデックスのスキップスキャン」

`/articles/2024/`: 7 2024年Gitワークフロー再考 / 8 署名付きURLを利用したファイルアップロードWeb API設計の勘所 / 9 Gitのブランチの役割を考える / 10 CI/CD初心者のためのJenkins入門

**空きも1〜6位との重複も出ませんでした。** おかわりが出るのは `/articles/` と2016・2017・2019〜2026年の計11ページです。

## 範囲外はノータッチ

issue の判断どおり、**カテゴリ・タグには足していません**。月ページ・著者ページ・ホームも範囲外です。

機械照合の方法と結果:

1. `origin/main` と本ブランチをそれぞれ**まっさらな状態から** `hexo generate`（同じ worktree ではなく別 worktree、`db.json` 無し）
2. 生成された **.html 全2,938枚**を md5 で突き合わせ。正規化したのは2つだけ ―― `site.css?v=<hash>`（CSS を1文字でも触ると全ページで変わる）と `article:(published|modified)_time`（ファイルの mtime 由来で、worktree を作った時刻がそのまま出る）
3. 差分は42枚。ただし**このビルドはもともと決定的ではない**（同点の並びが Warehouse の登録順で決まる箇所がある）ので、`origin/main` を**もう一度まっさらからビルドして A/A も取り**、同じコード同士で差が出るページ60枚を洗い出した
4. 42枚から A/A で揺れる60枚を引くと、**残るのは以下の11枚だけ**

```
./articles/index.html
./articles/2016/ 2017/ 2019/ 2020/ 2021/ 2022/ 2023/ 2024/ 2025/ 2026/
```

つまり `./tags/**`・`./categories/**`・`./authors/**`・`./articles/yyyy/mm/`・記事ページ・特設ページ・`./index.html` は**この変更では1バイトも動いていません**（A/A で揺れる分だけが残り、範囲外で「変更由来の差」は0枚）。`/articles/2018/` も予想どおり不変でした。

なお A/A で揺れる60枚（著者ページ52枚・カテゴリ6枚・ホーム）は**本 PR とは無関係の既存の性質**です。同点の決着が入っていない箇所（著者の「よく使うカテゴリ」の3位が2本ずつで並ぶ、カテゴリページの関連タグ、ホームのランキング34位）で、`db.json` が残っていれば再現するのでデプロイでは基本的に固定されます。気になるようなら別 issue で。

## 確認

- `make lint-css`（`css_lint.mjs` / `font_size_lint.mjs`）
- `npx prettier --check "scripts/**/*.js"`
- `themes/future/layout/archive.ejs` に textlint

Closes #3144

🤖 Generated with [Claude Code](https://claude.com/claude-code)
