### PR TITLE
og:image の候補から AVIF を外す (#3175)

### DIFF
--- a/themes/future/layout/_partial/head.ejs
+++ b/themes/future/layout/_partial/head.ejs
@@ -135,7 +135,10 @@
         }
       })
     }
-    options['image'] = images.filter(path => !(path.endsWith(".svg"))).slice(0, 10);
+    // OGP のクローラが読めない形式は候補から外す (#3175)。X の card は
+    // JPG / PNG / WebP / GIF、Facebook は JPG / PNG / GIF で、SVG と AVIF はどちらも入らない
+    const ogpUnsupportedExt = ['.svg', '.avif'];
+    options['image'] = images.filter(path => !ogpUnsupportedExt.some(ext => path.toLowerCase().endsWith(ext))).slice(0, 10);
     if (options['image'].length === 0) {
       options['image'] = '/ogp_techblog.jpg';
     }


### PR DESCRIPTION
#3175

## 変えたこと

`_partial/head.ejs` の `og:image` の候補から `.avif` を外した。除外する拡張子を `['.svg', '.avif']` の1箇所に持つ形にしている。

## 確認（worktree の hexo server と公開サイトの比較）

先頭画像が AVIF だった4記事と、`thumbnail.avif` を持つ記事が並ぶタグページ。

| ページ | 変更前（公開サイト） | 変更後 |
| --- | --- | --- |
| `/articles/20260423a/` | `top.avif` | `/ogp_techblog.jpg` にフォールバック |
| `/articles/20241210a/` | `export-demo.avif` | `usecase-1-share.png` |
| `/articles/20251001a/` | `新パーサー版文法追従コスト図.avif` | `再帰的なリスト構造を…の例.png` |
| `/articles/20260421b/` | `top.avif` | `Slackでチームに相談している様子.png` |
| `/tags/コーチング/` | `thumbnail.png` ＋ `thumbnail.avif` | `thumbnail.png` のみ |

`20260225a`（先頭が png）は変わらないことも確認した。json-ld の `image` は同じ配列の先頭を使うので一緒に AVIF でなくなっている。

**`20260423a` は記事の画像が AVIF 1枚だけなので、既定の OGP 画像にフォールバックする。** AVIF のカードが出ないことと引き換えなので、これは仕方ないものとして受け入れる。

## この PR の対象外

- 記事本文・一覧カードの画像は AVIF のまま。ブラウザは AVIF に対応済みで、困るのは OGP のクローラだけ
- 中身が AVIF で名前が `.png` のファイル（`source/images/2025/20250225a/arc.png`）は拡張子では拾えない。変換元の hexiita 側で直す（ma91n/hexiita#54）
