### PR TITLE
CI のチェックアウトから記事画像を外す (#3246)

### DIFF
--- a/.github/workflows/css.yml
+++ b/.github/workflows/css.yml
@@ -25,8 +25,16 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      # チェックアウトの 1,146MB のうち 1,122MB が source/images (#3246)。
+      # sparse だけでは fetch が減らないので blob:none と組で使う
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          filter: blob:none
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /*
+            !/source/images/
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/partials.yml
+++ b/.github/workflows/partials.yml
@@ -23,8 +23,16 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      # チェックアウトの 1,146MB のうち 1,122MB が source/images (#3246)。
+      # sparse だけでは fetch が減らないので blob:none と組で使う
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          filter: blob:none
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /*
+            !/source/images/
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -22,8 +22,16 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      # チェックアウトの 1,146MB のうち 1,122MB が source/images (#3246)。
+      # sparse だけでは fetch が減らないので blob:none と組で使う
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          filter: blob:none
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /*
+            !/source/images/
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -13,8 +13,16 @@ jobs:
     env:
       REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
     steps:
+      # チェックアウトの 1,146MB のうち 1,122MB が source/images (#3246)。
+      # sparse だけでは fetch が減らないので blob:none と組で使う
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          filter: blob:none
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /*
+            !/source/images/
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -34,6 +42,25 @@ jobs:
 
       - name: Fetch base branch
         run: git fetch origin ${{github.base_ref}} --depth=1
+
+      # 画像ファイルを開くローカルルールは no-img-ratio-mismatch だけで、
+      # そのルールは存在しないファイルを黙って飛ばす。#3246 で画像を働き場所から
+      # 外したので、変更された記事が参照するディレクトリを戻さないと #2643 の
+      # 検査が静かに消える。blob:none なので戻した分の blob だけが取得される
+      - name: Restore images referenced by changed posts
+        run: |
+          CHANGED="${{runner.temp}}/changed-posts"
+          git diff -z --diff-filter=ACMR --name-only origin/${{github.base_ref}} HEAD -- 'source/_posts/*.md' > "$CHANGED"
+          # ディレクトリ名は全1,467件が ASCII なので glob のメタ文字が混ざらない。
+          # ファイル名の側は1,274件が日本語などを含むため、末尾の / までで切る
+          DIRS=$(xargs -0 -r grep -hoE '/images/[A-Za-z0-9._/-]*/' < "$CHANGED" \
+            | sed 's|^|/source|' | sort -u)
+          if [ -z "$DIRS" ]; then
+            echo "参照している画像が無いためスキップします"
+            exit 0
+          fi
+          echo "$DIRS"
+          echo "$DIRS" | xargs -r git sparse-checkout add
 
       - name: Run textlint with reviewdog
         run: |


### PR DESCRIPTION
Close #3246

PR で走る4本（`reviewdog` / `css` / `partials` / `prettier`）の `actions/checkout` を部分クローン＋sparse にして、記事画像を働き場所から外す。

```yaml
filter: blob:none
sparse-checkout-cone-mode: false
sparse-checkout: |
  /*
  !/source/images/
```

`filter: blob:none` が要るのは、**sparse-checkout だけでは取得量が減らない**ため。sparse が効くのは働き場所への書き出しで、`git fetch` はツリー全体の blob を落とす。

## 効き

手元から実際にクローンして測った。

| | .git | 働き場所 | 所要 |
| --- | --- | --- | --- |
| いまの形（`--depth=1`） | — | 1,146MB / 9,235ファイル | ランナー実測 p50 25s・p90 34s |
| この PR の形 | 11MB | **29MB** / 画像0枚 | 手元で 9s |

内訳は `source/images` が 7,412ファイル・1,122MB で、**転送量の98%**。記事 md 1,488本は全部そろう。

## `no-img-ratio-mismatch` を消さないための手当て

18本あるローカルルールのうち画像ファイルを開くのは `no-img-ratio-mismatch` だけ（他は文字列だけを見る。`no-invalid-post-taxonomy` が読むのは `source/_data/categories.yml`）。

このルールは**存在しないファイルを黙って飛ばす**ので、画像を外すだけだと #2643 の検査が静かに無くなる。`reviewdog` には lint の直前に、変更された記事が参照しているディレクトリだけ戻す手当てを入れた。`blob:none` なので戻した分の blob だけが遅延取得される（実測 1秒）。

抽出は末尾の `/` までで切っている。画像ディレクトリ名は全1,467件が ASCII なので glob のメタ文字が混ざらないが、ファイル名の側は1,274件が日本語などを含むため。記事のファイル名にはシングルクォートを含むものが6件あるので、受け渡しは `-z` / `xargs -0`。

## 確認したこと

sparse でクローンした木の上で実際に流した。

- `ui_partials_lint.mjs` … 通る（部品62件）
- `css.mjs` → `css_lint.mjs` → `font_size_lint.mjs` … 通る
- `prettier --check` … 通る
- `no-img-ratio-mismatch` … 実在の記事の `height` を 286 → 572 に壊して確認
  - 画像が無い状態: **指摘0**（黙って飛ばすことの再現）
  - 手当てでディレクトリを戻した状態: **指摘あり**（`属性 512x572 に対し実寸 512x286`）
- 全記事1,488本から抽出したディレクトリ118件が、すべて実在するディレクトリに解決すること

`deploy` は hexo が全画像を `public/` へコピーするので触っていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
