### PR TITLE
検索ヒントのパネルに最近の検索を出す (#2931)

### DIFF
--- a/font_size_lint.mjs
+++ b/font_size_lint.mjs
@@ -42,7 +42,9 @@ const EXEMPT = new Map([
   ['.header-search:focus-within .header-search-close', '20px'],
   // 機能で決まる値。16px を下回ると iOS がフォーカス時に画面をズームする
   ['.header-search input', '16px'],
-  ['.header-search button', '16px'],
+  ['.header-search > button', '16px'],
+  // 1件ずつ消す ✕。押せる面の 24px の箱に収める絵の実寸 (#2931)
+  ['.header-search-recent-remove', '14px'],
   // 一点もの
   ['.page-404 .number', '128px'],
   // 行き先の名前に付く総数。行の主題は名前で、数字は選ぶ判断には効かない。

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -5567,12 +5567,16 @@ a.award-badge:focus {
   padding: 0;
   list-style: none;
 }
-/* 行として並ぶものなので反応は面 (#3162)。負のマージンは、面だけを左右へ
+.header-search-recent-list li {
+  display: flex;
+  align-items: center;
+}
+/* 行として並ぶものなので反応は面 (#3162)。負のマージンは、面だけを左へ
    広げて文字の左端をラベル・チップとそろえるため */
 .header-search-recent-item {
-  display: block;
-  width: unquote('calc(100% + ' + (space-step * 4) + ')');
-  margin: 0 (- space-step * 2);
+  flex: 1 1 auto;
+  min-width: 0;
+  margin-left: (- space-step * 2);
   padding: space-step (space-step * 2);
   background: none;
   border: 0;
@@ -5588,6 +5592,29 @@ a.award-badge:focus {
 }
 .header-search-recent-item:hover {
   background: var(--surface-mute);
+}
+/* 1件ずつ消す ✕ (#2931)。行き先ではないので面を持たず、色だけで反応する
+   （帯の中の他のアイコンだけのボタンと同じ）。24px は押せる面の下限 */
+.header-search-recent-remove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: none;
+  border: 0;
+  /* .svg-icon が 1em なので、これは文字ではなくアイコンの実寸。段の外 */
+  font-size: 14px;
+  color: var(--ink-mute);
+  cursor: pointer;
+}
+.header-search-recent-remove:hover {
+  color: var(--ink-strong);
+}
+.header-search-recent-remove .svg-icon {
+  margin-right: 0;
 }
 .reference-posts-item a {
   color: var(--ink-strong);

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -5363,7 +5363,9 @@ a.award-badge:focus {
 .header-search input::placeholder {
   color: var(--ink-faint);
 }
-.header-search button {
+/* フォーム自身の送信ボタン。子結合子で絞るのは、パネルの中のボタン
+   （最近の検索の行と「消す」#2931）まで当たるため */
+.header-search > button {
   display: flex;
   align-items: center;
   height: 32px;
@@ -5375,7 +5377,7 @@ a.award-badge:focus {
   background: none;
   border-radius: 0 radius-small radius-small 0;
 }
-.header-search button .svg-icon,
+.header-search > button .svg-icon,
 .header-search-open .svg-icon {
   margin-right: 0;
 }
@@ -5411,7 +5413,7 @@ a.award-badge:focus {
     opacity: 0;
     transition: width 0.15s ease, opacity 0.15s ease;
   }
-  .header-search button {
+  .header-search > button {
     display: none;
   }
   .site-header:has(.header-search:focus-within) .header-backdrop {

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -5533,6 +5533,60 @@ a.award-badge:focus {
   padding-left: 0;
   padding-right: 0;
 }
+/* 最近の検索 (#2931)。人気のタグより前に置く。履歴があるのは繰り返し検索する
+   読者だけで、その人がいま押した検索窓に対していちばん直接の入口になる */
+.header-search-recent {
+  margin-bottom: (space-step * 6);
+}
+.header-search-recent-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: (space-step * 2);
+}
+/* 面を持たない添えのリンクなので、反応は色と下線 (#2699)。padding は
+   押せる面を 24px 確保するためで、負のマージンで文字の右端を面の端にそろえる */
+.header-search-recent-clear {
+  margin: (- space-step) (- space-step) (- space-step) 0;
+  padding: space-step;
+  background: none;
+  border: 0;
+  font-size: text-meta;
+  line-height: leading-row;
+  font-weight: 400;
+  color: var(--ink-mute);
+}
+.header-search-recent-clear:hover {
+  color: var(--ink-strong);
+  text-decoration: underline;
+}
+.header-search-recent-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+/* 行として並ぶものなので反応は面 (#3162)。負のマージンは、面だけを左右へ
+   広げて文字の左端をラベル・チップとそろえるため */
+.header-search-recent-item {
+  display: block;
+  width: unquote('calc(100% + ' + (space-step * 4) + ')');
+  margin: 0 (- space-step * 2);
+  padding: space-step (space-step * 2);
+  background: none;
+  border: 0;
+  border-radius: radius-small;
+  font-size: text-base;
+  line-height: leading-row;
+  text-align: left;
+  color: var(--ink-strong);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: background-color hover-speed ease;
+}
+.header-search-recent-item:hover {
+  background: var(--surface-mute);
+}
 .reference-posts-item a {
   color: var(--ink-strong);
 }

--- a/themes/future/layout/_partial/search-hint.ejs
+++ b/themes/future/layout/_partial/search-hint.ejs
@@ -78,6 +78,12 @@
 			items.unshift(word);
 			write(items.slice(0, MAX));
 			render();
+			// 結果は別タブなのでこのタブの入力欄は残る。語を入れたままにすると
+			// :placeholder-shown が外れてパネルごと開かなくなる。同期で消すと
+			// q が空のまま送られるので、送信の後に空へ戻す
+			setTimeout(function () {
+				input.value = '';
+			}, 0);
 		});
 		box.querySelector('.header-search-recent-clear').addEventListener('click', function () {
 			write([]);

--- a/themes/future/layout/_partial/search-hint.ejs
+++ b/themes/future/layout/_partial/search-hint.ejs
@@ -7,6 +7,15 @@
     ここに3種類並べていた頃は、同じ行き先が2か所にあるうえ濃さとチップの形も
     揃っていなかった（#2871 / #2872）%>
 <div class="header-search-hint">
+	<%# 最近の検索 (#2931)。履歴は localStorage にしかないので、行は下のスクリプトが描く。
+	    キーワードはタグではないのでチップにしない（ピルはタグの印 #2892）%>
+	<div class="header-search-recent" hidden>
+		<p class="header-search-hint-label header-search-recent-label">
+			<span><%- partial('svg-icon', {icon: 'history'}) %>最近の検索</span>
+			<button type="button" class="header-search-recent-clear">消す</button>
+		</p>
+		<ul class="header-search-recent-list"></ul>
+	</div>
 	<p class="header-search-hint-label"><%- partial('svg-icon', {icon: 'tags'}) %>人気のタグ</p>
 	<%# /tags/ とサイドバーの「人気のタグ」と同じ部品・同じ見出し。検索窓の中なので「〜から探す」は書かない (#3083)。
 	    件数の右肩は .blog-tags が持つ %>
@@ -17,3 +26,66 @@
 	    「連載一覧へ」と同じ部品（.header-dropdown-more）。文言は全件導線の「◯◯一覧へ」(#2899) %>
 	<a class="header-dropdown-more header-search-hint-more" href="/tags/">タグ一覧へ</a>
 </div>
+
+<%# 検索したキーワードを localStorage に5件だけ持ち、次に検索窓を押したときに出す。
+    行は type="submit" のボタンで、押すと入力欄に入れてそのまま送信する
+    （Google の結果ページへの <a> にすると、キーワードが外部リンクの文字列になる）%>
+<script>
+	(function () {
+		var KEY = 'recentSearches';
+		var MAX = 5;
+		var form = document.querySelector('.header-search');
+		if (!form) return;
+		var input = form.querySelector('#header-search-q');
+		var box = form.querySelector('.header-search-recent');
+		var list = box.querySelector('.header-search-recent-list');
+
+		function read() {
+			try {
+				var items = JSON.parse(localStorage.getItem(KEY));
+				return Array.isArray(items) ? items.filter(function (w) { return typeof w === 'string'; }) : [];
+			} catch (e) {
+				return [];
+			}
+		}
+		function write(items) {
+			try {
+				localStorage.setItem(KEY, JSON.stringify(items));
+			} catch (e) {}
+		}
+		function render() {
+			var items = read();
+			list.textContent = '';
+			items.forEach(function (word) {
+				var button = document.createElement('button');
+				button.type = 'submit';
+				button.className = 'header-search-recent-item';
+				button.textContent = word;
+				button.addEventListener('click', function () {
+					input.value = word;
+				});
+				var li = document.createElement('li');
+				li.appendChild(button);
+				list.appendChild(li);
+			});
+			box.hidden = items.length === 0;
+		}
+
+		form.addEventListener('submit', function () {
+			var word = input.value.trim().slice(0, 100);
+			if (!word) return;
+			var items = read().filter(function (w) { return w !== word; });
+			items.unshift(word);
+			write(items.slice(0, MAX));
+			render();
+		});
+		box.querySelector('.header-search-recent-clear').addEventListener('click', function () {
+			write([]);
+			render();
+			// 消したボタンごと隠れるとフォーカスが外れてパネルが閉じるので、入力欄へ戻す
+			input.focus();
+		});
+
+		render();
+	})();
+</script>

--- a/themes/future/layout/_partial/search-hint.ejs
+++ b/themes/future/layout/_partial/search-hint.ejs
@@ -12,9 +12,17 @@
 	<div class="header-search-recent" hidden>
 		<p class="header-search-hint-label header-search-recent-label">
 			<span><%- partial('svg-icon', {icon: 'history'}) %>最近の検索</span>
-			<button type="button" class="header-search-recent-clear">消す</button>
+			<button type="button" class="header-search-recent-clear">すべて消す</button>
 		</p>
 		<ul class="header-search-recent-list"></ul>
+		<%# 行の markup はここが1箇所で持つ。スクリプトは複製して文字を入れるだけで、
+		    JS の中で組み立てるとアイコンの絵柄が辞書の外にもう1つ増える %>
+		<template class="header-search-recent-row">
+			<li>
+				<button type="submit" class="header-search-recent-item"></button>
+				<button type="button" class="header-search-recent-remove"><%- partial('svg-icon', {icon: 'x'}) %></button>
+			</li>
+		</template>
 	</div>
 	<p class="header-search-hint-label"><%- partial('svg-icon', {icon: 'tags'}) %>人気のタグ</p>
 	<%# /tags/ とサイドバーの「人気のタグ」と同じ部品・同じ見出し。検索窓の中なので「〜から探す」は書かない (#3083)。
@@ -39,6 +47,7 @@
 		var input = form.querySelector('#header-search-q');
 		var box = form.querySelector('.header-search-recent');
 		var list = box.querySelector('.header-search-recent-list');
+		var template = box.querySelector('.header-search-recent-row');
 
 		function read() {
 			try {
@@ -56,19 +65,32 @@
 		function render() {
 			var items = read();
 			list.textContent = '';
-			items.forEach(function (word) {
-				var button = document.createElement('button');
-				button.type = 'submit';
-				button.className = 'header-search-recent-item';
-				button.textContent = word;
-				button.addEventListener('click', function () {
+			items.forEach(function (word, index) {
+				var row = template.content.querySelector('li').cloneNode(true);
+				var item = row.querySelector('.header-search-recent-item');
+				item.textContent = word;
+				item.addEventListener('click', function () {
 					input.value = word;
 				});
-				var li = document.createElement('li');
-				li.appendChild(button);
-				list.appendChild(li);
+				var remove = row.querySelector('.header-search-recent-remove');
+				remove.setAttribute('aria-label', '「' + word + '」を履歴から消す');
+				remove.addEventListener('click', function () {
+					removeAt(index);
+				});
+				list.appendChild(row);
 			});
 			box.hidden = items.length === 0;
+		}
+		function removeAt(index) {
+			var items = read();
+			items.splice(index, 1);
+			write(items);
+			render();
+			// 押したボタンごと消えるとフォーカスが外れてパネルが閉じる。
+			// 次の行へ移し、最後の1件だったら入力欄へ戻す
+			var next = list.querySelectorAll('.header-search-recent-remove')[Math.min(index, items.length - 1)];
+			if (next) next.focus();
+			else input.focus();
 		}
 
 		form.addEventListener('submit', function () {

--- a/themes/future/layout/_partial/svg-icon.ejs
+++ b/themes/future/layout/_partial/svg-icon.ejs
@@ -54,6 +54,7 @@ const SVG_ICON_PATHS = {
     'M16 14v4',
   ],
   'search': ['M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0', 'M21 21l-6 -6'],
+  'history': ['M12 8l0 4l2 2', 'M3.05 11a9 9 0 1 1 .5 4m-.5 5v-5h5'],
   'chevron-down': ['M6 9l6 6l6 -6'],
   'chevron-right': ['M9 6l6 6l-6 6'],
   'x': ['M18 6l-12 12', 'M6 6l12 12'],


### PR DESCRIPTION
検索窓に打ったキーワードを `localStorage` に5件だけ持ち、次に検索窓を押したときにヒントのパネルの先頭に出す。押すと入力欄に入れてそのまま送信する。

## #2931 のうち、この PR がやること

issue は Google CSE をやめてサイト内に検索結果ページを作る提案だが、挙がっていた6つの不満のうち、実装を見ると成立するのは**⑤ Google 側の結果品質・UI 変更に依存する**だけだった。

| issue の主張 | 実装 |
| --- | --- |
| ① ナビと表示文法が途切れる / ② 元の文脈を維持できない | フォームは `target="_blank"`。元のタブは残るので切れない |
| ③ 検索条件を URL で保持・共有できない | CSE の結果 URL は `q` を持つので共有自体はできる。サイトの URL でないだけ |
| ④ 独自の属性で絞れない | 難易度・対象バージョンはフロントマターに無い（issue も別 issue 待ちと書いている） |
| ⑥ 0件時に表記ゆれを提案できない | Google 側が「次の検索結果を表示しています」を出す |

そのうえで、③が言う「共有」ではなく**自分の再検索の手間**の側だけを、Google CSE のフォームを残したまま小さく解く。

## 形の判断

- **キーワードはチップにしない。** ピル型のチップはタグの印で、例外はタイトルの上で名乗るチップ（表彰・連載）だけ (#2892)。検索語をピルにすると「押せば絞り込めるタグ」に読める
- **行の反応は面**（ヘッダーのドロップダウンと同じ #3162）。パネルの中に行として並ぶものなので
- **入力欄を前回語で prefill しない。** プレースホルダ（「記事を検索」）が消えて毎回消す手間が出る。行として出せば押した時だけ入る
- **行は `<a>` ではなく `type="submit"` のボタン。** Google の結果ページへのリンクにすると、キーワードがそのまま外部リンクの文字列になる（外部リンクの明示 #2346 / #2729 の対象になり、5行すべてに矢印が並ぶ）
- **人気のタグより前に置く。** 履歴があるのは繰り返し検索する読者だけで、その人がいま押した検索窓に対していちばん直接の入口になる。履歴が無い間は枠ごと出ないので、それ以外の読者のパネルは今までと同じ
- **「消す」を同じ枠が持つ。** 履歴は本人のもので、共用の端末で消す手段が無いのは具合が悪い。面を持たない添えなので反応は色と下線 (#2699)

## JS を1つ増やしている

`localStorage` にしか無いデータなので、行はクライアントの JS が描くしかない。ヒントのパネルはこれまで CSS と EJS だけで動いていた (#2791) ので、**ここに初めて JS が入る**。素の DOM API だけで、外部ライブラリは足していない（テーマトグルと同じ形のインラインスクリプト）。

## 検証

DOM をスタブして `search-hint.ejs` の `<script>` をそのまま実行した（13件すべて OK）。

- 初期は履歴なしで枠を隠す / 検索すると1件出る / `localStorage` に入る
- 新しい順に積む / 同じ語は重複せず先頭へ / 5件で打ち止め
- 空白だけの検索は残さない / 前後の空白は落とす / 長い語は100字で切る
- 行を押すと入力欄に入る / 消すと空になり枠が隠れる / 消した後は入力欄へフォーカスを戻す
- `localStorage` の値が壊れていても落ちない

そのほか

- `make css` → `css_lint.mjs` / `font_size_lint.mjs` ともに指摘なし
- 変更した `.ejs` 2本に textlint（`no-unmarked-external-link` 含む）→ 指摘なし
- `hexo server` で配信中の HTML に枠とスクリプトが出ていることを確認

## この PR の範囲外

issue 本体（Pagefind 等でサイト内に `/search/` を作る）は見送りの判断。検索が別ドメインに出ているので**利用実態を1件も測れておらず**、1,481記事ぶんのインデックス転送と日本語の検索品質を払う根拠が今は無い。⑤は残る。issue 側にも同じことを書く。

`Closes` は書かない。issue の主題は実装していないため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)