### PR TITLE
一覧のカードに著者名を出す

### DIFF
--- a/themes/future/layout/_partial/archive-post.ejs
+++ b/themes/future/layout/_partial/archive-post.ejs
@@ -29,6 +29,11 @@
     <% const cat = post.categories && post.categories.length ? post.categories.toArray()[0] : null; %>
     <ul class="blog-info">
       <li class="blog-info-item"><%- partial('post/date', {class_name: 'archive-article-date', date_format: 'YYYY.MM.DD'}) %></li>
+      <%# 著者ページでは全カードが同じ名前になるので出さない。下のカテゴリと同じ
+          「その一覧がまだ絞り込んでいない軸を出す」 (#2792) %>
+      <% if (!page.author) { %>
+      <%- post_author_link(post) %>
+      <% } %>
       <%# 出すのは、その一覧がまだ絞り込んでいない軸。カテゴリ一覧
           （/categories/<名>/ と「◯以外」）では全カードが同じ名前になるので、
           記事どうしの違いが出るタグを従来どおり出す %>


### PR DESCRIPTION
## 何が足りなかったか

一覧カードのメタ行は **日付＋カテゴリ**だけで、著者に触れる経路は「記事を開く」か「`/authors/` から入る」の2つしかありませんでした。読者が最も長く見る画面に、329人の書き手が一度も出てきません。

「この記事を書いた人の他の記事も読みたい」を一覧から始められないのが実害です。

## 直し方

`post_author_link` ヘルパーは既にあるので、`_partial/archive-post.ejs` の `blog-info` に1行足すだけです。

並びは **日付 → 著者 → カテゴリ** で、記事ヘッダーのメタ行と同じ順にしました。

**著者ページでは出しません。** 全カードが同じ名前になるので、カテゴリページでカテゴリの代わりにタグを出しているのと同じ判断です（#2792 の「その一覧がまだ絞り込んでいない軸を出す」）。

| ページ | 著者を出すか |
| --- | --- |
| ホーム / カテゴリ個別 / タグ個別 / 月アーカイブ | 出す |
| 著者個別 | 出さない |
| `/articles/` ・年アーカイブ | 対象外（カードではなくテキストの一覧） |

## 確認

- **折り返しゼロ。** メタ行は 221px → **302px**（+80px）で、幅 360 / 375 / 768 / 1280 の**25枚すべてで行の高さが変わらない**（使える幅は375pxで351px）
- 著者名329人のうち **325人（98.8%）が4文字以下**。はみ出しうるのは `kazuma-takeuchi` など**4人だけ**で、そのときメタ行が2行になるのは記事ヘッダーが767px以下で既に取っている形と同じ
- ページ種ごとの出し分けを実測（ホーム25 / カテゴリ25 / タグ25 / 月19 / 著者0 / `/articles/` 0）
- textlint 通過。`site-audit` でエラー0・警告5（変更前と同数）

一覧1ページあたりタブ停止が25増えます。行き先が増えたぶんなので意図どおりです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)