### PR TITLE
モバイルの引き出しで「表示テーマ」の左端がずれているのを直す

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -5296,13 +5296,21 @@ a.award-badge:focus {
 .header-theme:focus {
   color: var(--ink-strong);
 }
+/* 絵しか持たないボタンなので、.svg-icon の既定の右マージン（0.3em = 6px）を戻す。
+   残すと箱が 28px から 34px になり、絵が箱の中で左に寄る
+   （検索の虫眼鏡も同じ理由で戻している） */
+.header-theme .svg-icon {
+  margin-right: 0;
+}
 /* 引き出しの中の2つ目 (#2746 の切り替えを 575px 以下でここへ降ろす)。
    帯とは違って行として並ぶので、絵だけでなく名前を横に出す */
 .header-theme-drawer {
   display: none;
   align-items: center;
   gap: (space-step * 2);
-  padding: (space-step * 3) (space-step * 4);
+  /* 左右の余白は中の .header-nav-label が持つ。ここで持つと、下に並ぶ組の
+     ラベル（カテゴリ・連載…）より 16px 右へずれる */
+  padding: (space-step * 3) 0;
 }
 .header-theme-drawer .header-nav-label {
   margin: 0;


### PR DESCRIPTION
## 何を直したか

モバイル（1024px 以下）のヘッダーの引き出しで、先頭の「表示テーマ」の行だけが右へずれていた。

- `.header-theme-drawer` が左右 16px の余白を持ち、その中の `.header-nav-label` が自分の 12px を重ねるので、文字の左端が **28px** になっていた
- 下に並ぶ組のラベル（「カテゴリ」「連載」「リソース」「アクティビティ」）は **12px**

同じ段のラベルなので、左右の余白は中のラベルに任せて 12px にそろえた。縦の余白は変えていない（行の上端・文字の位置は実測で同じ）。

あわせて `.header-theme` の中のアイコンから `.svg-icon` 既定の `margin-right`（0.3em = 6px）を戻した。絵しか持たないボタンなので、残ると箱が 28px → 34px になり絵が箱の中で左に寄る。虫眼鏡と送信ボタンは既に同じ理由で戻してある。

## 実測（幅390px・引き出しを開いた状態）

| | before | after |
| --- | --- | --- |
| 「表示テーマ」の文字の左端 | 28px | 12px |
| 「カテゴリ」の文字の左端 | 12px | 12px |
| テーマのボタンの箱 | 34px（絵は 4px / 10px の非対称） | 28px（絵は 4px / 4px） |

`make lint-css` / `make lint-partials` は通っている。