### PR TITLE
X の反応の重みを リポスト 1/2・ブックマーク 1/4・いいね 1/8 に上げる (#2031)

### DIFF
--- a/scripts/lib/x_mentions.js
+++ b/scripts/lib/x_mentions.js
@@ -4,12 +4,12 @@
 // X の count API は 2015 年に消えているので、sns_count_cache.json の Twitter は
 // 2023-06 で凍結している。その続きをこちらが担う。
 //
-// 点は ポスト 1 ＋ リポスト 1/4 ＋ ブックマーク 1/8 ＋ いいね 1/16 を記事単位で切り上げる。
+// 点は ポスト 1 ＋ リポスト 1/2 ＋ ブックマーク 1/4 ＋ いいね 1/8 を記事単位で切り上げる。
 // 公式アカウントのポストは自己シェアなので本体の 1 を数えず、集まった反応だけを足す。
 // 重みが 2 の冪なので和は二進で正確で、丸めは最後の1回だけになる。
 const fs = require('fs');
 
-const WEIGHT = { post: 1, repost: 1 / 4, bookmark: 1 / 8, like: 1 / 16 };
+const WEIGHT = { post: 1, repost: 1 / 2, bookmark: 1 / 4, like: 1 / 8 };
 
 const loadMentions = () => {
   try {


### PR DESCRIPTION
`scripts/lib/x_mentions.js` の `WEIGHT` を変える。ポスト本体 1 は据え置き、リポスト 1/4 → 1/2、ブックマーク 1/8 → 1/4、いいね 1/16 → 1/8。返信・表示数は引き続き数えない。切り上げと公式ポストの扱い（本体を数えず反応だけ足す）はそのまま。

main の `x_mentions.json`（427 件・172 記事）で測った変化:

| | 旧 | 新 |
| --- | --- | --- |
| 点の合計 | 1,146 | 2,215 |
| 内訳（本体 / RP / BM / いいね） | 20 / 18 / 33 / 28 % | 10 / 19 / 39 / 31 % |
| 10 点以上の記事 | 32 | 46 |
| 最大（20260609a） | 193 | 373 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)