### PR TITLE
/series/ の期間を初回の年月だけにし、恒例行事の企画名を関連タグに出す

### DIFF
--- a/scripts/lib/series.js
+++ b/scripts/lib/series.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// 索引記事の判定に使うタグ。/series/ の関連タグもここから引く (#3101)
+// 索引記事の判定に使うタグ。/series/ の関連タグの先頭にもこれが出る (#3101)
 const INDEX_TAG = 'インデックス';
 
 /**
@@ -142,6 +142,43 @@ function successionMaps(site, groups) {
   return { nextOf, prevOf };
 }
 
+/**
+ * /series/ の関連タグ。索引記事に付いているタグのうち、**3つ以上の連載に
+ * またがり**、かつそのタグの記事の**8割以上が索引記事**のものを返す。
+ *
+ * 恒例行事の連載（春の入門祭り・夏休み自由研究・秋ブログ週間）は、年ごとの
+ * 連載の索引記事に同じタグが付いている。連載名はタグで表さない規則なので、
+ * 年をまたぐ企画の名前を持つ語はここにしか出てこない。
+ *
+ * 索引記事に居合わせただけの主題のタグと分けるのは比の方。3連載以上のタグは
+ * 8タグあり、比は 0.83 以上（インデックス・春・夏・秋）と 0.14 以下
+ * （Go 16連載・入門 6連載・Terraform 4連載・GoogleCloud / Vue.js / CNCF 3連載）に
+ * 割れて、間に何も無い。件数では切れない（Go は索引記事16本で最多）。
+ *
+ * 並びは連載数の多い順で、同数は初出の古い順（春 → 夏 → 秋）。
+ */
+const EVENT_MIN_SERIES = 3;
+const EVENT_MIN_INDEX_RATIO = 0.8;
+
+function relatedTags(site, indexPaths) {
+  const seriesCount = new Map(); // タグ -> そのタグを持つ索引記事の連載数
+  const total = new Map(); // タグ -> そのタグの記事数
+  const firstSeen = new Map(); // タグ -> 初出の日付
+  site.posts.each((post) => {
+    const isIndex = indexPaths.has(post.path);
+    (post.tags ? post.tags.toArray() : []).forEach((tag) => {
+      total.set(tag.name, (total.get(tag.name) || 0) + 1);
+      if (isIndex) seriesCount.set(tag.name, (seriesCount.get(tag.name) || 0) + 1);
+      const at = firstSeen.get(tag.name);
+      if (!at || post.date < at) firstSeen.set(tag.name, post.date);
+    });
+  });
+  return [...seriesCount]
+    .filter(([name, n]) => n >= EVENT_MIN_SERIES && n / total.get(name) >= EVENT_MIN_INDEX_RATIO)
+    .sort((a, b) => b[1] - a[1] || firstSeen.get(a[0]) - firstSeen.get(b[0]))
+    .map(([name]) => name);
+}
+
 let cache = null;
 
 function build(site) {
@@ -192,8 +229,16 @@ function build(site) {
   const all = [...groups.values()].flat();
   const oneYearAgo = Date.now() - 365 * 24 * 60 * 60 * 1000;
 
+  const indexPaths = new Set(
+    [...groups.values()]
+      .map((posts) => posts.find((p) => p.tags && p.tags.some((t) => t.name === INDEX_TAG)))
+      .filter(Boolean)
+      .map((p) => p.path),
+  );
+
   return {
     byPath: series,
+    relatedTags: relatedTags(site, indexPaths),
     list: [...groups].map(([name, posts]) => {
       const index = posts.find((p) => p.tags && p.tags.some((t) => t.name === INDEX_TAG));
       return {
@@ -254,6 +299,12 @@ function seriesStats(site) {
   return cache.stats;
 }
 
+/** /series/ の関連タグ。索引タグと恒例行事の企画名 */
+function seriesRelatedTags(site) {
+  if (!cache) cache = build(site);
+  return cache.relatedTags;
+}
+
 const NONE = new Set();
 
 /**
@@ -268,4 +319,11 @@ function navLinkedPaths(site, post) {
   return s ? s.linked : NONE;
 }
 
-module.exports = { INDEX_TAG, seriesOf, navLinkedPaths, allSeries, seriesStats };
+module.exports = {
+  INDEX_TAG,
+  seriesOf,
+  navLinkedPaths,
+  allSeries,
+  seriesStats,
+  seriesRelatedTags,
+};

--- a/scripts/series.js
+++ b/scripts/series.js
@@ -3,7 +3,7 @@
 // 連載ナビ本体。グループ化と題名の整形は lib/series.js にある
 // （related_posts / reference_posts も同じ結果を使うため）
 
-const { INDEX_TAG, seriesOf, allSeries, seriesStats } = require('./lib/series');
+const { seriesOf, allSeries, seriesStats, seriesRelatedTags } = require('./lib/series');
 
 hexo.extend.helper.register('series_nav', function (post) {
   return seriesOf(this.site, post);
@@ -71,9 +71,9 @@ hexo.extend.helper.register('all_series', function () {
   return allSeries(this.site);
 });
 
-// /series/ の関連タグ。索引記事の判定と同じ値 (#3101)
-hexo.extend.helper.register('series_index_tag', function () {
-  return INDEX_TAG;
+// /series/ の関連タグ。索引タグと恒例行事の企画名（規則は lib/series.js）
+hexo.extend.helper.register('series_related_tags', function () {
+  return seriesRelatedTags(this.site);
 });
 
 // /series/ の統計。累計と直近1年 (#2572)

--- a/themes/future/layout/series.ejs
+++ b/themes/future/layout/series.ejs
@@ -13,8 +13,8 @@
     <%# h1「連載一覧」と重ならない語にする（categories.ejs の流儀） %>
     <%- partial('_partial/section-heading', {id: 'series', text: 'すべての連載'}) %>
     <%# 最終更新の年ごとに h3 で束ねる (#3081)。/categories/ の群と同じ見出し。
-        並べ方の注記は置かない。年は見出しが、順序と期間は各カードの
-        「全9本・2026.02 〜 2026.08」が名乗っている（categories.ejs と同じ流儀） %>
+        並べ方の注記は置かない。年は見出しが、順序と規模は各カードの
+        「全9本・2026.02」が名乗っている（categories.ejs と同じ流儀） %>
     <% const byYear = new Map(); %>
     <% series.forEach(function(s){
          const y = date(s.latest, 'YYYY');
@@ -38,21 +38,23 @@
       <div class="series-panels row">
         <% list.forEach(function(s){ %>
         <div class="col-12 col-md-6 col-lg-4">
-          <%# 期間は連載の活動期間（初回〜最新）。単月で終わった連載は1つだけ名乗る %>
-          <% const first = date(s.first, 'YYYY.MM'); const latest = date(s.latest, 'YYYY.MM'); %>
+          <%# 期間は初回の年月だけ。78連載中31本は初回と最新が同じ月・69本は1ヶ月差で、
+              終わりの年月はほぼ同じ値の繰り返しだった。年をまたぐ4連載では年の
+              見出し（最終更新）と食い違うが、大雑把な時期が分かれば行き先は選べる %>
           <%- partial('_partial/panel-card', {
                 url: url_for(s.index.path),
                 title: s.name,
                 thumb: s.index.thumbnail ? {src: s.index.thumbnail, width: 200, height: 135} : null,
-                meta: '全' + s.total + '本・' + (first === latest ? first : first + ' 〜 ' + latest),
+                meta: '全' + s.total + '本・' + date(s.first, 'YYYY.MM'),
               }) %>
         </div>
         <% }) %>
       </div>
     <% }) %>
 
-    <%# 連載の索引記事の判定に使うタグ。値は scripts/lib/series.js が持ち、ここでは helper で引く (#3101) %>
-    <% const RELATED_TAGS = [series_index_tag()]; %>
+    <%# 索引記事のタグと、年ごとに続く恒例行事の企画名（春の入門祭り・夏休み自由研究・
+        秋ブログ週間）。どのタグがそれかの判定は scripts/lib/series.js が持つ %>
+    <% const RELATED_TAGS = series_related_tags(); %>
     <div class="footer-gap">
       <%- partial('_partial/section-heading', {id: 'relatedtags', text: '関連タグ'}) %>
       <div class="blog-tags">


### PR DESCRIPTION
## 期間は初回の年月だけ

`全9本・2026.02 〜 2026.08` → `全9本・2026.02`。

78連載を実測すると、**31本は初回と最新が同じ月・69本（88%）は1ヶ月差**で、後ろ半分はほぼ同じ値の繰り返しだった。3ヶ月より長いのは6本（最長50ヶ月）。行き先を選ぶには大雑把な開始時期で足りる。

| 初回と最新の差 | 連載数 |
| --- | --- |
| 同じ月 | 31 |
| 1ヶ月 | 38 |
| 2〜4ヶ月 | 5 |
| 7ヶ月以上 | 4 |

年をまたぐ4連載（インフラ入門・秋のブログ週間2020・GoのORマッパー・エネルギー業界）では、カードの年月が年の見出し（最終更新の年で束ねている #3081）と食い違う。

## 関連タグに恒例行事の企画名を出す

`インデックス` の1つだけだったところに、**春の入門祭り・夏休み自由研究・秋ブログ週間**が並ぶ。年ごとの連載（春の入門祭り2020〜2026 など）の索引記事に同じタグが付いていて、連載名はタグで表さない規則 (#2374) があるので、**年をまたぐ企画の名前を持つ語はここにしか出てこない**。

どのタグがそれかは `scripts/lib/series.js` が導出する（ハードコードしない）。条件は「索引記事に付いていて、**3つ以上の連載にまたがり**、そのタグの記事の**8割以上が索引記事**」。

3連載以上のタグは8つあり、比はきれいに割れて間に何も無い:

| タグ | 連載数 | 記事数 | 比 | |
| --- | --- | --- | --- | --- |
| インデックス | 78 | 90 | 0.87 | 出す |
| 春の入門祭り | 7 | 7 | 1.00 | 出す |
| 夏休み自由研究 | 7 | 7 | 1.00 | 出す |
| 秋ブログ週間 | 5 | 6 | 0.83 | 出す |
| CNCF | 3 | 22 | 0.14 | 落ちる |
| Vue.js | 3 | 42 | 0.07 | 落ちる |
| Terraform | 4 | 61 | 0.07 | 落ちる |
| 入門 | 6 | 62 | 0.10 | 落ちる |
| GoogleCloud | 3 | 108 | 0.03 | 落ちる |
| Go | 16 | 263 | 0.06 | 落ちる |

**件数では切れない**（索引記事の数では Go が16本で最多）。並びは連載数の多い順・同数は初出の古い順なので、インデックス → 春 → 夏 → 秋 になる。

`アドベントカレンダー` は入らない。13記事のうち連載の索引は1本だけで、あれは連載ではなく `/specials/advent-calendar/` が持つ活動の記録。

## 確認

- `/series/` を描いて 78枚すべてが `全N本・YYYY.MM` になっていること、関連タグが4つ出て `/tags/` の4ページが 200 で返ることを確認
- `make lint-css` / `make lint-partials` / prettier は通っている