### PR TITLE
浅い木を直す (#3205)

### DIFF
--- a/source/_data/tag_ontology.yml
+++ b/source/_data/tag_ontology.yml
@@ -164,6 +164,8 @@ pandas:
   broader: [Python]
 FastAPI:
   broader: [Python]
+Pipenv:
+  broader: [Python, パッケージ管理]
 Mypy:
   broader: [Python]
 Pyright:
@@ -195,6 +197,8 @@ Node.js:
   broader: [JavaScript]
 npm:
   broader: [Node.js, パッケージ管理]
+ESLint:
+  broader: [JavaScript, Linter]
 CSS:
   broader: []
 TailwindCSS:
@@ -433,6 +437,8 @@ Cypress:
   broader: [ドキュメント]
 Markdown:
   broader: []
+Markdownlint:
+  broader: [Markdown, Linter]
 アジャイル:
   broader: []
 スクラム:
@@ -469,8 +475,12 @@ UI/UX:
   broader: []
 暗号:
   broader: [セキュリティ]
+脆弱性:
+  broader: [セキュリティ]
+WAF:
+  broader: [セキュリティ]
 Vuls:
-  broader: []
+  broader: [セキュリティ]
 FutureVuls:
   broader: [Vuls]
 認証認可:
@@ -493,10 +503,10 @@ IAM:
 # 新人向け / TechBlog は同義タグの統合（新人向け→初心者向け、TechBlog→運営）が
 # 別PRで進行中のため、ノードを持たない。統合前は整合性チェックが未登録として
 # 報告するが想定内
-資格:
-  broader: []
 合格記:
-  broader: [資格]
+  broader: []
+全冠:
+  broader: [合格記]
 インターン:
   broader: []
 業界ドメイン:


### PR DESCRIPTION
#3205 の3レーン目。「根＋子1つ」の木17本を見て、**壊れている4件だけ**直しました。残り13本は浅いだけで間違っていないので触っていません。

## ① 親がタグとして存在しない概念ノード（3件）

`/tags/` では**押せないラベルに子が1つぶら下がるだけ**になっていました。子を足して群として成立させます。

| 木 | before | after |
| --- | --- | --- |
| `パッケージ管理(0)` | `npm4` | `npm4` `Pipenv2` |
| `セキュリティ(0)` | `暗号11` | `暗号11` `脆弱性6` `WAF2` ／ `Vuls6` → `FutureVuls2` |
| `資格(0)` | `合格記41` | **ノードごと削除**（下記④） |

- `Pipenv ⊆ [Python, パッケージ管理]` — 提供元＋種別の2軸（#2292 の規則②）。既存の `npm ⊆ [Node.js, パッケージ管理]` と同じ形
- `脆弱性 ⊆ [セキュリティ]` `WAF ⊆ [セキュリティ]`
- **`Vuls` を根からセキュリティの下へ移した。** 脆弱性スキャナで、名前がセキュリティの外に指示対象を持たない（#2292 の規則①）。`Vuls → FutureVuls` の木がそのままセキュリティの中に入る

## ② 子のほうが本数が多い（1件）

`静的解析(9) → Linter(10)` は逆転して見えていました。`ESLint2` `Markdownlint2` を Linter の下に足して**3段**にすると、Linter が中間ノードとして意味を持ちます。

- `ESLint ⊆ [JavaScript, Linter]`
- `Markdownlint ⊆ [Markdown, Linter]` — `Markdown(11)` は独立ノードだったので、こちらにも子が付きます

## ③ 統合候補（1件）— 統合しない

`Vuls(6) → FutureVuls(2)`。FutureVuls は OSS の Vuls の SaaS版で、**使い分けを一文で説明できる**ので #2292 の基準では統合しません。親子のまま、上の①でセキュリティの下へ移しました。

## ④ `資格(0) → 合格記(41)`

**`資格` の概念ノードをやめ、`合格記` を根にしました。** `全冠(2)` をその子にします。

- `合格記` は「合格した」という**記事の種類**を表すタグで、`書評(42)` `失敗談(10)` `論文紹介(10)` `Tips(16)` と同じ性格。**それらは全部根**なので揃えました
- `資格` を残す場合は兄弟が要りますが、**資格名のタグは1本もありません**。合格記41本と一緒に付くのは `AWS(17)` `GoogleCloud(14)` `ネットワーク(4)` で、資格そのものではなく対象の技術です
- `全冠 ⊆ [合格記]` — 2本とも「Google Cloud 資格試験 全冠体験記」型で、合格記の一種

## 数字

| | before | after |
| --- | --- | --- |
| ノード | 231 | **236** |
| 木 | 41 | 41 |
| 「根＋子1つ」の木 | 17 | **14** |
| 独立ノード | 43 | **42**（Markdown が子を持った） |
| 0本の概念ノードで子が1つ | 3（パッケージ管理・セキュリティ・資格） | **0** |

木が41本のままなのは、`Markdown` と `合格記` が木になった（+2）ぶんを、`資格` の削除と `Vuls` の移動（-2）が相殺したため。

## 確認したこと

- `node .claude/skills/tag-maintenance/check.mjs` — **エラー 0**（ノード 236）。`資格` を消しても参照は残っていない
- 配信 HTML（`/tags/#tagforest`）で群の中身を実測

| 群 | 中身 |
| --- | --- |
| セキュリティ | `暗号11 脆弱性6 WAF2` ／ `Vuls6` → `FutureVuls2` |
| 静的解析 | `Linter10` → `ESLint2 Markdownlint2` |
| パッケージ管理 | `npm4 Pipenv2` |
| 合格記 | `41` → `全冠2` |
| Markdown | `11` → `Markdownlint2` |
| Python | `… FastAPI3 PyCharm3 Pyright3 Pipenv2 pytest2` |
| JavaScript | `TypeScript25 Vite4 ESLint2 ／ Vue.js42 → …` |

## 触らなかった13本

`Swift→SwiftUI` `CMS→HeadlessCMS` `GitLab→GitLab CI` `アルゴリズム→競技プログラミング` `チーム開発→コードレビュー` `ガイドライン→コーディング規約` `ドキュメント→テクニカルライティング` `アジャイル→スクラム` `運営→ベスブロ` `出版→SoftwareDesign` `VSCode→VSCode拡張` `GoogleWorkspace→GoogleChat` と、新しく2ノードになった `Markdown→Markdownlint` `合格記→全冠`。いずれも親がタグとして実在し、本数の逆転も無いので浅いままで正しい。

## 範囲外

#3205 の残り2レーン（未登録439件の続き・独立ノード42件の妥当性・`check.mjs` の統合候補25件）は別 PR にします。この PR は issue を閉じません。