### PR TITLE
引き出しを表示領域の高さに収め、表示テーマを先頭へ出す (#3197)

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -483,8 +483,10 @@ Header and header elements
    下線を引く相手も無い。所在はリンク全体に出る focus の輪郭が示す */
 
 /* 行き先の帯。畳んだ中身は :hover と :focus-within で開く。JS は使わない
-   ——検索窓のヒントパネル (#2791) と同じ形 */
-.header-nav {
+   ——検索窓のヒントパネル (#2791) と同じ形。
+   992px 以上ではこの器は nav を通すだけで、引き出しの箱になるのは下の
+   メディアクエリの中 (#3197) */
+.header-drawer-panel {
   flex-shrink: 0;
 }
 .header-nav-list {
@@ -754,6 +756,7 @@ Header and header elements
   left: 0;
   right: 0;
   height: 100vh;
+  height: 100dvh;
   background: var(--backdrop);
   backdrop-filter: blur(8px);
 }
@@ -829,7 +832,7 @@ Header and header elements
     outline: 2px solid var(--brand-navy);
     outline-offset: 2px;
   }
-  .header-nav {
+  .header-drawer-panel {
     display: none;
   }
   /* 開いた引き出しは帯の下に敷く。帯の高さを押し広げないように絶対配置で、
@@ -837,14 +840,21 @@ Header and header elements
   .site-header:has(.header-drawer-input:checked) .header-backdrop {
     display: block;
   }
-  .header-drawer-input:checked ~ .header-nav {
+  .header-drawer-input:checked ~ .header-drawer-panel {
     display: block;
     position: absolute;
     top: 100%;
     left: 0;
     right: 0;
+    /* 高さの基準は dvh (#3197)。100vh はモバイルでは URL バーを畳んだときの高さ
+       （大ビューポート）なので、箱の下端が見えている範囲より 60〜115px 下に出る。
+       中身は約1,640px あって中で送れてしまうため、送り切っても最後の行が
+       画面の外に残る。vh の行は dvh を持たないブラウザ向けの控え */
     max-height: unquote('calc(100vh - ' + header-height + ')');
+    max-height: unquote('calc(100dvh - ' + header-height + ')');
     overflow-y: auto;
+    /* 送り切ったぶんを本文へ渡さない。渡すと追従しないヘッダーごと上へ抜ける */
+    overscroll-behavior: contain;
     padding: (space-step * 2) 0 (space-step * 4);
     background: var(--surface-base);
     border-bottom: 1px solid var(--rule-base);

--- a/themes/future/layout/_partial/header.ejs
+++ b/themes/future/layout/_partial/header.ejs
@@ -50,99 +50,104 @@
 			    引き出し（1024px 以下）ではパネルを常に並べるので、引き金は畳みの引き金ではなく
 			    組のラベルになる。summary を使い回すと open が false のまま中身が見えている
 			    状態になり、支援技術に「折りたたみ（閉）」と読まれる。幅ごとに要素を出し分ける %>
-			<nav class="header-nav" aria-label="サイト内の行き先">
-				<ul class="header-nav-list">
-					<%# カテゴリと連載は行き先そのものを畳む。
-					    カテゴリは /categories/ と同じ全件を、同じ群・同じ並びで出す（#2908。
-					    群と並びは category_groups が1箇所で持つ）。
-					    全件なので「一部だけ」を名乗るラベルは置かない。
-					    /categories/ へも送らない。あの一覧は運営用で、読者向けには作っていない %>
-
-					<li class="header-nav-item">
-						<details class="header-nav-disclosure">
-							<summary class="header-nav-trigger">カテゴリ<%- partial('svg-icon', {icon: 'chevron-down', class_name: 'svg-icon-trailing header-nav-caret'}).trim() %></summary>
-						</details>
-						<p class="header-nav-label">カテゴリ</p>
-						<div class="header-dropdown header-dropdown-grid">
-							<% category_groups().forEach(function(g){ %>
-							<div class="header-dropdown-group">
-								<p class="category-group-label"><%= g.name %></p>
-								<% g.categories.forEach(function(c){ %>
-								<a class="header-dropdown-item" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事 累計<%= c.count %>本（直近1年 <%= c.recent %>本）">
-									<span class="header-dropdown-row"><%- partial('category-icon', {name: c.name}) %><%= c.name %><span class="header-dropdown-count"><%= c.count %></span></span>
-								</a>
-								<% }) %>
-							</div>
-							<% }) %>
-						</div>
-					</li>
-					<li class="header-nav-item">
-						<details class="header-nav-disclosure">
-							<summary class="header-nav-trigger">連載<%- partial('svg-icon', {icon: 'chevron-down', class_name: 'svg-icon-trailing header-nav-caret'}).trim() %></summary>
-						</details>
-						<p class="header-nav-label">連載</p>
-						<div class="header-dropdown">
-							<%# 連載の行き先は索引記事（/series/ の一覧と同じ規則）。物差しはランキング記事と
-							    同じ経過年ペナルティ（#2855 の直近1年の窓から変更）。カテゴリと違って
-							    一覧ページが読者向けにあるので、最後に全件への導線を置く %>
-							<p class="header-dropdown-label"><%- partial('svg-icon', {icon: 'run-baton'}) %>人気の連載</p>
-							<% popular_series(6).forEach(function(s){ %>
-							<a class="header-dropdown-item" href="<%- url_for(s.path) %>" title="<%= s.name %> 連載 全<%= s.total %>本・累計 <%= s.pv.toLocaleString() %> View">
-								<span class="header-dropdown-row"><%= s.name %></span>
-							</a>
-							<% }) %>
-							<a class="header-dropdown-more" href="/series/">連載一覧へ</a>
-						</div>
-					</li>
-					<li class="header-nav-item">
-						<details class="header-nav-disclosure">
-							<summary class="header-nav-trigger">リソース<%- partial('svg-icon', {icon: 'chevron-down', class_name: 'svg-icon-trailing header-nav-caret'}).trim() %></summary>
-						</details>
-						<p class="header-nav-label">リソース</p>
-						<div class="header-dropdown">
-							<a class="header-dropdown-item" href="/specials/guidelines/">
-								<span class="header-dropdown-name">フューチャーのガイドライン</span>
-								<span class="header-dropdown-desc">設計ガイドライン・コーディング規約</span>
-							</a>
-							<a class="header-dropdown-item" href="https://future-architect.github.io/typescript-guide/" target="_blank" rel="noopener">
-								<span class="header-dropdown-name">仕事ですぐに使えるTypeScript<span class="sr-only">（外部サイト）</span><%- partial('svg-icon', {icon: 'external-link', class_name: 'svg-icon-trailing'}).trim() %></span>
-								<span class="header-dropdown-desc">実務向けの実践テキスト</span>
-							</a>
-							<a class="header-dropdown-item" href="https://github.com/future-architect" target="_blank" rel="noopener">
-								<span class="header-dropdown-name">OSS / ツール<span class="sr-only">（外部サイト）</span><%- partial('svg-icon', {icon: 'external-link', class_name: 'svg-icon-trailing'}).trim() %></span>
-								<span class="header-dropdown-desc">Cheetah Grid / uroboroSQL / Vuls</span>
-							</a>
-						</div>
-					</li>
-					<li class="header-nav-item">
-						<details class="header-nav-disclosure">
-							<summary class="header-nav-trigger">アクティビティ<%- partial('svg-icon', {icon: 'chevron-down', class_name: 'svg-icon-trailing header-nav-caret'}).trim() %></summary>
-						</details>
-						<p class="header-nav-label">アクティビティ</p>
-						<div class="header-dropdown">
-							<a class="header-dropdown-item" href="/specials/httf/">
-								<span class="header-dropdown-name">HACK TO THE FUTURE</span>
-								<span class="header-dropdown-desc">フューチャー主催のプログラミングコンテスト</span>
-							</a>
-							<a class="header-dropdown-item" href="/specials/techcast/">
-								<span class="header-dropdown-name">Future Tech Cast</span>
-								<span class="header-dropdown-desc">技術ブログ発のポッドキャスト</span>
-							</a>
-							<a class="header-dropdown-item" href="/specials/advent-calendar/">
-								<span class="header-dropdown-name">アドベントカレンダー</span>
-								<span class="header-dropdown-desc">2015年からの歴代一覧</span>
-							</a>
-						</div>
-					</li>
-				</ul>
+			<%# 引き出しの器 (#3197)。992px 以上では nav をそのまま通すだけの箱。
+			    表示テーマは行き先ではないので nav の外に置く %>
+			<div class="header-drawer-panel">
 				<%# 575px 以下では帯からここへ降りる。帯に ロゴ+サイト名(244px)・引き金・
-				    テーマ・虫眼鏡 を並べると 398px 要り、360px 級の画面で虫眼鏡が
-				    帯の外へ出る。一度決めたら触らない設定なので、常時出す側から外した %>
+				    テーマ・虫眼鏡 を並べると 398px 要り、360px 級の画面で虫眼鏡が帯の外へ出る。
+				    引き出しの先頭に置くのは、末尾だと中身1,640px の下敷きになって
+				    たどり着けないため (#3197) %>
 				<div class="header-theme-drawer">
 					<p class="header-nav-label">表示テーマ</p>
 					<%- partial('theme-toggle') %>
 				</div>
-			</nav>
+				<nav class="header-nav" aria-label="サイト内の行き先">
+					<ul class="header-nav-list">
+						<%# カテゴリと連載は行き先そのものを畳む。
+						    カテゴリは /categories/ と同じ全件を、同じ群・同じ並びで出す（#2908。
+						    群と並びは category_groups が1箇所で持つ）。
+						    全件なので「一部だけ」を名乗るラベルは置かない。
+						    /categories/ へも送らない。あの一覧は運営用で、読者向けには作っていない %>
+
+						<li class="header-nav-item">
+							<details class="header-nav-disclosure">
+								<summary class="header-nav-trigger">カテゴリ<%- partial('svg-icon', {icon: 'chevron-down', class_name: 'svg-icon-trailing header-nav-caret'}).trim() %></summary>
+							</details>
+							<p class="header-nav-label">カテゴリ</p>
+							<div class="header-dropdown header-dropdown-grid">
+								<% category_groups().forEach(function(g){ %>
+								<div class="header-dropdown-group">
+									<p class="category-group-label"><%= g.name %></p>
+									<% g.categories.forEach(function(c){ %>
+									<a class="header-dropdown-item" href="<%- url_for(c.path) %>" title="<%= c.name %> カテゴリの記事 累計<%= c.count %>本（直近1年 <%= c.recent %>本）">
+										<span class="header-dropdown-row"><%- partial('category-icon', {name: c.name}) %><%= c.name %><span class="header-dropdown-count"><%= c.count %></span></span>
+									</a>
+									<% }) %>
+								</div>
+								<% }) %>
+							</div>
+						</li>
+						<li class="header-nav-item">
+							<details class="header-nav-disclosure">
+								<summary class="header-nav-trigger">連載<%- partial('svg-icon', {icon: 'chevron-down', class_name: 'svg-icon-trailing header-nav-caret'}).trim() %></summary>
+							</details>
+							<p class="header-nav-label">連載</p>
+							<div class="header-dropdown">
+								<%# 連載の行き先は索引記事（/series/ の一覧と同じ規則）。物差しはランキング記事と
+								    同じ経過年ペナルティ（#2855 の直近1年の窓から変更）。カテゴリと違って
+								    一覧ページが読者向けにあるので、最後に全件への導線を置く %>
+								<p class="header-dropdown-label"><%- partial('svg-icon', {icon: 'run-baton'}) %>人気の連載</p>
+								<% popular_series(6).forEach(function(s){ %>
+								<a class="header-dropdown-item" href="<%- url_for(s.path) %>" title="<%= s.name %> 連載 全<%= s.total %>本・累計 <%= s.pv.toLocaleString() %> View">
+									<span class="header-dropdown-row"><%= s.name %></span>
+								</a>
+								<% }) %>
+								<a class="header-dropdown-more" href="/series/">連載一覧へ</a>
+							</div>
+						</li>
+						<li class="header-nav-item">
+							<details class="header-nav-disclosure">
+								<summary class="header-nav-trigger">リソース<%- partial('svg-icon', {icon: 'chevron-down', class_name: 'svg-icon-trailing header-nav-caret'}).trim() %></summary>
+							</details>
+							<p class="header-nav-label">リソース</p>
+							<div class="header-dropdown">
+								<a class="header-dropdown-item" href="/specials/guidelines/">
+									<span class="header-dropdown-name">フューチャーのガイドライン</span>
+									<span class="header-dropdown-desc">設計ガイドライン・コーディング規約</span>
+								</a>
+								<a class="header-dropdown-item" href="https://future-architect.github.io/typescript-guide/" target="_blank" rel="noopener">
+									<span class="header-dropdown-name">仕事ですぐに使えるTypeScript<span class="sr-only">（外部サイト）</span><%- partial('svg-icon', {icon: 'external-link', class_name: 'svg-icon-trailing'}).trim() %></span>
+									<span class="header-dropdown-desc">実務向けの実践テキスト</span>
+								</a>
+								<a class="header-dropdown-item" href="https://github.com/future-architect" target="_blank" rel="noopener">
+									<span class="header-dropdown-name">OSS / ツール<span class="sr-only">（外部サイト）</span><%- partial('svg-icon', {icon: 'external-link', class_name: 'svg-icon-trailing'}).trim() %></span>
+									<span class="header-dropdown-desc">Cheetah Grid / uroboroSQL / Vuls</span>
+								</a>
+							</div>
+						</li>
+						<li class="header-nav-item">
+							<details class="header-nav-disclosure">
+								<summary class="header-nav-trigger">アクティビティ<%- partial('svg-icon', {icon: 'chevron-down', class_name: 'svg-icon-trailing header-nav-caret'}).trim() %></summary>
+							</details>
+							<p class="header-nav-label">アクティビティ</p>
+							<div class="header-dropdown">
+								<a class="header-dropdown-item" href="/specials/httf/">
+									<span class="header-dropdown-name">HACK TO THE FUTURE</span>
+									<span class="header-dropdown-desc">フューチャー主催のプログラミングコンテスト</span>
+								</a>
+								<a class="header-dropdown-item" href="/specials/techcast/">
+									<span class="header-dropdown-name">Future Tech Cast</span>
+									<span class="header-dropdown-desc">技術ブログ発のポッドキャスト</span>
+								</a>
+								<a class="header-dropdown-item" href="/specials/advent-calendar/">
+									<span class="header-dropdown-name">アドベントカレンダー</span>
+									<span class="header-dropdown-desc">2015年からの歴代一覧</span>
+								</a>
+							</div>
+						</li>
+					</ul>
+				</nav>
+			</div>
 
 			<%# サイト内検索 (#2399)。全ページで使えるようサイドバーから昇格した。
 			    素の CSE フォームなので JS は増えない。


### PR DESCRIPTION
Closes #3197

## 1. なぜ引っかかったか

引き出しの高さが `calc(100vh - 64px)` だったため。

**モバイルの `100vh` は URL バーを畳んだときの高さ（大ビューポート）** で、URL バーが出ている間の表示領域より 60〜115px 大きい。引き出しは絶対配置で帯の下端から敷くので、**箱の下端がそのぶん画面の外にある**。

引き出しの中身は 375px 幅で **約1,640px** あって箱に収まらないので中で送れるが、送り切ってもいちばん下の行は画面の外に残る。ここで止まるのが「引っかかる」で、そこから先はスクロールが本文へ渡って（`overscroll-behavior` を持っていなかった）ページごと上へ動き、隠れていた下端が見えるようになる。これが「さらにスクロールすればダークモードが見つかる」の正体。

中身の内訳（375px・1列）:

| 組 | 高さ |
| --- | --- |
| カテゴリ（5群・18件） | 831px |
| 連載（6件＋一覧へ） | 327px |
| リソース（3件） | 209px |
| アクティビティ（3件） | 209px |
| 表示テーマ | 44px |
| 器の余白 | 24px |
| **合計** | **約1,640px** |

### 直したこと

- 引き出しの `max-height` と、背後のぼかしの面の `height` を **`dvh` 基準**にした（`vh` の行を控えに残す）。`.wrap` の `min-height` が既に同じ形（`100vh` → `100dvh`）
- **`overscroll-behavior: contain`** を足して、送り切ったぶんを本文へ渡さないようにした。渡すと、追従しないヘッダー（#2877）ごと画面の外へ抜ける

## 2. 表示テーマを先頭へ

引き出しの末尾（アクティビティの後ろ）から**先頭**へ移した。1,640px の下敷きになる場所に置くものではない。

**行き先ではないので `<nav aria-label="サイト内の行き先">` の外に出した。** そのままだと、ランドマークで移動する読者が「行き先」と名乗る領域の1つ目で設定に当たる。引き出しの器として `.header-drawer-panel` を1枚挟み、その中に「表示テーマ」→ `<nav>` の順で並べる。

```
.header-drawer-panel      ← 992px 未満で引き出しの箱になる。以上では nav を通すだけ
├─ .header-theme-drawer   ← 575px 以下だけ表示
└─ nav.header-nav
```

- `flex-shrink: 0` と、992px 未満の `display: none` / 開いたときの箱の指定を `.header-nav` から `.header-drawer-panel` へ移した
- 出るのは **575px 以下だけ**（帯にテーマを置けない幅）。576〜991px ではテーマは帯にあるので、引き出しの見た目は変わらない

## 確認したこと

- `make lint-css`（`css_lint.mjs` 3検査・`font_size_lint.mjs`）— いずれも指摘なし
- `textlint` — `themes/future/layout/_partial/header.ejs` 0件
- ローカルサーバの配信 HTML で `.header-drawer-panel > .header-theme-drawer + nav.header-nav > ul` の入れ子と、帯側のテーマボタンが従来どおり `.header-utility` 直下に残ることを確認
- 生成 CSS に `max-height: calc(100vh - 64px)` → `calc(100dvh - 64px)` の2行と `overscroll-behavior: contain` が出ることを確認

## 範囲外

#3198（引き出しの外を押して閉じる）は PR #3201。同じ引き出しだが、触る行は重ならない。