### PR TITLE
記事末の帯までの空きを 56px の1箇所に戻す (#3227)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1735,6 +1735,10 @@ bootstrap-subset → theme-styles.styl の順で `/css/site.css` に連結する
   - 帯までの空きは `.article-appendix` の `margin-top` の1箇所で決める。共有ボタンの下 padding と
     著者紹介の `margin-bottom` を落として、著者紹介の有無で空きが変わらないようにした
     （以前は 48px と 67.5px でばらついていた）
+    - **共有ボタンの `ul` が Bootstrap の既定で持つ下 1rem と、サイドバーの `padding-bottom`
+      40px もここに上乗せされていた**（#3227。375px で 112px、1280px で 72px）。1024px 以下では
+      目次が消えて中身が空でも padding だけが本文と帯の間に残る。前者は `.social-area` の中で
+      落とし、後者は `.footer-gap` と同じ `:has(+ .article-appendix)` で落とす
   - 短いページでは `.wrap > footer` の `margin-top: auto` が帯とネイビーの間に白を入れるので、
     余りは帯より前（本文の `container`）で吸わせる
   - 残っている難点: 中身がコンテナ幅（約1,116px）になるぶん、関連記事の行のタイトル占有率が

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -1023,6 +1023,8 @@ Header and header elements
   font-size: text-base;
   display: inline-block;
 }
+/* サイドバーがフッター直前に来るとき（1024px 以下で本文の下に落ちたとき・
+   2列で本文より長いとき）のフッター前の空き。帯が続くときは下で落とす (#3227) */
 .blog-sidebar {
   padding-bottom: 40px;
 }
@@ -1956,6 +1958,11 @@ summary:focus-visible,
    決めるため。著者紹介があってもなくても同じ空きになる */
 .social-area {
 	padding: 16px 0 0;
+}
+/* ul は Bootstrap の既定で下に 1rem 持つ。著者紹介との間は .author-box の
+   margin-top が持つので、ここに残すと帯までの空きに上乗せされる (#3227) */
+.social-area .social-button {
+  margin-bottom: 0;
 }
 
 .img-frame-line {
@@ -5069,6 +5076,11 @@ a.award-badge:focus {
    フッターに接する前提の footer-gap を持っているので、帯が続くときは落とす (#3141) */
 .wrap > .container:has(+ .article-appendix) .footer-gap {
   margin-bottom: 0;
+}
+/* サイドバーの下の空きも同じ。1024px 以下では目次が消えて中身が空でも
+   padding だけが本文と帯の間に残る (#3227) */
+.wrap > .container:has(+ .article-appendix) .blog-sidebar {
+  padding-bottom: 0;
 }
 
 /* タブ。JS を使わず radio + label で切り替えている。


### PR DESCRIPTION
Fixes #3227

## 変更内容

- `themes/future/css-src/theme-styles.styl`
  - `.social-area .social-button { margin-bottom: 0 }` を追加。共有ボタンの `ul` が Bootstrap の既定（`dl,ol,ul { margin-bottom: 1rem }`）で持つ下 16px を、記事ページの共有ボタンの中で落とす
  - `.wrap > .container:has(+ .article-appendix) .blog-sidebar { padding-bottom: 0 }` を追加。帯が続くときはサイドバーの `padding-bottom` 40px を落とす（#3141 で `.footer-gap` を落としているのと同じ形）
  - `.blog-sidebar { padding-bottom: 40px }` に役のコメントを付けた（metronic 由来で無コメントだった）
- `CLAUDE.md` の #2874 の節に、再発の経路と直し方を足した

## 判断した点

- **共有ボタンの 16px は `.social-area` の中だけで落とす。** 一覧カードは `.article-card .social-button` が既に 0 にしている。`ul.social-button` に一律で書くと部品ギャラリーの見本にも及ぶので、記事ページの器に絞った。著者紹介との 16px は `.author-box` の `margin-top` が持っているので、そちらの空きは変わらない
- **サイドバーの 40px は帯が続くときだけ落とす。** この padding はサイドバーがフッター直前に来るとき（1024px 以下で本文の下に落ちたとき・2列で本文より長いとき）のフッター前の空きで、一覧ページ・帯の無い特設ページではいまも効いている。全部落とすとそれらのフッター前が 40px 詰まるので、`:has(+ .article-appendix)` で帯のあるページ（記事・`career: true` の特設）に限った
- 帯を持つ特設（スタイルガイドなど）も同じ経路で 1024px 以下が 96px になっていたので、同時に 56px になる

## 実測（`getBoundingClientRect`、before は変更前の site.css を差し替えて同じサーバで計測）

共有ボタン（著者紹介があればその下端）→ 帯の上端:

| ページ | 375px | 768px | 1280px |
| --- | --- | --- | --- |
| `/articles/20251031a/`（著者紹介なし） | 112 → **56** | 112 → **56** | 72 → **56** |
| `/articles/20260612a/`（著者紹介あり。著者紹介 → 帯） | 96 → **56** | 96 → **56** | 56 → 56 |
| `/specials/styleguide/`（帯あり。本文の下端 → フッター） | 587 → 547（-40） | 440.8 → 400.8（-40） | 337.5 → 337.5 |

`20260612a` の共有ボタン → 著者紹介の 16px は前後で同じ。

帯を持たないページのフッター前（`main` の下端 → フッター、サイドバーの高さ）は3幅とも前後で同一:

| ページ | 375px | 768px | 1280px |
| --- | --- | --- | --- |
| `/articles/2026/` | 40 / 40 | 40 / 40 | 0 / 4638.1 |
| `/specials/httf/` | 40 / 40 | 40 / 40 | 0 / 1748.3 |
| `/` | 40 / 40 | 816.1 / 816 | 0 / 7123 |

`make css` の前後差分は上の2ルールだけ。`node css_lint.mjs` / `node font_size_lint.mjs` は通過。

## 確認ポイント

- 記事ページ（著者紹介あり・なし）で、共有ボタン（著者紹介）と関連記事の帯の間が幅に関わらず 56px
- 一覧ページ・帯の無い特設ページのフッター前の空きが変わっていない
- 帯を持つ特設（`/specials/styleguide/` `/specials/markdown/` `/specials/gallery/`）のモバイルで、本文と We're hiring の帯の間が記事と同じ 56px

🤖 Generated with [Claude Code](https://claude.com/claude-code)
