### PR TITLE
オントロジーに6件の親子を足す (#3205)

### DIFF
--- a/source/_data/tag_ontology.yml
+++ b/source/_data/tag_ontology.yml
@@ -46,6 +46,8 @@
   broader: [イベント]
 学会:
   broader: [イベント]
+YANS:
+  broader: [NLP, 学会]
 展示会:
   broader: [イベント]
 TechNight:
@@ -79,8 +81,12 @@ CloudEndure:
   broader: [AWS]
 Session-Manager:
   broader: [AWS]
+SAM:
+  broader: [AWS, サーバーレス]
 GoogleCloud:
   broader: []
+GoogleCloudNext:
+  broader: [GoogleCloud, イベント]
 BigQuery:
   broader: [GoogleCloud]
 GKE:
@@ -197,6 +203,8 @@ daisyUI:
   broader: [TailwindCSS]
 Vue.js:
   broader: [JavaScript]
+VueFes:
+  broader: [Vue.js, イベント]
 Vuetify:
   broader: [Vue.js]
 React:
@@ -371,8 +379,12 @@ LLM:
   broader: [生成AI]
 RAG:
   broader: [生成AI]
+DeepResearch:
+  broader: [生成AI]
 AIエージェント:
   broader: [生成AI]
+ADK:
+  broader: [AIエージェント]
 Claude:
   broader: [LLM]
 Gemini:


### PR DESCRIPTION
#3205 の1レーン目（未登録のタグから親を持てるものを拾う）。`/doctor/` の「オントロジーへの追加提案」に出ていた候補から6件を登録しました。

## 足した辺

| 子 | 親 | 判断 |
| --- | --- | --- |
| `SAM`(2) | `[AWS, サーバーレス]` | 提供元＋種別の2軸（#2292 の規則②）。**`Lambda` にはしない**——Lambda は AWS の兄弟のサービスで種別ではなく、「SAM は Lambda の一種」は成り立たない（SAM はサーバーレスを定義する枠組み）。既存の `Lambda ⊆ [AWS, サーバーレス]` と同じ流儀 |
| `GoogleCloudNext`(8) | `[GoogleCloud, イベント]` | 同上。`イベント` には `TechNight`（自社のイベント名）の前例がある |
| `VueFes`(2) | `[Vue.js, イベント]` | 同上 |
| `YANS`(4) | `[NLP, 学会]` | 種別は `学会`。`イベント` は `学会` の親なので**祖先で届くぶんは書かない**（規則②） |
| `ADK`(2) | `[AIエージェント]` | Google の Agent Development Kit。提供元の軸は取らない——OSS で GoogleCloud のサービスではない |
| `DeepResearch`(2) | `[生成AI]` | |

## 足さなかったもの

**`GoogleCloudNext2025 ⊆ GoogleCloud` は書きません。** `GoogleCloudNext2025` は名前規則で `GoogleCloudNext` に吸収される版タグ（`scripts/version_tags.js`）で、`GoogleCloudNext` の8本には2025の3本が既に含まれています。登録すると `/tags/` の GoogleCloud の群に **`GoogleCloudNext 8` と `GoogleCloudNext2025 3` が兄弟として並びます**。#2292 の「機械導出できる関係（`Go1.xx` 兄弟）は書かない」にも当たります。

`/doctor/` の提案に出るのは、あの節が「yml に未登録」を機械的に見ているためで、版タグは登録しなくてよいものです。

## 確認したこと

- `node .claude/skills/tag-maintenance/check.mjs` — **エラー 0**。ノード 225 → 231
- 配信 HTML（`/tags/#tagforest`）で6件すべてが描かれ、2親のものが2箇所に出ることを確認。群の中身も実測

| 群 | 中身（抜粋） |
| --- | --- |
| イベント | 登壇レポート88 参加レポート44 TechNight33 … **GoogleCloudNext8 VueFes2** ／ 学会19 → **YANS4** |
| AWS | Lambda29 S316 Glue13 LocalStack11 RDS4 Athena2 CloudEndure2 **SAM2** Session-Manager2 ／ DynamoDB22 → DynamoDBStreams2 |
| サーバーレス | Lambda29 CloudRun6 CloudFunctions3 **SAM2** |
| AI | 生成AI27 → **DeepResearch2** RAG2 ／ LLM24 → Claude18 Gemini14 ／ AIエージェント17 → **ADK2** ／ 機械学習45 → … NLP19 → **YANS4** |
| GoogleCloud | BigQuery17 **GoogleCloudNext8** GKE7 CloudRun6 CloudFunctions3 CloudSQL2 GCS2 |
| JavaScript | TypeScript25 Vite4 ／ Vue.js42 → Vuetify3 **VueFes2** ／ React23 → … |

## 範囲外

#3205 の残り3レーン（独立ノード43件の妥当性・「根＋子1つ」の木17本・`check.mjs` の統合候補25件）は別 PR にします。この PR は issue を閉じません。