### PR TITLE
引用の中の中黒・連番を一段薄くする

### DIFF
--- a/source/specials/styleguide/index.md
+++ b/source/specials/styleguide/index.md
@@ -24,7 +24,9 @@ editable: true
 | --- | --- | --- | --- | --- |
 | <span class="sg-chip sg-ink-strong"></span> | `ink-strong` | <span class="sg-hex sg-ink-strong"></span> | <span class="sg-ratio sg-ink-strong"></span> | 本文・見出し・リンク |
 | <span class="sg-chip sg-ink-mute"></span> | `ink-mute` | <span class="sg-hex sg-ink-mute"></span> | <span class="sg-ratio sg-ink-mute"></span> | 本文に添える補助情報（日付・著者・タグ・件数・注記）と引用の本文 |
-| <span class="sg-chip sg-ink-faint"></span> | `ink-faint` | <span class="sg-hex sg-ink-faint"></span> | <span class="sg-ratio sg-ink-faint"></span> | 空表示・無効と、補助情報の中でさらに弱くするもの（パンくずの `>`・折りたたみの三角・統計の内訳と枠の名前） |
+| <span class="sg-chip sg-ink-faint"></span> | `ink-faint` | <span class="sg-hex sg-ink-faint"></span> | <span class="sg-ratio sg-ink-faint"></span> | 空表示・無効と、補助情報の中でさらに弱くするもの（パンくずの `>`・折りたたみの三角・統計の内訳と枠の名前・引用の中の中黒と連番） |
+
+中黒と連番は、その項目の文字より一段弱い段に置きます。本文の中では `ink-mute`、文字が `ink-mute` まで下りる引用の中では `ink-faint` です。
 
 白はスケールの1段階ではなく背景の色そのもので、役割を選ぶ余地がありません。
 

--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -3229,6 +3229,12 @@ ul.tag-list {
 .blog-item blockquote li {
   color: var(--ink-mute);
 }
+/* 中黒・連番は項目の文字より一段弱い段に置く（本文は ink-strong に対して
+   ink-mute）。引用は地の文が ink-mute まで下りるので、マーカーも一段下げないと
+   記号だけが本文と同じ濃さで残る */
+.blog-item blockquote li::marker {
+  color: var(--ink-faint);
+}
 .blog-item blockquote::before {
   content: "";
   position: absolute;


### PR DESCRIPTION
## 何を

引用（blockquote）の中の箇条書きの中黒・連番を `ink-mute` から `ink-faint` へ一段落とす。

## なぜ

中黒・連番は「その項目の文字より一段弱い段」に置く決まりで、本文（`ink-strong`）に対して `ink-mute` になっている。引用は地の文を `ink-mute` まで下げているのに、マーカーだけが `.article-entry li::marker` の `ink-mute` を継いだままだったので、**引用の中では記号と文字が同じ濃さ**になり、相対的に記号が強く見えていた。

引用の中は `ink-faint`（白地 4.61 / 暗地 4.74 で AA を満たす最も薄い段）にして、本文と同じ「文字より一段弱い」関係に戻す。

## 変更

- `theme-styles.styl`: `.blog-item blockquote li::marker` を追加（詳細度 0,1,3 で `.article-entry li::marker` の 0,1,2 に勝つ）
- スタイルガイド: `ink-faint` の使いどころに追記し、「中黒・連番は項目の文字より一段弱い段」という規則を1文で名乗らせた

## 確認

- `make css` / `make lint-css` 通過
- textlint（スタイルガイドの md）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)