### PR TITLE
モバイル幅で画面外に出ていた検索の虫眼鏡を帯の中に戻す

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -710,6 +710,9 @@ Header and header elements
 .header-utility {
   display: flex;
   align-items: center;
+  /* flex アイテムの既定 min-width: auto は中身の最小幅で止まるので、
+     .header-search の min-width: 0（縮む逃げ場）がここで殺される */
+  min-width: 0;
   /* ナビと検索の間。縦棒があった頃はこの gap が棒の左右それぞれに効いて
      24 + 1 + 24 = 49px 空いていたので、棒を外した (#2901) ぶんを足して保つ。
      992px 未満は下のブロックで1段に戻す（引き金と検索が隣り合うため） */
@@ -751,10 +754,11 @@ Header and header elements
    開閉はチェックボックスの :checked と兄弟結合子で作る。JS は使わない
    ——ランキングのタブ（.tabs input:checked + .tab_item）と同じ手 */
 @media (max-width: 991px) {
-  /* ここではナビが帯から降りるので、帯に並ぶのは引き金と検索の2つ。
-     縦棒はもともと出していなかったので、間隔も元の1段のまま (#2901) */
+  /* ここではナビが帯から降りるので、帯に並ぶのは引き金・テーマ・検索の3つ。
+     間隔2つで 48px 使うと、サイト名 244px と合わせて幅 384px を切る画面から
+     検索が帯の外へ出る。3つとも 24px 角の的なので、間隔は半分でも隣と触れない */
   .header-utility {
-    gap: (space-step * 6);
+    gap: (space-step * 3);
   }
   /* 見えないがフォーカスできる形 (#2852)。display: none にすると Space で
      開閉できなくなり、代わりに label へ tabindex を付けると今度は発火しない */
@@ -5091,6 +5095,25 @@ a.award-badge:focus {
 .header-theme:hover,
 .header-theme:focus {
   color: var(--ink-strong);
+}
+/* 引き出しの中の2つ目 (#2746 の切り替えを 575px 以下でここへ降ろす)。
+   帯とは違って行として並ぶので、絵だけでなく名前を横に出す */
+.header-theme-drawer {
+  display: none;
+  align-items: center;
+  gap: (space-step * 2);
+  padding: (space-step * 3) (space-step * 4);
+}
+.header-theme-drawer .header-nav-label {
+  margin: 0;
+}
+@media (max-width: 575px) {
+  .header-theme-drawer {
+    display: flex;
+  }
+  .header-utility > .header-theme {
+    display: none;
+  }
 }
 /* 3つの状態のうち1つだけを出す。**出し分けは CSS が持つ**ので、描画時に JS を待たない。
    読み上げ名も同じ規則で切り替わる（各 span が sr-only の名前を連れている） */

--- a/themes/future/layout/_partial/header.ejs
+++ b/themes/future/layout/_partial/header.ejs
@@ -135,29 +135,29 @@
 						</div>
 					</li>
 				</ul>
+				<%# 575px 以下では帯からここへ降りる。帯に ロゴ+サイト名(244px)・引き金・
+				    テーマ・虫眼鏡 を並べると 398px 要り、360px 級の画面で虫眼鏡が
+				    帯の外へ出る。一度決めたら触らない設定なので、常時出す側から外した %>
+				<div class="header-theme-drawer">
+					<p class="header-nav-label">表示テーマ</p>
+					<%- partial('theme-toggle') %>
+				</div>
 			</nav>
 
 			<%# サイト内検索 (#2399)。全ページで使えるようサイドバーから昇格した。
 			    素の CSE フォームなので JS は増えない。
 			    狭い幅では虫眼鏡だけ出し、label タップで入力欄にフォーカスして
 			    :focus-within で展開する（CSSのみ）。送信はキーボードの検索キーが担う %>
-			<%# 明暗の切り替え (#2746)。状態は3つ（システム追従 / 明 / 暗）。2値にすると
-			    「OS は暗いがこのサイトは明るく読みたい」と、そこから戻る道が表せない。
-			    **どの絵とどの読み上げ名を出すかは CSS が :root[data-theme] を見て決める**ので、
-			    JS は head の属性付与とこのボタンのクリックだけ。描画時に JS を待たない %>
-			<button type="button" class="header-theme" data-theme-toggle>
-				<span class="header-theme-auto"><%- partial('svg-icon', {icon: 'device-desktop'}) %><span class="sr-only">表示テーマ: 端末の設定に従う。切り替える</span></span>
-				<span class="header-theme-light"><%- partial('svg-icon', {icon: 'sun'}) %><span class="sr-only">表示テーマ: 明るい。切り替える</span></span>
-				<span class="header-theme-dark"><%- partial('svg-icon', {icon: 'moon'}) %><span class="sr-only">表示テーマ: 暗い。切り替える</span></span>
-			</button>
+			<%- partial('theme-toggle') %>
 			<script>
 				// 押すたびに システム追従 → 明 → 暗 → システム追従 と回す。
 				// 絵と読み上げ名の出し分けは CSS が :root[data-theme] を見て行うので、
 				// ここでやるのは属性と localStorage の書き換えだけ
 				(function () {
-					var el = document.querySelector('[data-theme-toggle]');
-					if (!el) return;
+					// 帯と引き出しの2つある。表示されているのは常に片方だが、
+					// どちらが出ているかは CSS が幅で決めるので両方に付ける
 					var order = ['', 'light', 'dark'];
+					document.querySelectorAll('[data-theme-toggle]').forEach(function (el) {
 					el.addEventListener('click', function () {
 						var now = document.documentElement.dataset.theme || '';
 						var next = order[(order.indexOf(now) + 1) % order.length];
@@ -169,6 +169,7 @@
 						} catch (e) {}
 						// グラフは CSS 変数を読めないので、切り替えを知らせて描き直させる
 						document.dispatchEvent(new CustomEvent('themechange'));
+					});
 					});
 				})();
 			</script>

--- a/themes/future/layout/_partial/theme-toggle.ejs
+++ b/themes/future/layout/_partial/theme-toggle.ejs
@@ -1,0 +1,11 @@
+<%# 明暗の切り替え (#2746)。状態は3つ（システム追従 / 明 / 暗）。2値にすると
+    「OS は暗いがこのサイトは明るく読みたい」と、そこから戻る道が表せない。
+    **どの絵とどの読み上げ名を出すかは CSS が :root[data-theme] を見て決める**ので、
+    JS は head の属性付与とこのボタンのクリックだけ。描画時に JS を待たない。
+    帯と引き出しの2箇所から呼ぶ。片方は幅で display: none になるので、
+    読み上げに出るのは常に1つ %>
+<button type="button" class="header-theme" data-theme-toggle>
+	<span class="header-theme-auto"><%- partial('svg-icon', {icon: 'device-desktop'}) %><span class="sr-only">表示テーマ: 端末の設定に従う。切り替える</span></span>
+	<span class="header-theme-light"><%- partial('svg-icon', {icon: 'sun'}) %><span class="sr-only">表示テーマ: 明るい。切り替える</span></span>
+	<span class="header-theme-dark"><%- partial('svg-icon', {icon: 'moon'}) %><span class="sr-only">表示テーマ: 暗い。切り替える</span></span>
+</button>


### PR DESCRIPTION
## 何が起きていたか

サイト内検索の虫眼鏡が、3つの幅の帯で画面の外に落ちて押せませんでした。`overflow` で切られるので横スクロールでも届かず、**到達不能**でした。

| 幅 | はみ出し量 |
| --- | --- |
| 320〜386px | 最大 92px |
| 576〜688px | 最大 58px |
| 992〜1088px | 最大 49px |

iPhone SE / 12 mini (375)・iPhone 12〜15 (390)・Galaxy (360)・iPad landscape (1024) が全部この中に入ります。1,483本の記事が新着25本とカテゴリ経由でしか辿れない状態でした。

## 原因

`.header-search` には「帯が詰まったときに縮むのはここ」というコメント付きで `min-width: 0` が入っていますが、親の `.header-utility` が flex アイテムの既定 `min-width: auto` のままだったので、そこで縮小が止まっていました。意図された逃げ場が効いていなかった形です。

さらに虫眼鏡（`.header-search-open`、28px）は `overflow: visible` で縮んだフォームの箱の外に出るため、箱が画面内に収まっていても虫眼鏡だけが外に残っていました。

## 直し方

1. `.header-utility` に `min-width: 0` を足して、縮小が `.header-search` まで届くようにした
2. 992px 未満のユーティリティ間隔を 24 → 12px（`space-step * 3`）
3. **575px 以下ではテーマ切替を引き出しの中へ降ろした**

3 が要るのは、帯に並ぶ幅が足りないためです。`左右24 + ロゴとサイト名244 + 帯gap16 + 引き金28 + 間隔g + テーマ34 + 間隔g + 虫眼鏡28 = 374 + 2g` で、`g=12` なら 398px 必要になります。360px 級に収めるにはサイト名（156px）かテーマ切替（34px＋間隔）のどちらかを降ろすしかなく、**サイト名は初見の読者に何のサイトかを伝える唯一の要素**なので、一度決めたら触らないテーマ切替の側を外しました。

ボタンの markup は `_partial/theme-toggle.ejs` が1箇所で持ち、帯と引き出しの2箇所から呼びます。片方は幅で `display: none` になるので、読み上げに出るのは常に1つです。

## 確認

虫眼鏡の右端を基準に **320〜1400px を 2px 刻みで走査**しました。

| | 押せる下限 |
| --- | --- |
| 修正前 | 388px |
| 修正後 | **342px** |

- 360 / 375 / 390 / 576 / 768 / 992 / 1280px で、帯と引き出しのどちらにテーマ切替が出るかを実測（575px を境に入れ替わる）
- 375px で引き出しを開いてテーマ切替を実行し、`なし → light → dark` と回ることを確認
- `make lint-css` 通過。`site-audit` を再実行してエラー0・警告5（変更前と同数）。375px の本文までのタブ停止が 17 → 16 に減少

🤖 Generated with [Claude Code](https://claude.com/claude-code)