### PR TITLE
SNS キャッシュ更新の push が main の進行で弾かれるのを直す

### DIFF
--- a/.github/workflows/update-cache.yml
+++ b/.github/workflows/update-cache.yml
@@ -52,13 +52,22 @@ jobs:
       - name: Update GitHub followers
         run: node update_follower_counts.mjs
 
+      # 取得に10分近くかかるので、その間に main が進んで push が弾かれる。
+      # 触るのは生成物の4ファイルだけなので、取り込み直して積み直す
       - name: Commit and push
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add sns_count_cache.json ga_cache.json ga4_pv.json source/_data/follower_counts.yml
           git commit -m "Update SNS counts cache"
-          git push origin HEAD
+          for i in 1 2 3; do
+            git fetch origin main
+            # 衝突するのは人が同じファイルを触ったときだけなので、その場合は止めて気づけるようにする
+            git rebase origin/main || { git rebase --abort; exit 1; }
+            if git push origin HEAD:main; then exit 0; fi
+            sleep 5
+          done
+          exit 1
 
       - name: Trigger Deploy Workflow
         uses: actions/github-script@v7

--- a/.github/workflows/update-cache.yml
+++ b/.github/workflows/update-cache.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Update GitHub followers
         run: node update_follower_counts.mjs
 
-      # 取得に10分近くかかるので、その間に main が進んで push が弾かれる。
+      # 取得に10分近くかかるので、その間に main が進んで push が弾かれる (#3204)。
       # 触るのは生成物の4ファイルだけなので、取り込み直して積み直す
       - name: Commit and push
         run: |


### PR DESCRIPTION
## 何が起きていたか

日次の `update-cache.yml` が push で落ちた（[run 33708642628](https://github.com/future-architect/future-architect.github.io/actions/runs/33708642628/job/100503203803)）。

```
 ! [rejected]        HEAD -> main (fetch first)
error: failed to push some refs
```

ジョブは 02:42 に checkout して 02:50 に push する（Go ツールの `go install` と SNS / GA の取得で8分前後）。その間に PR がマージされると、checkout 時点のコミットの上に積んだコミットは fast-forward にならず弾かれる。キャッシュが更新されず、続く deploy のトリガーも飛ばない。

## 直し方

push の直前に `git fetch` → `git rebase origin/main` して積み直す。fetch と push の間にさらに割り込まれることもあるので3回まで繰り返す。

触るのは生成物の4ファイル（`sns_count_cache.json` / `ga_cache.json` / `ga4_pv.json` / `source/_data/follower_counts.yml`）だけで、これらを書くのはこのワークフローだけなので、通常は衝突しない。**衝突したときは `--abort` して落とす**——`-X theirs` で押し通すと、`follower_counts.yml` の X のフォロワー数（API が有料なので手打ち #2841）を人が直した分を黙って上書きすることになる。

## 確認

一時リポジトリで、`actions/checkout@v4` と同じ shallow clone（`--depth=1`、`is-shallow-repository: true`）に対して4通り走らせた。

| 状況 | 結果 |
| --- | --- |
| fetch 前に main が進む | 1回目で push 成功。相手のコミットの上に積まれる |
| fetch と push の間にさらに進む | 2回目で push 成功 |
| 同じファイルを人が触る（別の行） | rebase がマージして push 成功 |
| 同じファイルの同じ行を人が触る | `rebase --abort` して exit 1（ステップが落ちる） |

shallow でも rebase できるのは、main が checkout したコミットから進んでいるだけなので、マージベース（＝checkout したコミット）が手元にあるため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)