### PR TITLE
記法ガイドの太字が ** のまま出ていたのを直す

### DIFF
--- a/source/specials/markdown/index.md
+++ b/source/specials/markdown/index.md
@@ -409,7 +409,7 @@ store_id,item_id,sales_date,sales_quantity,sales_amount
 <iframe width="560" height="315" src="https://www.youtube.com/embed/jUJgXRPqGQQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 ```
 
-16:9 で本文の幅に合わせて出ます。**`title` は残してください。** 画面を読み上げて使う人には、これが動画の名前になります。
+16:9 で本文の幅に合わせて出ます。**属性の `title` は残してください。** 画面を読み上げて使う人には、これが動画の名前になります。
 
 Google スライドと SlideShare の `<iframe>` も同じように貼れます。こちらも幅を合わせています。
 
@@ -433,4 +433,4 @@ Google スライドと SlideShare の `<iframe>` も同じように貼れます�
 <iframe class="speakerdeck-iframe" src="https://speakerdeck.com/player/2d59638e59f04898857ce369ed20ba87" title="発表タイトル" allowfullscreen="true" style="border: 0px; background: rgba(0, 0, 0, 0.1); margin: 0px; padding: 0px; border-radius: 6px; box-shadow: rgba(0, 0, 0, 0.2) 0px 5px 40px; width: 100%; height: auto; aspect-ratio: 560 / 315;" data-ratio="1.7777777777777777"></iframe>
 ```
 
-Speakerdeck の埋め込みコードは幅と縦横比を自分で持っているので、こちら側では触っていません。**`style` の中身も消さずに残してください。**
+Speakerdeck の埋め込みコードは幅と縦横比を自分で持っているので、こちら側では触っていません。**インラインの `style` も消さずに残してください。**


### PR DESCRIPTION
#3225 で足した「埋め込み」の節で、2箇所の太字が `**` のまま表示されていた。

## 原因

`。**\`title\` は残してください。**` のように、**句点の直後に `**`、その直後にインラインコード**が来る形。marked は `。` を句読点として扱わないので、開きの `**` が「非空白・非句読点の直後で、句読点（バッククォート）の直前」となり左フランキングにならず、強調の区切りとして読まれない。`marked.parseInline` で再現を確認。

## 直し方

太字の先頭がインラインコードで始まらないよう語を足した（`**属性の \`title\` は…**`、`**インラインの \`style\` も…**`）。記法は変えていない。`marked.parse` で記法ガイド全文を描いてコードブロック外に `**` が残らないことを確認、textlint 通過。

同じ形（文字の直後に `**\``）は特設ページと 2026 年の記事には他に無い（`dbt/**` の1件はグロブ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
