### PR TITLE
mermaid の図の文字を選択したときの文字色を fill でも指定する

### DIFF
--- a/themes/future/css-src/theme-styles.styl
+++ b/themes/future/css-src/theme-styles.styl
@@ -196,10 +196,12 @@ dark-parts()
      単独のルールにする（同居させると Chrome / Safari でルールごと捨てられる #3058） */
   .site-footer ::-moz-selection {
     color: var(--selection-ink);
+    fill: var(--selection-ink);
     background: var(--selection-bg);
   }
   .site-footer ::selection {
     color: var(--selection-ink);
+    fill: var(--selection-ink);
     background: var(--selection-bg);
   }
   /* 塗り面。明暗を入れ替える。地だけ明るくすると白文字が飛ぶので、中の文字も一緒に返す。
@@ -370,12 +372,19 @@ Misc tools
 
 /* ベンダー接頭辞の擬似要素は他のセレクタと同じリストに入れない。
    1つでも解釈できないセレクタがあると、ブラウザはルールごと捨てる */
+/* SVG の <text> の文字色は color ではなく fill が決めるので、fill も同じ値にする (#3253)。
+   mermaid が図に焼き付けた fill:#333 が残ると、ネイビーの帯の上で 1.29 になって
+   文字の形が消える（_mermaid の 58 枚のうち <text> を持つ11枚が該当）。
+   foreignObject の中の HTML ラベルは color が効くので fill を無視する。
+   HTML の文字には効かない指定なので、当てる範囲を SVG に絞らない */
 ::-moz-selection {
   color: var(--selection-ink);
+  fill: var(--selection-ink);
   background: var(--selection-bg);
 }
 ::selection {
   color: var(--selection-ink);
+  fill: var(--selection-ink);
   background: var(--selection-bg);
 }
 /* フッターはネイビー地なので、ネイビーの選択色では選択が見えない。
@@ -384,10 +393,12 @@ Misc tools
    誤爆するため、ネイビーの面を持つクラスで絞る */
 .site-footer ::-moz-selection {
   color: var(--brand-navy);
+  fill: var(--brand-navy);
   background: var(--brand-gray);
 }
 .site-footer ::selection {
   color: var(--brand-navy);
+  fill: var(--brand-navy);
   background: var(--brand-gray);
 }
 
@@ -2827,10 +2838,12 @@ th {
 .highlight ::-moz-selection {
   background: dark-selection;
   color: dark-surface-base;
+  fill: dark-surface-base;
 }
 .highlight ::selection {
   background: dark-selection;
   color: dark-surface-base;
+  fill: dark-surface-base;
 }
 
 /* リンクの折り返し */


### PR DESCRIPTION
Fixes #3253

## 変更

`::selection` の4組（素の地・明るい側のフッター・暗い側のフッター・コードブロック）に `fill` を足した。値は `color` と同じトークンから引いている。`theme-styles.styl` だけの変更。

```styl
::selection {
  color: var(--selection-ink);
  fill: var(--selection-ink);
  background: var(--selection-bg);
}
```

## 判断した点

- **当てる範囲を SVG に絞らない。** `fill` は HTML の文字には効かないので限定する理由が無く、限定すると将来ほかの inline SVG（ロゴ・アイコン）を本文に置いたときに同じ不具合が再発する
- **フッターとコードブロックにも足す。** SVG の図が出るのは記事本文だけなので、機能として要るのは素の地の1組だけ。それでもそろえるのは、**選択の帯の型を場所ごとに割らない**ため（4組はいずれも `color` を明示している）
- **帯の色を図の中だけ明るくする案は採らない。** 「白い紙の上の図」として明るい帯＋暗い文字にすれば `fill` の対応に依らず読めるが、同じページの中で選択の見え方が2種類になる
- **スタイルガイドは直さない。** あちらが名乗っているのは「選択されると文字も下線も帯の文字色で塗り直される」という決まりで、そこは変わらない。SVG の文字色が `fill` で決まるのは実装の話

## 確認したこと

`make css` を通し、生成された `public/css/site.css` の4組すべてに `fill` が入っていることを確認。

Chrome 140（Windows、`--headless=new`）で、`source/_mermaid/` のシーケンス図（`a9821e77…`）を `.article-entry` に置いたページを修正前後の `site.css` で描き、プログラム的に全選択してスクリーンショットを撮って画素を数えた。

| | 帯の矩形の中の濃い画素 |
| --- | --- |
| 修正前 | 13,066 |
| 修正後 | **1,346**（残りは箱の枠・ライフライン・矢印・丸の中の連番で、stroke や図形なので選択の対象外） |

目でも確認した。修正前は文字が帯に沈み、修正後は白抜きで読める。

## 確認していないこと

Firefox / Safari が `::selection` の `fill` を受けるか。受けない場合はその2つで現状のまま（帯だけネイビー）になる。宣言が捨てられるだけで他の指定には影響しない。

アーキテクチャガイドライン側の同じ修正は [arch-guidelines#450](https://github.com/future-architect/arch-guidelines/pull/450)。
