### PR TITLE
ダークモードで検索窓の入力文字が読めない不具合を直す (#3156)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -5132,6 +5132,7 @@ a.award-badge:focus {
   height: 32px;
   padding: 0 (space-step * 3);
   font-size: 16px; /* 16px 未満だと iOS がフォーカス時に画面をズームする */
+  color: var(--ink-strong);
   border: 0;
   background: none;
   border-radius: radius-small 0 0 radius-small;


### PR DESCRIPTION
## 原因

`.header-search input`（ヘッダーの検索窓）に `color` を明示していなかった。
静止時は `background: var(--surface-tint)`、フォーカス時は `background: var(--surface-base)` が
`:root[data-theme="dark"]` / `prefers-color-scheme: dark` で暗いトークンに差し替わる一方、
`color` は指定が無いのでブラウザ既定（黒文字）のまま残っていた。ダークモードでは地だけが暗くなり、
黒い入力文字が暗い地にほぼ溶けて読めなくなっていた（issue #3156）。

`color-scheme` プロパティも宣言していないため、ブラウザは常にライト前提の既定色でフォームを描画する。
サイト全体は `body { color: var(--ink-strong) }` を持つが、`input` はフォーム要素なので
`font-family` / `font-size` / `line-height` しか継承しない（bootstrap-subset.css の reset）。
`color` はこの継承対象に入っていないため、`body` の指定が効かない。

隣接部品（検索の展開ボタン・✕・検索ヒントパネル・placeholder）はすでに `var(--ink-mute)` /
`var(--ink-faint)` / `var(--ink-strong)` をトークンで持っており、同じ穴は無かった。

## 直した範囲

`themes/future/css-src/theme-styles.styl` の `.header-search input` に
`color: var(--ink-strong)` を1行追加しただけ。CLAUDE.md の
「ダークモードは `:root` のトークンを差し替えて作る」の流儀どおり、
ライト/ダークで別々の値を書かず、テーマで自動追従するトークンを参照する形にした。

`make css` の diff は1行のみ。

```diff
   font-size: 16px; /* 16px 未満だと iOS がフォーカス時に画面をズームする */
+  color: var(--ink-strong);
   border: 0;
```

## コントラスト比（before → after）

`_variables.styl` の値から計算（WCAG 相対輝度式）。

| 状態 | 地 | before（UA既定の黒文字） | after（`ink-strong` / ダークは `dark-ink-strong`） |
| --- | --- | --- | --- |
| ライト・静止 | `surface-tint` `#f5f5f5` | 19.26 | 9.22 |
| ライト・フォーカス | `surface-base` `#fff` | 21.00 | 10.05 |
| ダーク・静止 | `dark-surface-tint` `#232329` | **1.34（読めない）** | **12.77** |
| ダーク・フォーカス | `dark-surface-base` `#1b1b1f` | **1.22（読めない）** | **14.03** |

ダークモードは AA 未達（1.2〜1.3）から大幅に改善し、AA（4.5）を余裕を持って満たす。
ライトモードは黒文字（19〜21）から `ink-strong`（9〜10）に下がるが、これは本文が
サイト全体で使っている文字色（白地で 10.05、CLAUDE.md 記載値）と同じで、
黒 (#000) より地の文の色に揃う方向の変化。AA は引き続き余裕で満たしている。

## 確認方法

1. ダークモードに切り替える（OS のダークモード、または右上のテーマ切り替えで `data-theme="dark"`）
2. ヘッダーの検索窓（575px 以下では虫眼鏡タップで展開）にフォーカスして文字を入力
3. 入力した文字が読める（暗い地に対して薄いグレー `#e8e8ea` で表示される）ことを確認
4. ライトモードでも読みやすさが変わっていないことを確認

## 検証

- `make css`: diff 1行のみ（上記）
- `make lint-css`: `css_lint.mjs`（未解決識別子・ベンダー接頭辞の同居）/ `font_size_lint.mjs` とも問題なし
- EJS・`scripts/` は未変更のため `hexo generate` は不要

Closes #3156

🤖 Generated with [Claude Code](https://claude.com/claude-code)
