### PR TITLE
カテゴリ一覧のカードからタグを外す

### DIFF
--- a/themes/future/layout/_partial/archive-post.ejs
+++ b/themes/future/layout/_partial/archive-post.ejs
@@ -35,11 +35,8 @@
       <%- post_author_link(post) %>
       <% } %>
       <%# 出すのは、その一覧がまだ絞り込んでいない軸。カテゴリ一覧
-          （/categories/<名>/ と「◯以外」）では全カードが同じ名前になるので、
-          記事どうしの違いが出るタグを従来どおり出す %>
-      <% if (page.category) { %>
-      <li class="blog-info-item"><%- partial('post/tag') %></li>
-      <% } else if (cat) { %>
+          （/categories/<名>/ と「◯以外」）は全カードが同じ名前になるので何も出さない %>
+      <% if (!page.category && cat) { %>
       <li class="blog-info-item"><%- partial('post/category', {cat: cat}) %></li>
       <% } %>
     </ul>


### PR DESCRIPTION
## やったこと

`/categories/<名>/`（と「◯◯以外の記事」）の一覧カードから、タグのチップを外した。メタ行は日付と著者だけになる。

## なぜ

一覧カードがタグではなくカテゴリを出すようになったのは、**タグのチップがカード内でタイトルと重複する**ため（#2792）。カテゴリ一覧だけは「その一覧がまだ絞り込んでいない軸を出す」という理由でタグを残していたが、**重複の理由はカテゴリ一覧でも変わらない**ので辻褄が合っていなかった。

実測（1,484記事・チップ5,037個）:

| 重複の相手 | 割合 |
| --- | --- |
| タイトル | 37.3% |
| タイトル or lede | 46.5% |

タブ移動の手数も増えていた。`/categories/Programming/` の1ページ目でチップは **76個**（1件あたり中央値3個）で、そのぶんキーボードの読者が一覧を通り抜けるのに止まる回数が増える。

カテゴリを代わりに出すことはしない。カテゴリ一覧は全カードが同じ名前になるので、#2792 の「その一覧がまだ絞り込んでいない軸を出す」の裏返しでどちらも出さないのが答えになる。

## 確認

- `/categories/Programming/` の25枚すべてでチップが消え、メタ行が日付＋著者になる
- 残る `tag-list-link` はヘッダーの検索ヒントとページ下部の関連タグで、カードではない

🤖 Generated with [Claude Code](https://claude.com/claude-code)