### PR TITLE
統合候補から親子を起こし、AD タグを畳む (#3205)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -158,6 +158,7 @@ alias:
   tags/ClaudeCode/: tags/Claude/
   tags/KVS/: tags/NoSQL/ # 「RDBでないデータストア」の意味で使っていた語を一般名へ (#2612)
   tags/Grafana-Alloy/: tags/Grafana/ # タグ名「Grafana Alloy」のスラッグ
+  tags/AD/: tags/EntraID/ # 3記事中2記事は Azure AD（EntraID の旧名）。残り1記事はオンプレAD だがタグを落とした (#3205)
   tags/TechBlog/: tags/運営/ # ブログ論一般と当ブログ運営の使い分けを説明できず統合 (#2292)
   tags/新人向け/: tags/初心者向け/ # 同義のため統合 (#2292)
   # 2記事とも Makefile と併記されており、単独では絞り込みに機能しない

--- a/source/_data/tag_ontology.yml
+++ b/source/_data/tag_ontology.yml
@@ -431,6 +431,8 @@ UML:
   broader: [設計]
 PlantUML:
   broader: [UML]
+Mermaid.js:
+  broader: [UML]
 アルゴリズム:
   broader: []
   notInText: true # 一般語。暗号アルゴリズム・探索アルゴリズムの一部として出る

--- a/source/_data/tag_ontology.yml
+++ b/source/_data/tag_ontology.yml
@@ -101,8 +101,12 @@ GCS:
   broader: [GoogleCloud]
 Azure:
   broader: []
+Prompt Flow:
+  broader: [Azure, LLM]
 Cloudflare:
   broader: []
+Cloudflare Workers:
+  broader: [Cloudflare, サーバーレス]
 サーバーレス:
   broader: []
 
@@ -331,6 +335,12 @@ Airflow:
 # --- DB・データ ---
 DB:
   broader: []
+DWH:
+  broader: [DB]
+Snowflake:
+  broader: [DWH]
+Redshift:
+  broader: [AWS, DWH]
 SQL:
   broader: [DB]
 # 当ブログは KVS を「RDB でないデータストア」の意味で使ってきたので、
@@ -417,6 +427,10 @@ Cypress:
   broader: []
 アーキテクチャ:
   broader: [設計]
+UML:
+  broader: [設計]
+PlantUML:
+  broader: [UML]
 アルゴリズム:
   broader: []
   notInText: true # 一般語。暗号アルゴリズム・探索アルゴリズムの一部として出る
@@ -492,6 +506,22 @@ Auth0Rules:
 # AWS / GoogleCloud 双方の記事で使われているのでクラウドの下には置かない
 IAM:
   broader: [認証認可]
+OAuth:
+  broader: [認証認可]
+# OIDC は OAuth 2.0 の上の identity layer。JWT は ID トークンの表現形式として
+# 使われるだけで包含ではないため親にしない
+OIDC:
+  broader: [OAuth]
+JWT:
+  broader: [認証認可]
+WebAuthn:
+  broader: [認証認可]
+パスキー:
+  broader: [WebAuthn]
+EntraID:
+  broader: [Azure, 認証認可]
+MSAL.js:
+  broader: [EntraID]
 
 # --- 学び・キャリア ---
 # 初心者向け＝IT初心者（文系新人想定）という読者レベル。入門＝その領域への入門という

--- a/source/_posts/2021/20210302_Auth0でADをユーザDBにし、SalesforceとのSSOを確認する.md
+++ b/source/_posts/2021/20210302_Auth0でADをユーザDBにし、SalesforceとのSSOを確認する.md
@@ -5,7 +5,6 @@ postid: ""
 tags:
   - Auth0
   - SSO
-  - AD
   - Auth0Rules
   - Salesforce
 categories:

--- a/source/_posts/2022/20221118a_MSAL.jsを使ってウェブフロントエンドだけでAzureAD認証する.md
+++ b/source/_posts/2022/20221118a_MSAL.jsを使ってウェブフロントエンドだけでAzureAD認証する.md
@@ -3,7 +3,6 @@ title: "MSAL.jsを使ってウェブフロントエンドだけでAzureAD認証�
 date: 2022/11/18 00:00:00
 postid: a
 tags:
-  - AD
   - MSAL.js
   - Azure
   - EntraID

--- a/source/_posts/2022/20221122a_AzureAD＋MSAL_for_Goでバッチコマンドの認証.md
+++ b/source/_posts/2022/20221122a_AzureAD＋MSAL_for_Goでバッチコマンドの認証.md
@@ -4,7 +4,6 @@ date: 2022/11/22 00:00:00
 postid: a
 tags:
   - Azure
-  - AD
   - MSAL.js
   - Go
   - EntraID


### PR DESCRIPTION
#3205 のAレーン（`check.mjs` の統合候補）とBレーン（独立ノードに子を足す）。合意した分を1本にまとめました。

## OIDC の親 — `JWT` は入れません

`/doctor/` の提案には `OIDC ⊆ JWT` と `OIDC ⊆ OAuth` の両方が出ていましたが、**採るのは `OAuth` だけ**です。

- **`OIDC ⊆ OAuth` は正しい。** OpenID Connect は仕様自身が "a simple identity layer **on top of the OAuth 2.0 protocol**" と定義していて、認可コードフローなど OAuth 2.0 の仕組みをそのまま使う。OIDC は OAuth の外では成立しないので #2292 の基準（子の名前が親の外で指示対象を持たない）を満たす
- **`OIDC ⊆ JWT` は誤り。** JWT は OIDC の ID トークンの**表現形式**として使われるだけで、包含ではなく利用関係。実データでも JWT の4本のうち2本は OIDC と無関係（`AWS APIGateway Custom Authorizer入門` / `Entra IDを使うウェブサービスのバックエンドのテスト`）で、JWT は OIDC の外に指示対象を持つ

提案に出たのは**2本の OIDC 記事がどちらも JWT タグを持つという包含関係だけを見ている**ためです。`JWT` は `認証認可` の直下に置きました。

## 足した辺（14件）

### 統合候補から（Aレーン）

| 辺 | 補足 |
| --- | --- |
| `DWH ⊆ [DB]` | 親のノードが無かったので作る |
| `Snowflake ⊆ [DWH]` | |
| `Redshift ⊆ [AWS, DWH]` | 同じ候補リストにあり Snowflake と同型。入れないと DWH が「根＋子1つ」になる |
| `UML ⊆ [設計]` | `設計(44)` は既存（データモデル・アーキテクチャを持つ） |
| `PlantUML ⊆ [UML]` | |
| `WebAuthn ⊆ [認証認可]` / `パスキー ⊆ [WebAuthn]` | |
| `OAuth ⊆ [認証認可]` / `JWT ⊆ [認証認可]` / `OIDC ⊆ [OAuth]` | 上の判断 |

### 独立ノードの子（Bレーン）

`Azure(17)` と `Cloudflare(11)` は AWS（12件）・GoogleCloud（7件）と同じ立場なのに子が1つも無い状態でした。

| 辺 | 根拠（実データ） |
| --- | --- |
| `EntraID ⊆ [Azure, 認証認可]` | Microsoft Entra ID（旧 Azure AD）。5本中4本が Azure と併記 |
| `MSAL.js ⊆ [EntraID]` | Microsoft Authentication Library。**3本すべて** EntraID と併記 |
| `Prompt Flow ⊆ [Azure, LLM]` | Azure ML の Prompt Flow。2本とも Azure＋LLM |
| `Cloudflare Workers ⊆ [Cloudflare, サーバーレス]` | 2本とも Cloudflare |

**`CDN(5)` は Cloudflare の子にしません。** Cloudflare は5本中3本で、残りは「ぼくのかんがえたさいきょうのキャッシュ戦略」「Software Design 寄稿」と一般概念としての使われ方。別の判断にします。

## `AD` タグを畳む（記事3本）

`AD(3)` は**指しているものが割れていました**。

| 記事 | 指しているもの |
| --- | --- |
| `MSAL.jsを使ってウェブフロントエンドだけでAzureAD認証する` | Azure AD（EntraID の旧名）。`EntraID` タグと併記 |
| `AzureAD＋MSAL for Goでバッチコマンドの認証` | 同上 |
| `Auth0でADをユーザDBにし、SalesforceとのSSOを確認する` | オンプレの Active Directory |

前2本は `EntraID` が既に付いているので `AD` は重複、3本目は単独では主題にならないので、**3本とも `AD` を外しました**。`_config.yml` の alias で `tags/AD/` → `tags/EntraID/` へ転送します（多数派の意味）。

## 数字

| | before | after |
| --- | --- | --- |
| ノード | 236 | **250** |
| タグ | 681 | **680**（`AD` を削除） |
| `check.mjs` の情報 | 29 | **24**（統合候補5件が解決） |
| 独立ノード | 42 | **38**（Azure・Cloudflare・設計まわりが子を持った） |

## 確認したこと

- `node .claude/skills/tag-maintenance/check.mjs` — **エラー 0**（ノード 250 / タグ 680）
- `textlint` — 書き換えた記事3本とも0件
- `/tags/AD/` が `https://future-architect.github.io/tags/EntraID/` へ転送されること、記事ページのタグが `Azure EntraID MSAL.js` になっていることを配信 HTML で確認
- `/tags/#tagforest` の群の中身を実測

| 群 | 中身 |
| --- | --- |
| 認証認可 | `IAM8 JWT4` ／ `Auth016 → Auth0Rules5` ／ `EntraID5 → MSAL.js3` ／ `OAuth4 → OIDC2` ／ `WebAuthn3 → パスキー2` |
| DB | `… ORM17 → GORM4` ／ `DWH4 → Redshift2 Snowflake2` |
| 設計 | `データモデル13 アーキテクチャ10` ／ `UML4 → PlantUML3` |
| Azure | `Prompt Flow2` ／ `EntraID5 → MSAL.js3` |
| Cloudflare | `Cloudflare Workers2` |
| AWS | `… Athena2 CloudEndure2 Redshift2 SAM2 Session-Manager2` ／ `DynamoDB22 → DynamoDBStreams2` |

## 範囲外

`check.mjs` の統合候補は20件残っています（`DB移行 ⊆ Oracle`、`Session-Manager ⊆ 踏み台`、`JetBrains ⊆ GoLand` など）。独立ノード38件の残りと合わせて別 PR にします。この PR は issue を閉じません。