### PR TITLE
独立ノードに子を足す (#3205)

### DIFF
--- a/source/_data/tag_ontology.yml
+++ b/source/_data/tag_ontology.yml
@@ -242,6 +242,11 @@ flutter_web:
   broader: [Flutter]
 iOS:
   broader: [モバイル]
+Android:
+  broader: [モバイル]
+# ストアの審査は iOS / Android の両方の記事に付く
+アプリストア審査:
+  broader: [モバイル]
 モバイル:
   broader: []
 Unity:
@@ -251,7 +256,14 @@ Unity:
 Web:
   broader: []
   notInText: true # 一般語。Web API / Webフロントエンド / Webアプリの一部として出る
-# Web タグは「Web技術一般」の曖昧な受け皿で、親として機能する概念ではない
+# #2292 では「曖昧な受け皿で親として機能しない」としていたが、ブラウザ・HTML のように
+# Web の外に指示対象を持たない語が出てきたので親として使う (#3205)
+ブラウザ:
+  broader: [Web]
+# HTML はブラウザが描画する対象で「ブラウザの一種」ではない。7本のうち ブラウザ タグが
+# 付くものは0本で、GAS の議事録・E2Eテストなどブラウザの話でない記事が半分を占める
+HTML:
+  broader: [Web]
 WebAPI:
   broader: []
 OpenAPI:
@@ -324,6 +336,8 @@ IaC:
   broader: []
 Terraform:
   broader: [IaC]
+Ansible:
+  broader: [IaC]
 tfstate:
   broader: [Terraform]
 TerraformCloud:
@@ -389,8 +403,6 @@ uroboroSQL:
 # フロントエンドのダッシュボード実装等も混ざるので、データ分析の子にはしない
 可視化:
   broader: []
-階層グラフ:
-  broader: [可視化]
 データマネジメント:
   broader: []
 # 検索エンジンの記事も PostgreSQL の全文検索機能の記事も入るので、DB の子にはしない
@@ -610,8 +622,10 @@ RealWorldHTTP:
   broader: []
 
 # --- ツール・その他 ---
+# #2292 では「エディタとしての記事が主」として IDE の外に置いていたが、実態としては
+# もう IDE なので中に入れる (#3205)
 VSCode:
-  broader: []
+  broader: [IDE]
 Obsidian:
   broader: []
 VSCode拡張:

--- a/source/_data/tag_ontology.yml
+++ b/source/_data/tag_ontology.yml
@@ -81,6 +81,8 @@ CloudEndure:
   broader: [AWS]
 Session-Manager:
   broader: [AWS, 踏み台]
+CloudWatch:
+  broader: [AWS]
 AWSIoT:
   broader: [AWS, MQTT]
 SAM:
@@ -308,6 +310,8 @@ k3s:
   broader: [Kubernetes]
 CNCF:
   broader: []
+KubeCon:
+  broader: [CNCF, イベント]
 OS:
   broader: []
 Linux:
@@ -345,6 +349,8 @@ DR:
 # 8本中1本しか重ならないため根に置く (#2611)
 Airflow:
   broader: []
+Breeze:
+  broader: [Airflow]
 
 # --- DB・データ ---
 DB:
@@ -383,6 +389,8 @@ uroboroSQL:
 # フロントエンドのダッシュボード実装等も混ざるので、データ分析の子にはしない
 可視化:
   broader: []
+階層グラフ:
+  broader: [可視化]
 データマネジメント:
   broader: []
 # 検索エンジンの記事も PostgreSQL の全文検索機能の記事も入るので、DB の子にはしない
@@ -405,6 +413,8 @@ TensorFlow:
   broader: [AI]
 LLM:
   broader: [生成AI]
+Llama:
+  broader: [LLM]
 RAG:
   broader: [生成AI]
 DeepResearch:
@@ -421,6 +431,8 @@ NLP:
   broader: [機械学習]
 MLOps:
   broader: [機械学習]
+ICLR:
+  broader: [機械学習, 学会]
 # Evidently AI は evidentlyai.com の独立した OSS で Google の製品ではない。
 # VertexAI と併記されるのは Model Monitoring と並べて使うため (#3205)
 AI監視:
@@ -448,6 +460,8 @@ Cypress:
 設計:
   broader: []
 アーキテクチャ:
+  broader: [設計]
+DDD:
   broader: [設計]
 UML:
   broader: [設計]
@@ -497,6 +511,8 @@ Tips:
   broader: []
 環境構築:
   broader: []
+キーバインド:
+  broader: [環境構築]
 パッケージ管理:
   broader: []
 フォーマッター:
@@ -565,6 +581,14 @@ MSAL.js:
   broader: []
 業界ドメイン:
   broader: []
+エネルギー業界:
+  broader: [業界ドメイン]
+LPガス業界:
+  broader: [エネルギー業界]
+メディア業界:
+  broader: [業界ドメイン]
+物流業界:
+  broader: [業界ドメイン]
 
 # --- ブログ・出版 ---
 運営:
@@ -578,6 +602,8 @@ MSAL.js:
   broader: []
 SoftwareDesign:
   broader: [出版]
+RealWorldHTTP:
+  broader: [HTTP, 出版]
 書評:
   broader: []
 論文紹介:
@@ -613,10 +639,23 @@ GoogleChat:
   broader: [GoogleWorkspace]
 OSS:
   broader: []
+OSSコントリビュート:
+  broader: [OSS]
+# ライセンスは OSS の外にもある（Docker Desktop の商用ライセンスの記事）ので根に置く
+ライセンス:
+  broader: []
+AGPL:
+  broader: [ライセンス]
 電子工作:
   broader: []
+KiCAD:
+  broader: [電子工作]
+自作キーボード:
+  broader: [電子工作]
 リモートワーク:
   broader: []
+昇降デスク:
+  broader: [リモートワーク]
 コアテク:
   broader: []
 ソフトウェア:

--- a/source/_data/tag_ontology.yml
+++ b/source/_data/tag_ontology.yml
@@ -174,6 +174,8 @@ FastAPI:
   broader: [Python]
 Pipenv:
   broader: [Python, パッケージ管理]
+MicroPython:
+  broader: [Python]
 Mypy:
   broader: [Python]
 Pyright:
@@ -286,7 +288,7 @@ HeadlessCMS:
 HTTP:
   broader: [ネットワーク]
 gRPC:
-  broader: [ネットワーク]
+  broader: [ネットワーク, CNCF]
 MQTT:
   broader: [ネットワーク]
 プロキシ:
@@ -303,7 +305,7 @@ VPC:
 コンテナビルド:
   broader: [コンテナ]
 Buildpacks:
-  broader: [コンテナビルド]
+  broader: [コンテナビルド, CNCF]
 コンテナデプロイ:
   broader: [コンテナ]
 Docker:
@@ -313,17 +315,34 @@ DockerCompose:
 Dev Containers:
   broader: [Docker]
 Kubernetes:
-  broader: [コンテナ]
+  broader: [コンテナ, CNCF]
 Minikube:
   broader: [Kubernetes]
 Istio:
   broader: [Kubernetes]
 k3s:
   broader: [Kubernetes]
+# CNCF がホストするプロジェクトは提供元の軸として CNCF を持つ。Docker は Docker 社の
+# 製品で CNCF ではない（CNCF なのは containerd）。Minikube は Kubernetes の
+# サブプロジェクトなので Kubernetes 経由で届く。Istio / k3s も Kubernetes の子として
+# 届くので CNCF を直接は書かない（祖先で届くものは書かない #2292）
 CNCF:
   broader: []
 KubeCon:
   broader: [CNCF, イベント]
+OpenTelemetry:
+  broader: [CNCF]
+ArgoCD:
+  broader: [CNCF, CI/CD]
+Knative:
+  broader: [CNCF, サーバーレス]
+Keycloak:
+  broader: [CNCF, 認証認可]
+OpenPolicyAgent:
+  broader: [CNCF]
+# Rego は OPA のポリシー言語で、単独の CNCF プロジェクトではない
+Rego:
+  broader: [OpenPolicyAgent]
 OS:
   broader: []
 Linux:

--- a/source/_data/tag_ontology.yml
+++ b/source/_data/tag_ontology.yml
@@ -92,7 +92,7 @@ GoogleCloud:
 GoogleCloudNext:
   broader: [GoogleCloud, イベント]
 BigQuery:
-  broader: [GoogleCloud]
+  broader: [GoogleCloud, DWH]
 GKE:
   broader: [GoogleCloud, Kubernetes]
 CloudRun:
@@ -371,6 +371,9 @@ DB:
   broader: []
 DWH:
   broader: [DB]
+# 8本中6本が PostgreSQL だが、Oracle・SQL の記事もあるので DB の直下に置く
+実行計画:
+  broader: [DB]
 Snowflake:
   broader: [DWH]
 Redshift:
@@ -601,6 +604,8 @@ LPガス業界:
   broader: [業界ドメイン]
 物流業界:
   broader: [業界ドメイン]
+銀行:
+  broader: [業界ドメイン]
 
 # --- ブログ・出版 ---
 運営:
@@ -613,6 +618,8 @@ LPガス業界:
 出版:
   broader: []
 SoftwareDesign:
+  broader: [出版]
+WEB+DBPRESS:
   broader: [出版]
 RealWorldHTTP:
   broader: [HTTP, 出版]


### PR DESCRIPTION
#3205 の2レーン目（独立ノード39件が本当に根でよいか）。**部分集合の検定を全独立ノードにかけて**候補を機械で出し、1件ずつ判断しました。

やり方は `/doctor/` の追加提案と同じで、「あるタグの記事が**すべて**独立ノードの記事にも含まれる」ものを列挙しています。

## 足した辺（19件）

### 提案どおり親子だったもの

| 辺 | 判断 |
| --- | --- |
| `エネルギー業界 ⊆ [業界ドメイン]` / `LPガス業界 ⊆ [エネルギー業界]` | LPガス5本はすべてエネルギー業界。**3段**になる |
| `メディア業界 ⊆ [業界ドメイン]` / `物流業界 ⊆ [業界ドメイン]` | 検定には出ないが同じ形（名前が業界を名乗る）なので揃える |
| `自作キーボード ⊆ [電子工作]` / `KiCAD ⊆ [電子工作]` | KiCAD は基板CAD |
| `OSSコントリビュート ⊆ [OSS]` | |
| `AGPL ⊆ [ライセンス]` | `check.mjs` の統合候補にもあった |
| `RealWorldHTTP ⊆ [HTTP, 出版]` | 自社社員の著書。既存の `SoftwareDesign ⊆ 出版` と同じ形に、主題の軸（HTTP）を足した |
| `キーバインド ⊆ [環境構築]` | 4本すべて環境構築（Mac/Windows の設定） |
| `昇降デスク ⊆ [リモートワーク]` | 3本すべてリモートワーク環境の話。`環境構築` は当ブログでは開発環境の意味で使われているので採らない |
| `KubeCon ⊆ [CNCF, イベント]` | CNCF 主催のカンファレンス |
| `Breeze ⊆ [Airflow]` | Airflow のローカル開発環境 |
| `階層グラフ ⊆ [可視化]` | 2本とも可視化 |

**`ライセンス(4)` は根に置きました。** OSS の子にしたくなりますが、`Docker Desktop有償化！どのライセンス契約する？` という商用ライセンスの記事があるので OSS の外にも指示対象を持ちます。

### 提案の親が違っていたもの（3件）

部分集合は成立していても、**意味の上では別の親**でした。

| 提案 | 実際に入れた辺 | 理由 |
| --- | --- | --- |
| `CloudWatch(2) ⊆ 保守運用(12)` | `CloudWatch ⊆ [AWS]` | AWS のサービス。保守運用の記事で使われただけ |
| `Llama(2) ⊆ ソフトウェア(11)` | `Llama ⊆ [LLM]` | LLM。「ソフトウェア」は記事タイトルの「日本語×ソフトウェア開発」由来 |
| `ICLR(2) ⊆ 論文紹介(10)` | `ICLR ⊆ [機械学習, 学会]` | 国際学会。2本とも `学会` タグ付き。`YANS ⊆ [NLP, 学会]` と同じ形 |
| `DDD(3) ⊆ 書評(42)` | `DDD ⊆ [設計]` | 設計手法。書評記事で扱われただけ |

## 入れなかったもの

- **`ブラウザ(2) ⊆ Web(18)`** — `tag_ontology.yml` に **「Web タグは『Web技術一般』の曖昧な受け皿で、親として機能する概念ではない」**（#2292）というコメントがあるので従いました
- **連載名のタグ**（`春の入門祭り(7)` `夏休み自由研究(7)` `他言語からGoへ(3)` が `インデックス` / `入門` に包含）— #2374 で「連載名はタグで表さず `series` に書き、旧タグは alias で先頭記事へ転送」と決まっているので、**削除・統合のレーン**
- **偶然の包含** — `MetaQuest` `ブラインドサッカー` ⊆ Unity（Unity で作っただけ）、`SIMD` ⊆ インデックス、`IoTプラットフォーム` `Dataflow` ⊆ インターン、`ANTLR4` ⊆ コアテク（組織名）
- **`シリアル通信(2)` ⊆ 電子工作** — 名前が電子工作の外に指示対象を持つ（産業機器・組込み）。2記事では例外扱いの根拠に足りない
- **`リーダブルコード(3)` ⊆ 書評** — 書籍名を書評の子にする型を作ることになる。迷ったら書かない（#2292）

## 数字

| | before | after |
| --- | --- | --- |
| ノード | 262 | **281** |
| 木 | 44 | **53** |
| 独立ノード | 39 | **31** |
| 未登録タグ（版タグ除く） | 400 | **381** |
| `check.mjs` の情報 | 19 | **18** |

**「根＋子1つ」の木は 15 → 21 に増えます**が、#3208 で直したのは「親がタグとして存在しない概念ノード」と「子のほうが本数が多い」の2つで、**浅いこと自体は問題ではない**と確認済みです。今回増えた木はすべて親がタグとして実在し、逆転もありません。

## 確認したこと

- `node .claude/skills/tag-maintenance/check.mjs` — **エラー 0**（ノード 281 / タグ 680）
- 配信 HTML（`/tags/#tagforest`）で群の中身を実測

| 群 | 中身 |
| --- | --- |
| 業界ドメイン | `物流業界6 メディア業界4` ／ `エネルギー業界8 → LPガス業界5` |
| 電子工作 | `自作キーボード4 KiCAD2` |
| OSS | `OSSコントリビュート2` |
| ライセンス | `AGPL3` |
| 出版 | `SoftwareDesign13 RealWorldHTTP3` |
| 設計 | `データモデル13 アーキテクチャ10 DDD3` ／ `UML4 → Mermaid.js4 PlantUML3` |
| AWS | `… CloudEndure2 CloudWatch2 Redshift2 SAM2 Session-Manager2` |
| AI | `… LLM24 → Claude18 Gemini14 Llama2` ／ `機械学習45 → TensorFlow6 ICLR2 …` |
| 可視化 / 環境構築 / リモートワーク / CNCF / Airflow | `階層グラフ2` / `キーバインド4` / `昇降デスク3` / `KubeCon2` / `Breeze2` |

## 残る独立ノード31件

```
インデックス(90) 初心者向け(83) 入門(62) 書評(42) インターン(26) コミュニケーション(20)
技術選定(20) Web(18) トラブルシュート(18) コアテク(18) Rust(17) Tips(16) フォーマッター(15)
UI/UX(14) データマネジメント(13) Slack(13) ShellScript(12) 保守運用(12) Redmine(12)
WebAssembly(11) データ分析(11) ソフトウェア(11) Unity(10) リーダーシップ(10) 失敗談(10)
論文紹介(10) GitHub(8) LSP(5) DR(3) Obsidian(2) タスク管理(1)
```

**このうち21件は部分集合の検定で候補が1件も出ませんでした**（`初心者向け` `Rust` `Tips` `フォーマッター` `UI/UX` `Slack` `ShellScript` `WebAssembly` `データ分析` `リーダーシップ` `失敗談` `GitHub` ほか）。記事の種類・読者レベル・横断的な話題で、親も子も持たないのが実態です。**これで「独立ノードは妥当か」のレーンは一巡**しました。