### PR TITLE
同点の並びに決着を入れて、コールドビルドの揺れを止める

### DIFF
--- a/scripts/author_generator.js
+++ b/scripts/author_generator.js
@@ -179,7 +179,9 @@ hexo.extend.helper.register('author_stats', function (name) {
       tagCount.set(t.name, e);
     });
   });
-  const byCount = (a, b) => b.count - a.count;
+  // 同数は名前で決める（決着が無いとビルドごとに並びが変わる）。
+  // 上位3件・10件で切るので、境目が同点だと出る項目自体が入れ替わる
+  const byCount = (a, b) => b.count - a.count || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
   // 使用が1本だけの項目は「よく使う」傾向とは言えないので省く (#2139)。
   // ただし省いた結果が空になる著者（投稿1本や、投稿ごとにタグが全部違う著者）は
   // 何も出せなくなるので、その場合だけ省かずに全部見せる
@@ -242,8 +244,11 @@ hexo.extend.helper.register('author_monthly_chart', function (name) {
     }
   }
 
-  // 積み上げの並びは合計の多いカテゴリから。凡例の順もこれに従う
-  const cats = [...catTotal.entries()].sort((a, b) => b[1] - a[1]).map(([c]) => c);
+  // 積み上げの並びは合計の多いカテゴリから。凡例の順もこれに従う。
+  // 同数は名前で決める（決着が無いとビルドごとに積む順と色が変わる）
+  const cats = [...catTotal.entries()]
+    .sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+    .map(([c]) => c);
   const series = cats.map((cat) => ({
     name: cat,
     type: 'bar',

--- a/scripts/category_chart_helpers.js
+++ b/scripts/category_chart_helpers.js
@@ -340,7 +340,9 @@ function buildCategoryStats(category) {
   const topTags = [...tagCount.entries()]
     // インデックスは連載索引の構造タグで、カテゴリの中身を表さない
     .filter(([name]) => name !== 'インデックス')
-    .sort((a, b) => b[1] - a[1])
+    // 同数は名前で決める（決着が無いとビルドごとに並びが変わる）。
+    // 上位5件で切るので、5位が同点だと出るタグ自体が入れ替わる
+    .sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
     .slice(0, 5)
     .map(([name, count]) => {
       const tag = this.site.tags.findOne({ name });

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -87,7 +87,15 @@ hexo.extend.helper.register('doctor_checks', function () {
       }
     }
   }
-  nearDuplicates.sort((x, y) => x.bN - x.aN - (y.bN - y.aN) || y.aN - x.aN);
+  // 同点はタグ名で決める（決着が無いとビルドごとに並びが変わる）。
+  // 差は0〜2の3通りしか無いので同点は構造的に出る
+  nearDuplicates.sort(
+    (x, y) =>
+      x.bN - x.aN - (y.bN - y.aN) ||
+      y.aN - x.aN ||
+      (x.a < y.a ? -1 : x.a > y.a ? 1 : 0) ||
+      (x.b < y.b ? -1 : x.b > y.b ? 1 : 0),
+  );
 
   // 6) 1記事タグ。同じ記事に1記事タグ同士が同居している場合は、その記事の
   //    タグ付けがまとめて薄い可能性が高いので印を付ける
@@ -205,9 +213,14 @@ hexo.extend.helper.register('doctor_ontology_suggestions', function () {
       });
     }
   }
-  // 記事数の多い子から。影響するページが大きい順に見てもらう
+  // 記事数の多い子から。影響するページが大きい順に見てもらう。
+  // 子が同じで親の本数も同じ行は名前まで見ないと決着しない
   suggestions.sort(
-    (a, b) => b.childN - a.childN || a.parentN - b.parentN || (a.child < b.child ? -1 : 1),
+    (a, b) =>
+      b.childN - a.childN ||
+      a.parentN - b.parentN ||
+      (a.child < b.child ? -1 : a.child > b.child ? 1 : 0) ||
+      (a.parent < b.parent ? -1 : a.parent > b.parent ? 1 : 0),
   );
 
   const childCount = new Set(suggestions.map((s) => s.child)).size;
@@ -325,7 +338,8 @@ hexo.extend.helper.register('doctor_text_suggestions', function () {
       if (count >= TEXT_SUGGEST_MIN_COUNT) hits.push({ name: c.name, path: c.path, count });
     }
     if (!hits.length) return;
-    hits.sort((a, b) => b.count - a.count);
+    // 同数はタグ名で決める（決着が無いとビルドごとに並びが変わる）
+    hits.sort((a, b) => b.count - a.count || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
     total += hits.length;
     // 直す単位は記事のフロントマターなので、記事ごとにまとめる
     rows.push({ title: post.title, path: post.path, tags: hits, top: hits[0].count });

--- a/scripts/popular_posts.js
+++ b/scripts/popular_posts.js
@@ -94,9 +94,9 @@ hexo.extend.helper.register('popular_posts', function (term = 'weekly') {
   const threeDayAgo = new Date();
   threeDayAgo.setDate(threeDayAgo.getDate() - 3); // 3day
 
-  const compareFunc = (a, b) => {
-    return b.pv - a.pv;
-  };
+  // 同点はパスで決める（決着が無いとビルドごとに並びが変わる）。
+  // GA4 の PV は 100 単位に丸められているので、下位ほど同点が出る
+  const compareFunc = (a, b) => b.pv - a.pv || (a.path < b.path ? -1 : a.path > b.path ? 1 : 0);
 
   let [rate3d, rate1w, rate2w, rate4w, rate2m, rate3m, rate6m, rate12m] = [
     10, 8, 5, 4, 3.5, 3, 2.5, 2,
@@ -105,20 +105,19 @@ hexo.extend.helper.register('popular_posts', function (term = 'weekly') {
     [rate3d, rate1w, rate2w, rate4w, rate2m, rate3m, rate6m, rate12m] = [3, 3, 3, 2, 2, 1.5, 1, 1];
   }
 
+  // GA のパスから記事を引くのはパスの完全一致で行う。部分一致だと
+  // 一覧ページ /articles/ が全記事の permalink に含まれて全件に一致し、
+  // 先頭の1本が一覧ページの PV を持ってしまう。どれが先頭かは
+  // site.posts.data の格納順＝ファイルを読み終えた順で、コールドビルドの
+  // たびに変わる。完全一致なら一覧ページはどの記事にも当たらず落ちる
+  const postByPath = new Map(this.site.posts.data.map((post) => [`/${post.path}`, post]));
+
   const popularPosts = gaCache[term]
-    .filter((gaPage) => gaPage.path.indexOf('articles') > 0)
-    .filter((gaPage) => {
-      return this.site.posts.data.some((post) => post.permalink.indexOf(gaPage.path) > 0);
-    })
     .flatMap((gaPage) => {
-      const post = this.site.posts.data
-        .filter((post) => post.permalink.indexOf(gaPage.path) > 0)
-        .slice(0, 1);
-      if (post && post.length > 0) {
-        post[0].pv = parseInt(gaPage.pv);
-        return post;
-      }
-      return []; // もしpostがundefinedや空の配列なら空の配列を返す
+      const post = postByPath.get(gaPage.path);
+      if (!post) return [];
+      post.pv = parseInt(gaPage.pv);
+      return [post];
     })
     .map((post) => {
       if (post.date.toISOString() >= threeDayAgo.toISOString()) {

--- a/scripts/sitemap.js
+++ b/scripts/sitemap.js
@@ -113,14 +113,20 @@ hexo.extend.generator.register('sitemap', function (locals) {
   // 従来のプラグインは pages をそのまま出しており 404.html が混ざっていた
   const pages = locals.pages.filter((p) => !/(^|\/)404\.html$/.test(p.path));
 
+  // 並びはパス順にそろえる。toArray() は Warehouse の格納順＝ファイルを
+  // 読み終えた順で、コールドビルドのたびに入れ替わる。サイトマップに
+  // 並び順の意味は無いが、順序が不定だと差分の照合でノイズになる
+  const byPath = (a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0);
+  const sorted = (list) => list.toArray().sort(byPath);
+
   const children = [
-    { path: 'post-sitemap.xml', data: build(locals.posts.toArray(), RULES.post, (p) => p.path) },
-    { path: 'page-sitemap.xml', data: build(pages.toArray(), RULES.page, (p) => p.path) },
+    { path: 'post-sitemap.xml', data: build(sorted(locals.posts), RULES.post, (p) => p.path) },
+    { path: 'page-sitemap.xml', data: build(sorted(pages), RULES.page, (p) => p.path) },
     {
       path: 'category-sitemap.xml',
-      data: buildTaxonomy(locals.categories.toArray(), RULES.category),
+      data: buildTaxonomy(sorted(locals.categories), RULES.category),
     },
-    { path: 'tag-sitemap.xml', data: buildTaxonomy(locals.tags.toArray(), RULES.tag) },
+    { path: 'tag-sitemap.xml', data: buildTaxonomy(sorted(locals.tags), RULES.tag) },
   ];
 
   // 子サイトマップの lastmod は、その中で最も新しい更新日時


### PR DESCRIPTION
Closes #3158

コードが同じでもコールドビルドのたびに生成 HTML が変わる箇所を潰した。

## 揺れの根はソートではなく入力の順序

V8 の `Array#sort` は安定なので、**同点の並びは入力順そのまま**になる。その入力が非決定なら、同点に決着の無いソートはビルドごとに違う答えを出す。

入力の非決定は1箇所から来ている。`site.posts` / `site.tags` / `site.categories` はいずれも Warehouse の **格納順＝ソースファイルを読み終えた順**（`Post.find(query)` / `Tag.filter(...)`。date でも name でも並んでいない）で、ファイルの読み込みが非同期なのでコールドビルドのたびに変わる。ここを `forEach` して作った `Map` の挿入順も同じように揺れるので、`[...map.values()].sort(件数の降順)` の同点が毎回違う順に並ぶ。

`db.json` が残っていれば記事は再描画されないので普段は表に出ないが、`make clean` 後のデプロイと CI のコールドビルドでは差分が出る。

## 発生源と直したもの

| 集計 | 非決定な入力 | 鍵 | 影響 |
| --- | --- | --- | --- |
| `author_stats`（著者の「よく使うカテゴリ／タグ」） | `catCount` / `tagCount` … `posts.forEach` で作る Map | 件数 → **名前** | 上位3件・10件で切るので、境目が同点だと**出る項目自体**が入れ替わる（issue の実測どおり） |
| `author_monthly_chart` | `catTotal` … 同上 | 件数 → **名前** | 積み上げの順と色の位置 |
| `buildCategoryStats`（カテゴリの「よく使われるタグ」） | `tagCount` … `category.posts.forEach` で作る Map | 件数 → **名前** | 上位5件で切る。`related_categories` がこの結果を使うので**関連カテゴリも一緒に**揺れていた |
| `doctor_checks` のほぼ重なるタグ | `tagPostSets` … `site.tags.forEach` で作る Map | 差 → 本数 → **タグ名** | 差は0〜2の3通りしか無いので同点は構造的に出る |
| `doctor_ontology_suggestions` | 同上 | 子の本数 → 親の本数 → 子名 → **親名** | 子が同じ行どうしが未決着だった |
| `doctor_text_suggestions` | `candidates` … 同上 | 回数 → **タグ名** | |
| `sitemap` | `locals.posts.toArray()` ほか4本 | **パス** | **そもそも並べていなかった**（格納順をそのまま出力） |

決着の鍵は「同点は名前で決める」に揃えた。サイドバーの4枠（人気のカテゴリ・連載・タグ・記事）が既に採っている規則で、`ga4_pv.js` / `tags.js` / `related_tags.js` / `category_chart_helpers.js` にも同じ形が入っている。記事の並びだけは名前を持たないのでパスで決める（`popular_posts_in` と同じ）。**順位の鍵そのものは変えていない**——同点の中の並びが固定されるだけで、1位と2位が入れ替わるような変更は入れていない。

### ホームのランキングだけは同点ではなかった

`popular_posts` は GA のパスから記事を引くのに `post.permalink.indexOf(gaPage.path) > 0` を使っていた。**一覧ページ `/articles/` は全記事の permalink に含まれる**ので全件に一致し、`.slice(0, 1)` が拾った1本が一覧ページの PV を持って年間ランキングに紛れ込んでいた。どれが先頭かは格納順次第なので、紛れ込む記事がビルドごとに変わる。

これは並びの決着では直らない（拾う記事の**同一性**が不定なので）。パスの完全一致にして、一覧ページがどの記事にも当たらないようにした。実測では `/articles/`（年間3,522PV）が1件だけ落ち、`/articles/20200116/` のような旧 URL は完全一致でも部分一致でも当たらないので挙動は変わらない。紛れ込んだ記事の順位は、その記事の公開日で決まる経過年の係数次第で **7位〜32位**まで動く（今回のビルドでは1本目の「ごあいさつ」が32位付近に入っていた）。

## 検証

`hexo clean` 相当（`db.json` と `public/` を消す）からのコールドビルドを2回。生成 `.html` **全2,938枚**の md5 を突き合わせた。正規化するのは `site.css?v=` の内容ハッシュと、mtime 由来の `article:published_time` / `article:modified_time` の2つだけ（PR #3155 の検証と同じ）。

| 比較 | 結果 |
| --- | --- |
| **origin/main の A/A**（同一コード・2回） | **34枚が不一致** … 著者32枚 + `/categories/` + `/categories/DataScience/` |
| **本ブランチの A/A**（同一コード・2回） | **2,938枚すべて一致** |

`*-sitemap.xml` は URL の集合が main と同一であることも確認済み（並びだけが変わる）。

## 固定化で並びが変わったページ

今まで不定だったものが固定されるので、main と比べると差分は出る。本ブランチ（A）と main（C）のコールドビルドで **277枚**。

| ページ種 | 変わった枚数 |
| --- | --- |
| 著者ページ | 252 / 349 |
| カテゴリページ | 24 / 77（1ページ目の「よく使われるタグ」と、最終ページの「関連カテゴリ」） |
| ホーム | 1（`/articles/` の紛れ込みが1件消え、年間人気の畳みが「残りの24本」→「残りの23本」） |

`/doctor/` は今回のビルドでは差分ゼロだった（たまたま名前順に並んでいた）。入れた決着は再発防止として効く。

## 確認ポイント

- 著者ページ（例: `/authors/久保樹礼/`）… 「よく使うカテゴリ」の同数の並びが名前順になる
- カテゴリページ（例: `/categories/DataScience/`）… 「よく使われるタグ」の同数の並びが名前順になる
- ホーム（`/`）… 年間人気の一覧に「ごあいさつ」が出ていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)